### PR TITLE
feat: add manifest metadata rules

### DIFF
--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
+from typing import Any
 
 from hasscheck.models import (
     Applicability,
@@ -13,8 +15,8 @@ from hasscheck.models import (
 )
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
-HA_MANIFEST_SOURCE = "https://developers.home-assistant.io/docs/creating_integration_manifest/"
 HACS_INTEGRATION_SOURCE = "https://www.hacs.xyz/docs/publish/integration/"
+CATEGORY = "manifest_metadata"
 
 
 def _manifest_path(context: ProjectContext):
@@ -23,14 +25,194 @@ def _manifest_path(context: ProjectContext):
     return context.integration_path / "manifest.json"
 
 
+def _manifest_display_path(context: ProjectContext) -> str:
+    path = _manifest_path(context)
+    return "custom_components/<domain>/manifest.json" if path is None else str(path.relative_to(context.root))
+
+
+def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str | None]:
+    path = _manifest_path(context)
+    if path is None or not path.is_file():
+        return None, None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, exc.msg
+
+    if not isinstance(payload, dict):
+        return None, "manifest root must be a JSON object"
+
+    return payload, None
+
+
+def _not_applicable_for_missing_manifest(rule_id: str, title: str, field_name: str, fix_summary: str) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.REQUIRED,
+        title=title,
+        message=f"manifest.json is missing, so the {field_name} field cannot be inspected yet.",
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason=f"manifest.json must exist before HassCheck can inspect manifest.{field_name}.",
+        ),
+        source=RuleSource(url=HACS_INTEGRATION_SOURCE),
+        fix=FixSuggestion(summary=fix_summary),
+        path="custom_components/<domain>/manifest.json",
+    )
+
+
+def _invalid_manifest_finding(rule_id: str, title: str, error: str, path: str) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title=title,
+        message=f"manifest.json is not valid JSON: {error}.",
+        applicability=Applicability(reason="manifest.json exists but cannot be parsed."),
+        source=RuleSource(url=HACS_INTEGRATION_SOURCE),
+        fix=FixSuggestion(summary="Fix manifest.json syntax, then rerun HassCheck."),
+        path=path,
+    )
+
+
+def _required_string_field_rule(
+    *,
+    rule_id: str,
+    field_name: str,
+    title: str,
+    present_message: str,
+    missing_message: str,
+    applicability_reason: str,
+    fix_summary: str,
+) -> Callable[[ProjectContext], Finding]:
+    def check(context: ProjectContext) -> Finding:
+        path = _manifest_path(context)
+        display_path = _manifest_display_path(context)
+        if path is None or not path.is_file():
+            return _not_applicable_for_missing_manifest(rule_id, title, field_name, fix_summary)
+
+        payload, error = _read_manifest(context)
+        if error is not None:
+            return _invalid_manifest_finding(rule_id, title, error, display_path)
+
+        value = payload.get(field_name) if payload else None
+        is_present = isinstance(value, str) and bool(value.strip())
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS if is_present else RuleStatus.FAIL,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message=present_message if is_present else missing_message,
+            applicability=Applicability(reason=applicability_reason),
+            source=RuleSource(url=HACS_INTEGRATION_SOURCE),
+            fix=None if is_present else FixSuggestion(summary=fix_summary),
+            path=display_path,
+        )
+
+    return check
+
+
+def _codeowners_rule(context: ProjectContext) -> Finding:
+    path = _manifest_path(context)
+    display_path = _manifest_display_path(context)
+    title = "manifest.json defines codeowners"
+    if path is None or not path.is_file():
+        return _not_applicable_for_missing_manifest(
+            "manifest.codeowners.exists",
+            title,
+            "codeowners",
+            "Create manifest.json first, then define a non-empty codeowners list.",
+        )
+
+    payload, error = _read_manifest(context)
+    if error is not None:
+        return _invalid_manifest_finding("manifest.codeowners.exists", title, error, display_path)
+
+    value = payload.get("codeowners") if payload else None
+    is_present = isinstance(value, list) and any(isinstance(item, str) and item.strip() for item in value)
+    return Finding(
+        rule_id="manifest.codeowners.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if is_present else RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title=title,
+        message=(
+            "manifest.json defines at least one code owner."
+            if is_present
+            else "manifest.json does not define a non-empty codeowners list."
+        ),
+        applicability=Applicability(reason="HACS expects custom integration manifests to define codeowners."),
+        source=RuleSource(url=HACS_INTEGRATION_SOURCE),
+        fix=None if is_present else FixSuggestion(summary="Add a non-empty codeowners list to manifest.json."),
+        path=display_path,
+    )
+
+
+manifest_domain_exists = _required_string_field_rule(
+    rule_id="manifest.domain.exists",
+    field_name="domain",
+    title="manifest.json defines domain",
+    present_message="manifest.json defines a domain.",
+    missing_message="manifest.json does not define a non-empty domain.",
+    applicability_reason="HACS expects custom integration manifests to define domain.",
+    fix_summary="Add a stable domain field to manifest.json.",
+)
+manifest_name_exists = _required_string_field_rule(
+    rule_id="manifest.name.exists",
+    field_name="name",
+    title="manifest.json defines name",
+    present_message="manifest.json defines a name.",
+    missing_message="manifest.json does not define a non-empty name.",
+    applicability_reason="HACS expects custom integration manifests to define name.",
+    fix_summary="Add a human-readable name field to manifest.json.",
+)
+manifest_version_exists = _required_string_field_rule(
+    rule_id="manifest.version.exists",
+    field_name="version",
+    title="manifest.json defines version",
+    present_message="manifest.json defines a version.",
+    missing_message="manifest.json does not define a non-empty version.",
+    applicability_reason="HACS expects custom integration manifests to define version.",
+    fix_summary="Add a version field to manifest.json.",
+)
+manifest_documentation_exists = _required_string_field_rule(
+    rule_id="manifest.documentation.exists",
+    field_name="documentation",
+    title="manifest.json defines documentation",
+    present_message="manifest.json defines documentation.",
+    missing_message="manifest.json does not define a non-empty documentation URL.",
+    applicability_reason="HACS expects custom integration manifests to define documentation.",
+    fix_summary="Add a documentation URL to manifest.json.",
+)
+manifest_issue_tracker_exists = _required_string_field_rule(
+    rule_id="manifest.issue_tracker.exists",
+    field_name="issue_tracker",
+    title="manifest.json defines issue tracker",
+    present_message="manifest.json defines an issue tracker.",
+    missing_message="manifest.json does not define a non-empty issue_tracker URL.",
+    applicability_reason="HACS expects custom integration manifests to define issue_tracker.",
+    fix_summary="Add an issue_tracker URL to manifest.json.",
+)
+manifest_codeowners_exists = _codeowners_rule
+
+
 def manifest_exists(context: ProjectContext) -> Finding:
     path = _manifest_path(context)
     exists = path is not None and path.is_file()
-    display = "custom_components/<domain>/manifest.json" if path is None else str(path.relative_to(context.root))
+    display = _manifest_display_path(context)
     return Finding(
         rule_id="manifest.exists",
         rule_version="1.0.0",
-        category="manifest_metadata",
+        category=CATEGORY,
         status=RuleStatus.PASS if exists else RuleStatus.FAIL,
         severity=RuleSeverity.REQUIRED,
         title="manifest.json exists",
@@ -48,65 +230,11 @@ def manifest_exists(context: ProjectContext) -> Finding:
     )
 
 
-def manifest_domain_exists(context: ProjectContext) -> Finding:
-    path = _manifest_path(context)
-    if path is None or not path.is_file():
-        return Finding(
-            rule_id="manifest.domain.exists",
-            rule_version="1.0.0",
-            category="manifest_metadata",
-            status=RuleStatus.NOT_APPLICABLE,
-            severity=RuleSeverity.REQUIRED,
-            title="manifest.json defines domain",
-            message="manifest.json is missing, so the domain field cannot be inspected yet.",
-            applicability=Applicability(
-                status=ApplicabilityStatus.NOT_APPLICABLE,
-                reason="manifest.json must exist before HassCheck can inspect manifest.domain.",
-            ),
-            source=RuleSource(url=HACS_INTEGRATION_SOURCE),
-            fix=FixSuggestion(summary="Create manifest.json first, then define the domain field."),
-            path="custom_components/<domain>/manifest.json",
-        )
-
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return Finding(
-            rule_id="manifest.domain.exists",
-            rule_version="1.0.0",
-            category="manifest_metadata",
-            status=RuleStatus.FAIL,
-            severity=RuleSeverity.REQUIRED,
-            title="manifest.json defines domain",
-            message=f"manifest.json is not valid JSON: {exc.msg}.",
-            applicability=Applicability(reason="manifest.json exists but cannot be parsed."),
-            source=RuleSource(url=HACS_INTEGRATION_SOURCE),
-            fix=FixSuggestion(summary="Fix manifest.json syntax, then rerun HassCheck."),
-            path=str(path.relative_to(context.root)),
-        )
-
-    domain = payload.get("domain")
-    has_domain = isinstance(domain, str) and bool(domain.strip())
-    return Finding(
-        rule_id="manifest.domain.exists",
-        rule_version="1.0.0",
-        category="manifest_metadata",
-        status=RuleStatus.PASS if has_domain else RuleStatus.FAIL,
-        severity=RuleSeverity.REQUIRED,
-        title="manifest.json defines domain",
-        message=("manifest.json defines a domain." if has_domain else "manifest.json does not define a non-empty domain."),
-        applicability=Applicability(reason="HACS expects custom integration manifests to define domain."),
-        source=RuleSource(url=HACS_INTEGRATION_SOURCE),
-        fix=None if has_domain else FixSuggestion(summary="Add a stable domain field to manifest.json."),
-        path=str(path.relative_to(context.root)),
-    )
-
-
 RULES = [
     RuleDefinition(
         id="manifest.exists",
         version="1.0.0",
-        category="manifest_metadata",
+        category=CATEGORY,
         severity=RuleSeverity.REQUIRED,
         title="manifest.json exists",
         why="Home Assistant integrations use manifest.json for integration metadata.",
@@ -116,11 +244,61 @@ RULES = [
     RuleDefinition(
         id="manifest.domain.exists",
         version="1.0.0",
-        category="manifest_metadata",
+        category=CATEGORY,
         severity=RuleSeverity.REQUIRED,
         title="manifest.json defines domain",
         why="The domain is the stable integration identifier used by Home Assistant and HACS.",
         source_url=HACS_INTEGRATION_SOURCE,
         check=manifest_domain_exists,
+    ),
+    RuleDefinition(
+        id="manifest.name.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json defines name",
+        why="The name is the human-readable integration label exposed in Home Assistant and HACS metadata.",
+        source_url=HACS_INTEGRATION_SOURCE,
+        check=manifest_name_exists,
+    ),
+    RuleDefinition(
+        id="manifest.version.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json defines version",
+        why="HACS expects custom integration manifests to include a version for release and update metadata.",
+        source_url=HACS_INTEGRATION_SOURCE,
+        check=manifest_version_exists,
+    ),
+    RuleDefinition(
+        id="manifest.documentation.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json defines documentation",
+        why="Documentation gives users and HACS a stable path to setup and support information.",
+        source_url=HACS_INTEGRATION_SOURCE,
+        check=manifest_documentation_exists,
+    ),
+    RuleDefinition(
+        id="manifest.issue_tracker.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json defines issue tracker",
+        why="An issue tracker gives users a clear support path for custom integration problems.",
+        source_url=HACS_INTEGRATION_SOURCE,
+        check=manifest_issue_tracker_exists,
+    ),
+    RuleDefinition(
+        id="manifest.codeowners.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json defines codeowners",
+        why="Code owners make maintainership explicit and are expected by HACS integration metadata.",
+        source_url=HACS_INTEGRATION_SOURCE,
+        check=manifest_codeowners_exists,
     ),
 ]

--- a/tests/test_manifest_metadata_rules.py
+++ b/tests/test_manifest_metadata_rules.py
@@ -1,0 +1,77 @@
+import json
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+REQUIRED_FIELD_RULES = {
+    "name": "manifest.name.exists",
+    "version": "manifest.version.exists",
+    "documentation": "manifest.documentation.exists",
+    "issue_tracker": "manifest.issue_tracker.exists",
+    "codeowners": "manifest.codeowners.exists",
+}
+
+
+def write_manifest(root, payload: dict) -> None:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+def test_required_manifest_metadata_fields_pass_when_present(tmp_path) -> None:
+    write_manifest(
+        tmp_path,
+        {
+            "domain": "demo",
+            "name": "Demo",
+            "documentation": "https://example.com/docs",
+            "issue_tracker": "https://example.com/issues",
+            "codeowners": ["@demo"],
+            "version": "0.1.0",
+        },
+    )
+
+    findings = findings_for(tmp_path)
+
+    for rule_id in REQUIRED_FIELD_RULES.values():
+        assert findings[rule_id].status is RuleStatus.PASS
+        assert findings[rule_id].source.url == "https://www.hacs.xyz/docs/publish/integration/"
+        assert findings[rule_id].rule_version == "1.0.0"
+
+
+def test_required_manifest_metadata_fields_fail_when_missing(tmp_path) -> None:
+    write_manifest(tmp_path, {"domain": "demo"})
+
+    findings = findings_for(tmp_path)
+
+    for rule_id in REQUIRED_FIELD_RULES.values():
+        assert findings[rule_id].status is RuleStatus.FAIL
+        assert findings[rule_id].fix is not None
+
+
+def test_required_manifest_metadata_fields_are_not_applicable_without_manifest(tmp_path) -> None:
+    findings = findings_for(tmp_path)
+
+    for rule_id in REQUIRED_FIELD_RULES.values():
+        assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
+        assert "manifest.json must exist" in findings[rule_id].applicability.reason
+
+
+def test_codeowners_requires_non_empty_list_of_strings(tmp_path) -> None:
+    write_manifest(
+        tmp_path,
+        {
+            "domain": "demo",
+            "name": "Demo",
+            "documentation": "https://example.com/docs",
+            "issue_tracker": "https://example.com/issues",
+            "codeowners": [],
+            "version": "0.1.0",
+        },
+    )
+
+    assert findings_for(tmp_path)["manifest.codeowners.exists"].status is RuleStatus.FAIL


### PR DESCRIPTION
This pull request significantly refactors and expands the manifest metadata rules for Home Assistant custom integrations. It introduces reusable helper functions for manifest validation, adds new rules to check for required metadata fields, and provides comprehensive test coverage for these rules.

**Manifest metadata rule improvements and expansion:**

* Refactored manifest validation logic by introducing helper functions for reading, validating, and reporting on `manifest.json` and its fields, improving code reuse and maintainability.
* Added new rules to enforce the presence of required fields (`name`, `version`, `documentation`, `issue_tracker`, and `codeowners`) in `manifest.json`, using a generic rule factory for string fields and a custom rule for `codeowners`. [[1]](diffhunk://#diff-a7ddead5536d5a2d5ba0ca45017105a2e9cf302186ec4c259ff5002aa6131ab7L26-R237) [[2]](diffhunk://#diff-a7ddead5536d5a2d5ba0ca45017105a2e9cf302186ec4c259ff5002aa6131ab7L119-R303)

**Testing enhancements:**

* Added a new test suite (`tests/test_manifest_metadata_rules.py`) to verify that all required manifest metadata fields are properly checked for presence, absence, and correct types, including edge cases like empty lists for `codeowners`.

**Rule registration and consistency:**

* Updated the `RULES` list to register all new and refactored rules, ensuring they are enforced during checks and use a consistent category and source URL.

**Constants and code organization:**

* Centralized the manifest metadata category and HACS documentation URL in module-level constants for consistency and easier updates.

These changes make the manifest metadata checks more robust, extensible, and easier to maintain.