### PR TITLE
feat: add diagnostics and repairs rules

### DIFF
--- a/examples/good_integration/custom_components/demo_good/diagnostics.py
+++ b/examples/good_integration/custom_components/demo_good/diagnostics.py
@@ -1,0 +1,10 @@
+"""Diagnostics fixture for the HassCheck good integration example."""
+
+from __future__ import annotations
+
+TO_REDACT = {"api_key", "token", "password"}
+
+
+async def async_get_config_entry_diagnostics(hass, config_entry):
+    """Return placeholder diagnostics for fixture purposes."""
+    return {"domain": config_entry.domain if config_entry else "demo_good"}

--- a/examples/good_integration/custom_components/demo_good/repairs.py
+++ b/examples/good_integration/custom_components/demo_good/repairs.py
@@ -1,0 +1,5 @@
+"""Repairs fixture for the HassCheck good integration example."""
+
+from __future__ import annotations
+
+# Placeholder module: HassCheck v0.1 currently checks only file presence.

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -11,6 +11,7 @@ CATEGORY_LABELS = {
     "hacs_structure": "HACS Structure",
     "manifest_metadata": "Manifest Metadata",
     "modern_ha_patterns": "Modern HA Patterns",
+    "diagnostics_repairs": "Diagnostics/Repairs",
     "docs_support": "Docs/Support",
     "maintenance_signals": "Maintenance Signals",
 }

--- a/src/hasscheck/rules/diagnostics.py
+++ b/src/hasscheck/rules/diagnostics.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "diagnostics_repairs"
+DIAGNOSTICS_SOURCE = "https://developers.home-assistant.io/docs/core/integration/diagnostics/"
+
+
+def diagnostics_file_exists(context: ProjectContext) -> Finding:
+    if context.integration_path is None:
+        return Finding(
+            rule_id="diagnostics.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py exists",
+            message="No integration directory was detected, so diagnostics.py cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect diagnostics.py.",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding diagnostics.py."),
+            path="custom_components/<domain>/diagnostics.py",
+        )
+
+    path = context.integration_path / "diagnostics.py"
+    exists = path.is_file()
+    return Finding(
+        rule_id="diagnostics.file.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="diagnostics.py exists",
+        message=(
+            "Integration includes diagnostics.py."
+            if exists
+            else "Integration does not include diagnostics.py; downloadable troubleshooting data support cannot be inspected."
+        ),
+        applicability=Applicability(reason="Diagnostics help users provide support data while redacting sensitive information."),
+        source=RuleSource(url=DIAGNOSTICS_SOURCE),
+        fix=None if exists else FixSuggestion(summary="Add diagnostics.py with redaction for sensitive values."),
+        path=str(path.relative_to(context.root)),
+    )
+
+
+RULES = [
+    RuleDefinition(
+        id="diagnostics.file.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="diagnostics.py exists",
+        why="Diagnostics help users and maintainers troubleshoot without exposing secrets when implemented with redaction.",
+        source_url=DIAGNOSTICS_SOURCE,
+        check=diagnostics_file_exists,
+    )
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from hasscheck.rules.brand import RULES as BRAND_RULES
 from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
+from hasscheck.rules.diagnostics import RULES as DIAGNOSTICS_RULES
 from hasscheck.rules.docs import RULES as DOCS_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
+from hasscheck.rules.repairs import RULES as REPAIRS_RULES
 from hasscheck.rules.repository import RULES as REPOSITORY_RULES
 
-RULES = [*HACS_STRUCTURE_RULES, *BRAND_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES, *DOCS_RULES, *REPOSITORY_RULES]
+RULES = [*HACS_STRUCTURE_RULES, *BRAND_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES, *DIAGNOSTICS_RULES, *REPAIRS_RULES, *DOCS_RULES, *REPOSITORY_RULES]
 RULES_BY_ID = {rule.id: rule for rule in RULES}

--- a/src/hasscheck/rules/repairs.py
+++ b/src/hasscheck/rules/repairs.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "diagnostics_repairs"
+REPAIRS_SOURCE = "https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/repair-issues/"
+
+
+def repairs_file_exists(context: ProjectContext) -> Finding:
+    if context.integration_path is None:
+        return Finding(
+            rule_id="repairs.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="repairs.py exists",
+            message="No integration directory was detected, so repairs.py cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect repairs.py.",
+            ),
+            source=RuleSource(url=REPAIRS_SOURCE),
+            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding repairs.py."),
+            path="custom_components/<domain>/repairs.py",
+        )
+
+    path = context.integration_path / "repairs.py"
+    exists = path.is_file()
+    return Finding(
+        rule_id="repairs.file.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="repairs.py exists",
+        message=(
+            "Integration includes repairs.py."
+            if exists
+            else "Integration does not include repairs.py; user-fixable repair flows cannot be inspected."
+        ),
+        applicability=Applicability(reason="Repair flows are useful when integrations have user-fixable problems."),
+        source=RuleSource(url=REPAIRS_SOURCE),
+        fix=None if exists else FixSuggestion(summary="Add repairs.py when the integration has user-fixable repair scenarios."),
+        path=str(path.relative_to(context.root)),
+    )
+
+
+RULES = [
+    RuleDefinition(
+        id="repairs.file.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="repairs.py exists",
+        why="Repair flows guide users through problems they can fix themselves.",
+        source_url=REPAIRS_SOURCE,
+        check=repairs_file_exists,
+    )
+]

--- a/tests/test_diagnostics_repairs_rules.py
+++ b/tests/test_diagnostics_repairs_rules.py
@@ -1,0 +1,52 @@
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+
+def write_integration(root, *, diagnostics: bool = False, repairs: bool = False) -> None:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text('{"domain":"demo"}', encoding="utf-8")
+    if diagnostics:
+        (integration / "diagnostics.py").write_text('"""Diagnostics fixture."""\n', encoding="utf-8")
+    if repairs:
+        (integration / "repairs.py").write_text('"""Repairs fixture."""\n', encoding="utf-8")
+
+
+def findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+def test_diagnostics_and_repairs_pass_when_files_exist(tmp_path) -> None:
+    write_integration(tmp_path, diagnostics=True, repairs=True)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["diagnostics.file.exists"].status is RuleStatus.PASS
+    assert findings["repairs.file.exists"].status is RuleStatus.PASS
+
+
+def test_diagnostics_and_repairs_warn_when_files_are_missing(tmp_path) -> None:
+    write_integration(tmp_path)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["diagnostics.file.exists"].status is RuleStatus.WARN
+    assert findings["diagnostics.file.exists"].fix is not None
+    assert findings["repairs.file.exists"].status is RuleStatus.WARN
+    assert findings["repairs.file.exists"].fix is not None
+
+
+def test_diagnostics_and_repairs_not_applicable_without_integration(tmp_path) -> None:
+    findings = findings_for(tmp_path)
+
+    assert findings["diagnostics.file.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["repairs.file.exists"].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_diagnostics_and_repairs_use_diagnostics_repairs_category(tmp_path) -> None:
+    write_integration(tmp_path, diagnostics=True, repairs=True)
+
+    findings = findings_for(tmp_path)
+
+    assert findings["diagnostics.file.exists"].category == "diagnostics_repairs"
+    assert findings["repairs.file.exists"].category == "diagnostics_repairs"


### PR DESCRIPTION
This pull request introduces new checks in the codebase to verify the presence of `diagnostics.py` and `repairs.py` files in Home Assistant custom integrations, and groups these checks under a new "Diagnostics/Repairs" category. It also adds corresponding example and test files to ensure the checks work as intended.

**New diagnostics and repairs checks:**

* Added a new rule in `src/hasscheck/rules/diagnostics.py` to check for the existence of `diagnostics.py` in each integration, recommending its addition if missing.
* Added a new rule in `src/hasscheck/rules/repairs.py` to check for the existence of `repairs.py` in each integration, recommending its addition if missing.
* Registered the new rules in the rule registry and grouped them under the new "diagnostics_repairs" category. [[1]](diffhunk://#diff-70d27533ac2f2e34ea9d9ba752abe216c3850babb7935cc3fe202b65b1d4efd4R5-R12) [[2]](diffhunk://#diff-8045ad0268a25c9d537a72ab6856426a887d80c00ac9dd68c7f12a5a0b05e30aR14)

**Examples and fixtures:**

* Added example `diagnostics.py` and `repairs.py` files to the demo integration for fixture and documentation purposes. [[1]](diffhunk://#diff-a988374ce66390fc51e28a157859b5b2aae9c1b9254e3dcf249c4a3987a48d3dR1-R10) [[2]](diffhunk://#diff-df638a2331294bda7af6ab34e9542841d06f954014b41b560a77b9f6113f248fR1-R5)

**Testing:**

* Added a new test file `tests/test_diagnostics_repairs_rules.py` to verify the new rules work as expected, including tests for presence, absence, and applicability of the files.