### PR TITLE
feat: add tests and ci rules

### DIFF
--- a/examples/good_integration/.github/workflows/tests.yml
+++ b/examples/good_integration/.github/workflows/tests.yml
@@ -1,0 +1,13 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "fixture workflow"

--- a/examples/good_integration/tests/test_placeholder.py
+++ b/examples/good_integration/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_good_integration_fixture_exists() -> None:
+    assert True

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -14,6 +14,7 @@ CATEGORY_LABELS = {
     "diagnostics_repairs": "Diagnostics/Repairs",
     "docs_support": "Docs/Support",
     "maintenance_signals": "Maintenance Signals",
+    "tests_ci": "Tests/CI",
 }
 
 

--- a/src/hasscheck/rules/ci.py
+++ b/src/hasscheck/rules/ci.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "tests_ci"
+GITHUB_ACTIONS_SOURCE = "https://docs.github.com/actions/using-workflows/about-workflows"
+
+
+def _workflow_files(context: ProjectContext):
+    workflows_dir = context.root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+    return sorted(path for path in workflows_dir.iterdir() if path.is_file() and path.suffix in {".yml", ".yaml"})
+
+
+def github_actions_exists(context: ProjectContext) -> Finding:
+    workflows = _workflow_files(context)
+    exists = bool(workflows)
+    path = workflows[0] if exists else context.root / ".github" / "workflows"
+    return Finding(
+        rule_id="ci.github_actions.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="GitHub Actions workflow exists",
+        message=(
+            f"Repository contains GitHub Actions workflow {workflows[0].name}."
+            if exists
+            else "Repository does not contain a GitHub Actions workflow file."
+        ),
+        applicability=Applicability(reason="CI helps maintainers catch regressions before releases and pull request merges."),
+        source=RuleSource(url=GITHUB_ACTIONS_SOURCE),
+        fix=None if exists else FixSuggestion(summary="Add a .github/workflows/*.yml workflow that runs HassCheck and tests."),
+        path=str(path.relative_to(context.root)) if exists else ".github/workflows",
+    )
+
+
+RULES = [
+    RuleDefinition(
+        id="ci.github_actions.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="GitHub Actions workflow exists",
+        why="A CI workflow makes quality checks repeatable for pushes and pull requests.",
+        source_url=GITHUB_ACTIONS_SOURCE,
+        check=github_actions_exists,
+    )
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from hasscheck.rules.brand import RULES as BRAND_RULES
+from hasscheck.rules.ci import RULES as CI_RULES
 from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
 from hasscheck.rules.diagnostics import RULES as DIAGNOSTICS_RULES
 from hasscheck.rules.docs import RULES as DOCS_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 from hasscheck.rules.repairs import RULES as REPAIRS_RULES
+from hasscheck.rules.tests import RULES as TESTS_RULES
 from hasscheck.rules.repository import RULES as REPOSITORY_RULES
 
-RULES = [*HACS_STRUCTURE_RULES, *BRAND_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES, *DIAGNOSTICS_RULES, *REPAIRS_RULES, *DOCS_RULES, *REPOSITORY_RULES]
+RULES = [*HACS_STRUCTURE_RULES, *BRAND_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES, *DIAGNOSTICS_RULES, *REPAIRS_RULES, *DOCS_RULES, *REPOSITORY_RULES, *TESTS_RULES, *CI_RULES]
 RULES_BY_ID = {rule.id: rule for rule in RULES}

--- a/src/hasscheck/rules/tests.py
+++ b/src/hasscheck/rules/tests.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "tests_ci"
+TESTS_SOURCE = "https://developers.home-assistant.io/docs/development_testing/"
+
+
+def tests_folder_exists(context: ProjectContext) -> Finding:
+    path = context.root / "tests"
+    exists = path.is_dir()
+    return Finding(
+        rule_id="tests.folder.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="tests folder exists",
+        message=(
+            "Repository contains a tests directory."
+            if exists
+            else "Repository does not contain a tests directory; automated test coverage cannot be inspected."
+        ),
+        applicability=Applicability(reason="Tests help maintainers keep integration behavior stable as Home Assistant evolves."),
+        source=RuleSource(url=TESTS_SOURCE),
+        fix=None if exists else FixSuggestion(summary="Add a tests/ directory with pytest-based integration tests."),
+        path="tests",
+    )
+
+
+RULES = [
+    RuleDefinition(
+        id="tests.folder.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="tests folder exists",
+        why="Tests provide maintainers a safety net for future Home Assistant and integration changes.",
+        source_url=TESTS_SOURCE,
+        check=tests_folder_exists,
+    )
+]

--- a/tests/test_tests_ci_rules.py
+++ b/tests/test_tests_ci_rules.py
@@ -1,0 +1,62 @@
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+
+def findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+def test_tests_folder_passes_when_tests_directory_exists(tmp_path) -> None:
+    (tmp_path / "tests").mkdir()
+
+    finding = findings_for(tmp_path)["tests.folder.exists"]
+
+    assert finding.status is RuleStatus.PASS
+
+
+def test_tests_folder_warns_when_missing(tmp_path) -> None:
+    finding = findings_for(tmp_path)["tests.folder.exists"]
+
+    assert finding.status is RuleStatus.WARN
+    assert finding.fix is not None
+
+
+def test_github_actions_passes_with_yml_or_yaml_workflow(tmp_path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "tests.yml").write_text("name: tests\n", encoding="utf-8")
+
+    finding = findings_for(tmp_path)["ci.github_actions.exists"]
+
+    assert finding.status is RuleStatus.PASS
+    assert finding.path == ".github/workflows/tests.yml"
+
+
+def test_github_actions_accepts_yaml_extension(tmp_path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yaml").write_text("name: ci\n", encoding="utf-8")
+
+    finding = findings_for(tmp_path)["ci.github_actions.exists"]
+
+    assert finding.status is RuleStatus.PASS
+    assert finding.path == ".github/workflows/ci.yaml"
+
+
+def test_github_actions_warns_when_missing(tmp_path) -> None:
+    finding = findings_for(tmp_path)["ci.github_actions.exists"]
+
+    assert finding.status is RuleStatus.WARN
+    assert finding.fix is not None
+
+
+def test_tests_ci_category_is_used(tmp_path) -> None:
+    (tmp_path / "tests").mkdir()
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "tests.yml").write_text("name: tests\n", encoding="utf-8")
+
+    findings = findings_for(tmp_path)
+
+    assert findings["tests.folder.exists"].category == "tests_ci"
+    assert findings["ci.github_actions.exists"].category == "tests_ci"


### PR DESCRIPTION
This pull request adds new rules to ensure that Home Assistant integrations include both a `tests` directory and a GitHub Actions workflow for continuous integration. It introduces rule definitions, updates the rule registry, and adds tests to verify these new checks. Additionally, it introduces a new category for these rules and provides a minimal example integration with a test and workflow file.

**New rules for test and CI requirements:**

* Added `tests.folder.exists` rule to check for the presence of a `tests` directory, encouraging automated test coverage (`src/hasscheck/rules/tests.py`).
* Added `ci.github_actions.exists` rule to check for at least one GitHub Actions workflow file (`.yml` or `.yaml`) in `.github/workflows`, promoting CI best practices (`src/hasscheck/rules/ci.py`).

**Rule registry and categorization updates:**

* Registered the new test and CI rules in the rule registry and introduced a new `tests_ci` category (`src/hasscheck/rules/registry.py`, `src/hasscheck/checker.py`) [[1]](diffhunk://#diff-70d27533ac2f2e34ea9d9ba752abe216c3850babb7935cc3fe202b65b1d4efd4R4-R14) [[2]](diffhunk://#diff-8045ad0268a25c9d537a72ab6856426a887d80c00ac9dd68c7f12a5a0b05e30aR17).

**Testing and example integration:**

* Added comprehensive tests to verify the new rules for both the `tests` directory and GitHub Actions workflows (`tests/test_tests_ci_rules.py`).
* Provided an example integration with a minimal test and a fixture GitHub Actions workflow (`examples/good_integration/tests/test_placeholder.py`, `examples/good_integration/.github/workflows/tests.yml`) [[1]](diffhunk://#diff-bc74dde73ee79fad98a2268d3e1e9f6e8fe1d814fb207f744396ba4469b79d5eR1-R2) [[2]](diffhunk://#diff-80392a216c630f7dc2921ad98dcfb2ebad56dadac46be2f669c58e60caaffacaR1-R13).