### PR TITLE
feat: add config flow consistency rules

### DIFF
--- a/examples/good_integration/custom_components/demo_good/config_flow.py
+++ b/examples/good_integration/custom_components/demo_good/config_flow.py
@@ -1,0 +1,8 @@
+"""Demo config flow fixture."""
+
+from __future__ import annotations
+
+
+class DemoGoodConfigFlow:
+    """Placeholder config flow fixture for HassCheck examples."""
+

--- a/examples/good_integration/custom_components/demo_good/manifest.json
+++ b/examples/good_integration/custom_components/demo_good/manifest.json
@@ -3,6 +3,9 @@
   "name": "Demo Good",
   "documentation": "https://example.com/demo_good",
   "issue_tracker": "https://example.com/demo_good/issues",
-  "codeowners": ["@demo"],
-  "version": "0.1.0"
+  "codeowners": [
+    "@demo"
+  ],
+  "version": "0.1.0",
+  "config_flow": true
 }

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -10,6 +10,7 @@ from hasscheck.rules.registry import RULES
 CATEGORY_LABELS = {
     "hacs_structure": "HACS Structure",
     "manifest_metadata": "Manifest Metadata",
+    "modern_ha_patterns": "Modern HA Patterns",
 }
 
 

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "modern_ha_patterns"
+CONFIG_FLOW_SOURCE = "https://developers.home-assistant.io/docs/core/integration/config_flow"
+MANIFEST_SOURCE = "https://developers.home-assistant.io/docs/creating_integration_manifest"
+
+
+def _config_flow_path(context: ProjectContext):
+    if context.integration_path is None:
+        return None
+    return context.integration_path / "config_flow.py"
+
+
+def _manifest_path(context: ProjectContext):
+    if context.integration_path is None:
+        return None
+    return context.integration_path / "manifest.json"
+
+
+def _display_path(path, context: ProjectContext, fallback: str) -> str:
+    if path is None:
+        return fallback
+    return str(path.relative_to(context.root))
+
+
+def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str | None]:
+    path = _manifest_path(context)
+    if path is None or not path.is_file():
+        return None, None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, exc.msg
+
+    if not isinstance(payload, dict):
+        return None, "manifest root must be a JSON object"
+
+    return payload, None
+
+
+def config_flow_file_exists(context: ProjectContext) -> Finding:
+    path = _config_flow_path(context)
+    if path is None:
+        return Finding(
+            rule_id="config_flow.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py exists",
+            message="No integration directory was detected, so config_flow.py cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect config_flow.py.",
+            ),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding config_flow.py."),
+            path="custom_components/<domain>/config_flow.py",
+        )
+
+    exists = path.is_file()
+    return Finding(
+        rule_id="config_flow.file.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py exists",
+        message=(
+            "Integration includes config_flow.py."
+            if exists
+            else "Integration does not include config_flow.py; UI setup support cannot be inspected."
+        ),
+        applicability=Applicability(reason="Config flows are the standard way to set up integrations via the UI."),
+        source=RuleSource(url=CONFIG_FLOW_SOURCE),
+        fix=None
+        if exists
+        else FixSuggestion(summary="Add config_flow.py when the integration should support setup via the Home Assistant UI."),
+        path=_display_path(path, context, "custom_components/<domain>/config_flow.py"),
+    )
+
+
+def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
+    config_path = _config_flow_path(context)
+    manifest_path = _manifest_path(context)
+    if config_path is None or manifest_path is None:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="No integration directory was detected, so config flow consistency cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect config flow consistency.",
+            ),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Create custom_components/<domain>/ and manifest.json first."),
+            path="custom_components/<domain>/",
+        )
+
+    manifest, error = _read_manifest(context)
+    if manifest is None and error is None:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="manifest.json is missing, so config_flow metadata cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.json must exist before HassCheck can inspect config_flow metadata.",
+            ),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Create manifest.json first, then define config_flow when needed."),
+            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+        )
+
+    if error is not None:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.FAIL,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message=f"manifest.json is not valid JSON: {error}.",
+            applicability=Applicability(reason="manifest.json exists but cannot be parsed."),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Fix manifest.json syntax, then rerun HassCheck."),
+            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+        )
+
+    has_file = config_path.is_file()
+    manifest_flag = manifest.get("config_flow") is True if manifest else False
+
+    if has_file and manifest_flag:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="config_flow.py exists and manifest.json sets config_flow: true.",
+            applicability=Applicability(reason="Home Assistant needs both config_flow.py and manifest config_flow metadata."),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=None,
+            path=_display_path(config_path, context, "custom_components/<domain>/config_flow.py"),
+        )
+
+    if has_file and not manifest_flag:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.FAIL,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="config_flow.py exists, but manifest.json does not set config_flow: true.",
+            applicability=Applicability(reason="Home Assistant activates config flows through manifest config_flow metadata."),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Add \"config_flow\": true to manifest.json."),
+            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+        )
+
+    if manifest_flag and not has_file:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.FAIL,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="manifest.json sets config_flow: true, but config_flow.py is missing.",
+            applicability=Applicability(reason="Home Assistant docs say config_flow.py needs to exist when config_flow is specified."),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=FixSuggestion(summary="Add config_flow.py or remove config_flow from manifest.json until UI setup is implemented."),
+            path=_display_path(config_path, context, "custom_components/<domain>/config_flow.py"),
+        )
+
+    return Finding(
+        rule_id="config_flow.manifest_flag_consistent",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.REQUIRED,
+        title="config_flow.py and manifest config_flow flag agree",
+        message="No config_flow.py file and no manifest config_flow flag were found.",
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason="The integration does not currently advertise a config flow.",
+        ),
+        source=RuleSource(url=CONFIG_FLOW_SOURCE),
+        fix=FixSuggestion(summary="Add config_flow.py and set config_flow: true when adding UI setup support."),
+        path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+    )
+
+
+RULES = [
+    RuleDefinition(
+        id="config_flow.file.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py exists",
+        why="Config flows are the standard way for Home Assistant integrations to support UI setup.",
+        source_url=CONFIG_FLOW_SOURCE,
+        check=config_flow_file_exists,
+    ),
+    RuleDefinition(
+        id="config_flow.manifest_flag_consistent",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="config_flow.py and manifest config_flow flag agree",
+        why="Home Assistant requires manifest config_flow metadata to match the config_flow.py implementation.",
+        source_url=CONFIG_FLOW_SOURCE,
+        check=config_flow_manifest_flag_consistent,
+    ),
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 
-RULES = [*HACS_STRUCTURE_RULES, *MANIFEST_RULES]
+RULES = [*HACS_STRUCTURE_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES]
 RULES_BY_ID = {rule.id: rule for rule in RULES}

--- a/tests/test_config_flow_rules.py
+++ b/tests/test_config_flow_rules.py
@@ -1,0 +1,77 @@
+import json
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+
+def write_integration(root, manifest: dict, *, config_flow: bool = False) -> None:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    if config_flow:
+        (integration / "config_flow.py").write_text("class DemoConfigFlow: ...\n", encoding="utf-8")
+
+
+def findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+def test_config_flow_file_presence_passes_when_file_exists(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.file.exists"].status is RuleStatus.PASS
+
+
+def test_config_flow_file_presence_warns_when_file_missing(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo"})
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.file.exists"].status is RuleStatus.WARN
+    assert findings["config_flow.file.exists"].fix is not None
+
+
+def test_config_flow_manifest_consistency_passes_when_file_and_manifest_flag_match(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.PASS
+    assert findings["config_flow.manifest_flag_consistent"].source.url == (
+        "https://developers.home-assistant.io/docs/core/integration/config_flow"
+    )
+
+
+def test_config_flow_manifest_consistency_fails_when_file_exists_but_flag_is_not_true(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo"}, config_flow=True)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.FAIL
+    assert "config_flow: true" in findings["config_flow.manifest_flag_consistent"].message
+
+
+def test_config_flow_manifest_consistency_fails_when_manifest_flag_true_but_file_missing(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo", "config_flow": True})
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.FAIL
+    assert "config_flow.py" in findings["config_flow.manifest_flag_consistent"].message
+
+
+def test_config_flow_manifest_consistency_not_applicable_when_no_config_flow_signal(tmp_path) -> None:
+    write_integration(tmp_path, {"domain": "demo"})
+
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_config_flow_rules_not_applicable_without_integration(tmp_path) -> None:
+    findings = findings_for(tmp_path)
+
+    assert findings["config_flow.file.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.NOT_APPLICABLE


### PR DESCRIPTION
This pull request introduces a new set of rules to check for modern Home Assistant (HA) integration patterns, specifically focusing on the presence and consistency of `config_flow.py` and the `config_flow` flag in `manifest.json`. It also adds comprehensive tests to ensure these rules work as intended, and updates the rule registry and category labels to support these new checks.

**Modern Home Assistant Patterns: Config Flow Checks**

* Added a new rule category `"modern_ha_patterns"` to `CATEGORY_LABELS` to classify rules related to modern Home Assistant integration practices.
* Implemented a new rule module `config_flow.py` that checks:
  * Whether `config_flow.py` exists in the integration directory.
  * Whether the `config_flow` flag in `manifest.json` is consistent with the presence of `config_flow.py`.
  * Provides detailed findings, applicability, and fix suggestions for various scenarios (missing files, mismatched flags, invalid JSON, etc.).
* Registered the new config flow rules in the main rules registry so they are included in checks.

**Example and Manifest Updates**

* Updated the `examples/good_integration/custom_components/demo_good/manifest.json` to include `"config_flow": true`, demonstrating the correct manifest setup for integrations supporting UI setup.
* Added a placeholder `config_flow.py` file in the example integration to serve as a fixture for the new rules.

**Testing**

* Added a new test suite `test_config_flow_rules.py` covering all major scenarios for the config flow rules, including presence/absence and consistency of `config_flow.py` and the manifest flag, as well as not-applicable cases.