### PR TITLE
feat: add project applicability context

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ HassCheck starts as a local CLI. Public badges, hosted reports, and any future h
 
 ## Current status
 
-HassCheck is at **v0.2.0**.
+HassCheck is at **v0.3.0**.
 
 It includes:
 
@@ -36,6 +36,7 @@ It includes:
 - Source links and source timestamps
 - Applicability-aware statuses
 - Per-rule config overrides via `hasscheck.yaml`
+- Project applicability context via `hasscheck.yaml`
 - Example good/partial/bad integration fixtures
 - Pytest coverage for the current rule set
 
@@ -87,22 +88,34 @@ Run the CLI without installing globally:
 
 ## Configuration
 
-HassCheck reads `hasscheck.yaml` at the repository root when present. The file lets you
-mark RECOMMENDED rules as `not_applicable` or `manual_review` for your specific project.
+HassCheck reads `hasscheck.yaml` at the repository root when present.
+
+The file supports two separate kinds of user intent:
+
+1. **Project applicability context** — declare project-level facts once, so selected rules can return `not_applicable` without repetitive per-rule overrides.
+2. **Per-rule overrides** — mark specific RECOMMENDED rules as `not_applicable` or `manual_review` with a written reason.
 
 ```yaml
 # hasscheck.yaml
-schema_version: "0.2.0"
+schema_version: "0.3.0"
+
+applicability:
+  supports_diagnostics: false
+  has_user_fixable_repairs: false
+  uses_config_flow: false
 
 rules:
-  repairs.file.exists:
-    status: not_applicable
-    reason: No user-fixable repair scenarios in this integration.
-
-  diagnostics.file.exists:
+  repo.license.exists:
     status: manual_review
-    reason: Diagnostics planned but not yet implemented; tracked in #42.
+    reason: License decision pending before public release.
 ```
+
+**Rules for project applicability:**
+
+- Flags only explain intentionally missing optional signals.
+- Natural `pass` findings still win — existing files are not hidden by stale config.
+- Correctness failures stay locked. For example, `uses_config_flow: false` does not hide a `config_flow.py` / `manifest.json` mismatch.
+- Applied decisions are disclosed in JSON as `summary.applicability_applied` and marked in terminal findings with `(config)`.
 
 **Rules for overrides:**
 
@@ -113,7 +126,7 @@ rules:
 - Use `--no-config` to ignore `hasscheck.yaml` (useful for CI debugging).
 
 See `hasscheck.example.yaml` in this repository for a full annotated example.
-See `docs/architecture/config-file.md` for the design rationale.
+See `docs/architecture/config-file.md` and `docs/architecture/project-applicability-context.md` for the design rationale.
 
 ## Finding statuses
 
@@ -207,6 +220,7 @@ JSON output includes:
 - project metadata
 - ruleset metadata
 - category summaries
+- config disclosure summaries (`overrides_applied` and `applicability_applied`)
 - findings with rule IDs, rule versions, statuses, applicability, source URLs, and fix suggestions
 
 Example:
@@ -237,9 +251,9 @@ Run HassCheck against the current repository:
 .venv/bin/python -m hasscheck check --path .
 ```
 
-## Release checklist for v0.1.0
+## Release checklist for v0.3.0
 
-Before tagging v0.1.0:
+Before tagging v0.3.0:
 
 ```bash
 .venv/bin/python -m pytest -q
@@ -252,13 +266,13 @@ Before tagging v0.1.0:
 Then tag:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.3.0
+git push origin v0.3.0
 ```
 
-## Non-goals for v0.1.0
+## Non-goals for v0.3.0
 
-HassCheck v0.1.0 does not attempt:
+HassCheck v0.3.0 does not attempt:
 
 - Security certification
 - Official Home Assistant quality tier assignment
@@ -267,6 +281,8 @@ HassCheck v0.1.0 does not attempt:
 - Full semantic correctness checks
 - Public crawling or ranking of random repositories
 - Automatic PRs to third-party repos
+- Source-code auto-detection of project applicability
+- Multi-integration repository support
 
 ## Philosophy
 

--- a/docs/architecture/config-file.md
+++ b/docs/architecture/config-file.md
@@ -1,6 +1,6 @@
-# Config file: `hasscheck.yaml` (v0.2)
+# Config file: `hasscheck.yaml`
 
-> Status: in design. This document evolves as v0.2 ships.
+> Status: shipped in v0.2 and extended in v0.3.
 
 ## Why
 
@@ -13,12 +13,23 @@ Without an override mechanism, those warnings become nagging lint noise.
 v0.2 introduces `hasscheck.yaml` so maintainers can declare, with a
 written reason, that a rule does not apply to their project.
 
+v0.3 adds project-level applicability context for common facts that multiple
+rules can consume without repetitive per-rule overrides. See
+[`project-applicability-context.md`](project-applicability-context.md).
+
 ## Shape
 
 ```yaml
 # hasscheck.yaml — at the repo root
+schema_version: "0.3.0"
+
 project:
   type: integration
+
+applicability:
+  supports_diagnostics: false
+  has_user_fixable_repairs: false
+  uses_config_flow: false
 
 rules:
   repairs.file.exists:
@@ -65,6 +76,19 @@ honest:
 Math stays consistent with v0.1 (overridden findings excluded from
 `points_possible`). Trust comes from disclosure, not punishment.
 
+v0.3 adds a second disclosure field:
+
+```json
+"applicability_applied": {
+  "count": 2,
+  "rule_ids": ["diagnostics.file.exists", "repairs.file.exists"],
+  "flags": ["has_user_fixable_repairs", "supports_diagnostics"]
+}
+```
+
+This field is separate from `overrides_applied` because project applicability
+and per-rule overrides are different sources of user intent.
+
 ### Overridable rules in v0.2
 
 Of the 18 v0.1 rules, **8 are overridable** by `hasscheck.yaml`:
@@ -77,7 +101,7 @@ tests.folder.exists           ci.github_actions.exists
 
 The other 10 are locked (9 REQUIRED + 1 mixed-status).
 
-## What is NOT in v0.2
+## What moved past v0.2
 
 The original brief (`idea.md` section 6) shows two blocks in
 `hasscheck.yaml`. Only Block B (per-rule overrides) ships in v0.2.
@@ -85,8 +109,8 @@ The original brief (`idea.md` section 6) shows two blocks in
 | Feature | Status |
 |---|---|
 | Per-rule overrides (Block B) | ✅ v0.2 |
-| Project-level applicability flags (Block A — `auth_required`, `has_devices`, …) | ⏭️ deferred to v0.3 |
-| Auto-detection of applicability from project code | ⏭️ deferred to v0.3 |
+| Project-level applicability flags (Block A, limited to consumed flags) | ✅ v0.3 |
+| Auto-detection of applicability from project code | ⏭️ future work |
 | Multi-integration support (multiple subdirs in `custom_components/`) | ⏭️ orthogonal, separate work |
 
 See [`../decisions/0002-block-a-deferred-to-v03.md`](../decisions/0002-block-a-deferred-to-v03.md).
@@ -114,8 +138,8 @@ reports, the future hub) can see what was overridden:
 | Value | Meaning |
 |---|---|
 | `default` | The rule's built-in applicability decision (no override, no auto-detection). |
-| `detected` | (v0.3) The rule auto-detected applicability from the project. |
-| `config` | `hasscheck.yaml` overrode the finding. |
+| `detected` | Reserved for future source-code auto-detection. |
+| `config` | `hasscheck.yaml` changed or explained the finding. |
 
 ## Validation behavior
 

--- a/docs/architecture/project-applicability-context.md
+++ b/docs/architecture/project-applicability-context.md
@@ -1,0 +1,152 @@
+# Project applicability context architecture (v0.3)
+
+## Goal
+
+Allow maintainers to declare project-level applicability facts once in
+`hasscheck.yaml`, then let selected rules use those facts to return
+`not_applicable` without requiring repetitive per-rule overrides.
+
+## Non-goal
+
+This is not source-code auto-detection. v0.3 consumes explicit user-declared
+context only.
+
+## Example
+
+```yaml
+schema_version: "0.3.0"
+
+applicability:
+  supports_diagnostics: false
+  has_user_fixable_repairs: false
+  uses_config_flow: true
+
+rules:
+  repo.license.exists:
+    status: manual_review
+    reason: License decision pending before public release.
+```
+
+## Data flow
+
+```text
+CLI/checker
+  -> discover_config(root)
+  -> detect_project(root, applicability=config.applicability)
+  -> run rules with ProjectContext(applicability=...)
+  -> collect config-driven applicability changes
+  -> apply v0.2 per-rule overrides
+  -> build ReportSummary(categories, applicability_applied, overrides_applied)
+```
+
+## Model additions
+
+```python
+class ProjectApplicability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    supports_diagnostics: bool | None = None
+    has_user_fixable_repairs: bool | None = None
+    uses_config_flow: bool | None = None
+
+class HassCheckConfig(BaseModel):
+    schema_version: Literal["0.2.0", "0.3.0"] = "0.3.0"
+    project: ProjectConfig | None = None
+    applicability: ProjectApplicability | None = None
+    rules: dict[str, RuleOverride] = Field(default_factory=dict)
+
+class ApplicabilityApplied(BaseModel):
+    count: int = 0
+    rule_ids: list[str] = Field(default_factory=list)
+    flags: list[str] = Field(default_factory=list)
+```
+
+`ProjectContext` should gain:
+
+```python
+applicability: ProjectApplicability | None = None
+```
+
+Do not use module globals. Tests must be able to inject context/config without
+writing files.
+
+## Rule consumer contracts
+
+### `diagnostics.file.exists`
+
+| Condition | Result |
+|---|---|
+| no integration | native `not_applicable` |
+| `diagnostics.py` exists | `pass` |
+| missing + `supports_diagnostics is false` | `not_applicable`, source `config` |
+| missing + flag absent/true | native `warn` |
+
+### `repairs.file.exists`
+
+| Condition | Result |
+|---|---|
+| no integration | native `not_applicable` |
+| `repairs.py` exists | `pass` |
+| missing + `has_user_fixable_repairs is false` | `not_applicable`, source `config` |
+| missing + flag absent/true | native `warn` |
+
+### `config_flow.file.exists`
+
+| Condition | Result |
+|---|---|
+| no integration | native `not_applicable` |
+| `config_flow.py` exists | `pass` |
+| missing + `uses_config_flow is false` | `not_applicable`, source `config` |
+| missing + flag absent/true | native `warn` |
+
+### `config_flow.manifest_flag_consistent`
+
+| Condition | Result |
+|---|---|
+| file + manifest flag agree | `pass` |
+| file exists but manifest flag is not true | `fail` |
+| manifest flag true but file missing | `fail` |
+| no file and no flag + `uses_config_flow is false` | `not_applicable`, source `config` |
+| no file and no flag + flag absent/true | native `not_applicable` |
+
+The flag is allowed to explain intentional absence. It is not allowed to hide a
+mismatch.
+
+## Interaction with v0.2 per-rule overrides
+
+Rule-level overrides still apply post-hoc after rule execution.
+
+If a project flag produces config N/A, then a matching per-rule override is a
+natural N/A/no-op case and should not increment `overrides_applied`. The finding
+is already config-driven and is counted in `applicability_applied`.
+
+If a rule returns `warn` and a per-rule override exists, v0.2 behavior applies.
+
+## Terminal output
+
+When `summary.applicability_applied.count > 0`, terminal output should display a
+summary line such as:
+
+```text
+2 applicability decision(s) applied from hasscheck.yaml.
+```
+
+Findings changed by project applicability should be visually marked using the
+existing `(config)` marker or equivalent because `applicability.source ==
+"config"`.
+
+## Test strategy
+
+Start with failing tests for:
+
+1. Config schema accepts `applicability:` with the three v0.3 flags.
+2. Unknown applicability key fails due to `extra="forbid"`.
+3. Existing v0.2 config with only `rules:` still parses.
+4. Each consuming rule converts missing optional files to config N/A only when
+   its flag is explicitly false.
+5. Natural PASS wins over false flags.
+6. Config-flow consistency mismatches still fail despite `uses_config_flow:
+   false`.
+7. `summary.applicability_applied` is present, sorted, and counts changed
+   findings.
+8. Per-rule overrides still work and remain separately disclosed.

--- a/docs/decisions/0004-project-applicability-context.md
+++ b/docs/decisions/0004-project-applicability-context.md
@@ -1,0 +1,171 @@
+# ADR 0004 — Project applicability context for v0.3
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Tag**: v0.3 scope
+
+## Context
+
+v0.2 shipped `hasscheck.yaml` per-rule overrides:
+
+```yaml
+rules:
+  repairs.file.exists:
+    status: not_applicable
+    reason: No user-fixable repair scenarios.
+```
+
+That solved the immediate warning-noise problem, but it creates honest friction:
+maintainers must repeat per-rule overrides for common project-level facts.
+
+ADR 0002 intentionally deferred Block A — project-level applicability flags — to
+v0.3 because Block A is a rule-engine feature. A flag is only useful if concrete
+rules consume it.
+
+## Decision
+
+v0.3 introduces a small `applicability:` block in `hasscheck.yaml` and wires it
+to a limited set of rule consumers.
+
+Initial flags:
+
+```yaml
+applicability:
+  supports_diagnostics: false
+  has_user_fixable_repairs: false
+  uses_config_flow: false
+```
+
+Each flag is optional. Absence means "no declaration" and existing v0.2 behavior
+continues.
+
+## Scope
+
+### In
+
+- Extend `HassCheckConfig` with an optional `applicability` block.
+- Add a `ProjectApplicability` Pydantic model with `extra="forbid"`.
+- Route loaded config applicability into rule execution through context, not via
+  global state.
+- Add rule consumers:
+  - `diagnostics.file.exists` consumes `supports_diagnostics`.
+  - `repairs.file.exists` consumes `has_user_fixable_repairs`.
+  - `config_flow.file.exists` consumes `uses_config_flow`.
+  - `config_flow.manifest_flag_consistent` MAY use `uses_config_flow` only for
+    no-signal cases; it MUST NOT hide file/manifest mismatches.
+- Add JSON disclosure for config-driven applicability decisions.
+- Add terminal disclosure when config applicability changed findings.
+- Keep v0.2 per-rule overrides working unchanged.
+
+### Out
+
+- Static source-code auto-detection.
+- Project flags from the original idea that no current rule consumes
+  (`auth_required`, `has_devices`, `cloud_service`, `uses_config_entry`).
+- Multi-integration support.
+- Scaffolding commands.
+- GitHub Action.
+
+## Behavior rules
+
+### 1. Flags only soften missing-signal warnings
+
+A config applicability flag may convert a missing optional signal from `warn` to
+`not_applicable`.
+
+Example:
+
+```yaml
+applicability:
+  has_user_fixable_repairs: false
+```
+
+If `repairs.py` is absent, `repairs.file.exists` becomes `not_applicable` with
+`applicability.source = "config"`.
+
+### 2. Natural PASS wins
+
+If a file exists and the rule naturally passes, project applicability MUST NOT
+turn it into `not_applicable`.
+
+Example: if `diagnostics.py` exists but `supports_diagnostics: false`, the rule
+still passes. This avoids stale config hiding real repository state.
+
+### 3. Correctness failures remain locked
+
+Applicability flags MUST NOT hide consistency or correctness failures.
+
+Example: if `config_flow.py` exists but `manifest.json` does not set
+`config_flow: true`, `config_flow.manifest_flag_consistent` still fails even when
+`uses_config_flow: false`.
+
+### 4. Per-rule overrides win over project applicability for non-PASS findings
+
+Order:
+
+1. Run rules with project applicability context.
+2. Apply v0.2 per-rule overrides post-hoc.
+
+This preserves v0.2's explicit override mechanism and keeps per-rule written
+reasons as the strongest user intent.
+
+### 5. Disclosure is mandatory
+
+Config-driven applicability changes score denominators. They must be visible.
+
+v0.3 adds a separate summary field rather than reusing `overrides_applied`:
+
+```json
+"applicability_applied": {
+  "count": 2,
+  "rule_ids": ["diagnostics.file.exists", "repairs.file.exists"],
+  "flags": ["has_user_fixable_repairs", "supports_diagnostics"]
+}
+```
+
+`overrides_applied` remains specific to v0.2 per-rule overrides.
+
+## Schema/version policy
+
+- Package/tool version becomes `0.3.0` when shipped.
+- Report `schema_version` becomes `0.3.0` because `summary.applicability_applied`
+  is a new JSON field.
+- Existing v0.2 config files with only `rules:` must keep working.
+- `hasscheck.yaml` with no `schema_version` is accepted and treated as current.
+- Explicit `schema_version: "0.2.0"` is accepted for backward compatibility when
+  using only v0.2 fields.
+- Explicit `schema_version: "0.3.0"` is accepted for v0.3 fields.
+
+## Rationale
+
+- The initial flags are chosen from current rule pain, not from speculative
+  product ideas. Flags with no consumers are dead config.
+- Natural PASS wins because v0.2 already rejected PASS-to-N/A overrides as stale
+  or suspicious. Project applicability should follow the same trust model.
+- Correctness checks remain locked because HassCheck's credibility depends on not
+  letting config hide broken wiring.
+- A separate `applicability_applied` summary keeps JSON consumers from confusing
+  project-level applicability with per-rule overrides.
+
+## Alternatives rejected
+
+### Add all idea.md flags now
+
+Rejected. `auth_required`, `has_devices`, `cloud_service`, and
+`uses_config_entry` are plausible future flags, but no current v0.3 rule has a
+clear consumer. Adding them now would create dead config.
+
+### Reuse `summary.overrides_applied`
+
+Rejected. Per-rule overrides and project applicability are different sources of
+user intent. Mixing them makes downstream badge/report logic harder to trust.
+
+### Let flags override PASS findings
+
+Rejected. This repeats the v0.2 S4.3 pitfall: stale config could hide files that
+actually exist.
+
+### Auto-detect applicability in v0.3
+
+Rejected for initial v0.3 scope. Auto-detection is valuable, but should follow
+explicit config consumers once behavior is proven.

--- a/examples/good_integration/custom_components/demo_good/config_flow.py
+++ b/examples/good_integration/custom_components/demo_good/config_flow.py
@@ -5,4 +5,3 @@ from __future__ import annotations
 
 class DemoGoodConfigFlow:
     """Placeholder config flow fixture for HassCheck examples."""
-

--- a/hasscheck.example.yaml
+++ b/hasscheck.example.yaml
@@ -1,15 +1,27 @@
-# hasscheck.yaml — applicability overrides for hasscheck v0.2
-# Copy this file to your integration root as `hasscheck.yaml` and remove the rules
+# hasscheck.yaml — project context and rule overrides for hasscheck v0.3
+# Copy this file to your repository root as `hasscheck.yaml` and remove entries
 # that do not apply to your project.
 #
 # Documentation: docs/architecture/config-file.md
+# Project context: docs/architecture/project-applicability-context.md
 # Override rules: run `hasscheck explain <rule-id>` to see if a rule is overridable.
 
-schema_version: "0.2.0"
+schema_version: "0.3.0"
 
-# Reserved for v0.3. In v0.2, only `type: integration` is accepted.
+# Optional project metadata. In v0.3, only `type: integration` is accepted.
 # project:
 #   type: integration
+
+# Project-level applicability facts. These are not scores and not certifications.
+# They only explain why selected optional signals are intentionally absent.
+#
+# Natural PASS findings still win. Example: if diagnostics.py exists, the
+# diagnostics rule still passes even when `supports_diagnostics: false` is stale.
+# Correctness failures also stay locked.
+applicability:
+  supports_diagnostics: false
+  has_user_fixable_repairs: false
+  uses_config_flow: false
 
 # Per-rule overrides. Each entry softens a finding to:
 #   not_applicable — the rule legitimately does not apply to this project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.2.1"
+version = "0.3.0"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -16,12 +16,22 @@ hasscheck = "hasscheck.cli:main"
 
 [dependency-groups]
 dev = [
+    "pre-commit>=4.6.0",
     "pytest>=8.0",
+    "ruff>=0.15.12",
 ]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501", "B008"]
 
 [build-system]
 requires = ["hatchling>=1.25"]

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -5,8 +5,22 @@ from pathlib import Path
 
 from hasscheck.config import HassCheckConfig, apply_overrides, discover_config
 from hasscheck.detect import detect_project
-from hasscheck.models import CategorySignal, HassCheckReport, ProjectInfo, ReportSummary, RuleStatus
+from hasscheck.models import (
+    ApplicabilityApplied,
+    CategorySignal,
+    HassCheckReport,
+    ProjectInfo,
+    ReportSummary,
+    RuleStatus,
+)
 from hasscheck.rules.registry import RULES
+
+APPLICABILITY_FLAGS_BY_RULE = {
+    "diagnostics.file.exists": "supports_diagnostics",
+    "repairs.file.exists": "has_user_fixable_repairs",
+    "config_flow.file.exists": "uses_config_flow",
+    "config_flow.manifest_flag_consistent": "uses_config_flow",
+}
 
 CATEGORY_LABELS = {
     "hacs_structure": "HACS Structure",
@@ -33,10 +47,29 @@ def run_check(
     if config is None and not no_config:
         config = discover_config(root)
 
-    context = detect_project(root)
+    context = detect_project(
+        root, applicability=config.applicability if config else None
+    )
     findings = [rule.check(context) for rule in RULES]
 
+    config_applicability_rule_ids = sorted(
+        finding.rule_id
+        for finding in findings
+        if finding.applicability.source == "config"
+    )
+    applicability_applied = ApplicabilityApplied(
+        count=len(config_applicability_rule_ids),
+        rule_ids=config_applicability_rule_ids,
+        flags=sorted(
+            {
+                APPLICABILITY_FLAGS_BY_RULE[rule_id]
+                for rule_id in config_applicability_rule_ids
+            }
+        ),
+    )
+
     from hasscheck.models import OverridesApplied
+
     overrides_applied = OverridesApplied()
 
     if config is not None:
@@ -66,8 +99,14 @@ def run_check(
             path=str(root),
             type="integration" if context.integration_path is not None else "unknown",
             domain=context.domain,
-            integration_path=str(context.integration_path.relative_to(root)) if context.integration_path else None,
+            integration_path=str(context.integration_path.relative_to(root))
+            if context.integration_path
+            else None,
         ),
-        summary=ReportSummary(categories=categories, overrides_applied=overrides_applied),
+        summary=ReportSummary(
+            categories=categories,
+            overrides_applied=overrides_applied,
+            applicability_applied=applicability_applied,
+        ),
         findings=findings,
     )

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -31,16 +31,30 @@ def version_callback(value: bool) -> None:
 
 @app.callback()
 def root(
-    version: bool = typer.Option(False, "--version", "-V", callback=version_callback, help="Show version and exit."),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=version_callback,
+        help="Show version and exit.",
+    ),
 ) -> None:
     """Validate Home Assistant custom integration quality signals."""
 
 
 @app.command()
 def check(
-    path: Path = typer.Option(Path("."), "--path", "-p", help="Repository path to inspect."),
-    json_output: bool = typer.Option(False, "--json", help="Emit the stable JSON report."),
-    no_config: bool = typer.Option(False, "--no-config", help="Ignore hasscheck.yaml even if present (useful for CI debugging)."),
+    path: Path = typer.Option(
+        Path("."), "--path", "-p", help="Repository path to inspect."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the stable JSON report."
+    ),
+    no_config: bool = typer.Option(
+        False,
+        "--no-config",
+        help="Ignore hasscheck.yaml even if present (useful for CI debugging).",
+    ),
 ) -> None:
     """Check a custom integration repository and print actionable findings.
 
@@ -54,14 +68,16 @@ def check(
     """
     if not path.exists():
         console.print(f"[red]Error:[/] Path '{path}' does not exist.")
-        console.print("[yellow]Suggestion:[/] Pass an existing repository path with --path.")
+        console.print(
+            "[yellow]Suggestion:[/] Pass an existing repository path with --path."
+        )
         raise typer.Exit(code=1)
 
     try:
         report = run_check(path, no_config=no_config)
     except ConfigError as exc:
         typer.echo(f"hasscheck: error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
     if json_output:
         typer.echo(report_to_json(report), nl=False)
@@ -77,12 +93,18 @@ def schema() -> None:
 
 
 @app.command()
-def explain(rule_id: str = typer.Argument(..., help="Rule ID to explain, for example manifest.domain.exists.")) -> None:
+def explain(
+    rule_id: str = typer.Argument(
+        ..., help="Rule ID to explain, for example manifest.domain.exists."
+    ),
+) -> None:
     """Explain why a rule exists, how it is sourced, and what it checks."""
     rule = RULES_BY_ID.get(rule_id)
     if rule is None:
         console.print(f"[red]Error:[/] Unknown rule '{rule_id}'.")
-        console.print("[yellow]Suggestion:[/] Run 'hasscheck check --json' to see emitted rule IDs.")
+        console.print(
+            "[yellow]Suggestion:[/] Run 'hasscheck check --json' to see emitted rule IDs."
+        )
         raise typer.Exit(code=1)
 
     console.print(f"[bold]{rule.id}[/bold]")

--- a/src/hasscheck/config.py
+++ b/src/hasscheck/config.py
@@ -1,4 +1,5 @@
 """hasscheck.yaml schema models, config loader, and override engine."""
+
 from __future__ import annotations
 
 import sys
@@ -6,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TextIO
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 if TYPE_CHECKING:
     from hasscheck.models import Finding, OverridesApplied
@@ -30,12 +31,29 @@ class ProjectConfig(BaseModel):
     type: Literal["integration"] = "integration"
 
 
+class ProjectApplicability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    supports_diagnostics: bool | None = None
+    has_user_fixable_repairs: bool | None = None
+    uses_config_flow: bool | None = None
+
+
 class HassCheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0"] = "0.2.0"
+    schema_version: Literal["0.2.0", "0.3.0"] = "0.3.0"
     project: ProjectConfig | None = None
+    applicability: ProjectApplicability | None = None
     rules: dict[str, RuleOverride] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _schema_version_matches_fields(self) -> HassCheckConfig:
+        if self.schema_version == "0.2.0" and self.applicability is not None:
+            raise ValueError(
+                "schema_version 0.2.0 does not support applicability; use 0.3.0"
+            )
+        return self
 
 
 def load_config_file(path: Path) -> HassCheckConfig:
@@ -143,7 +161,10 @@ def apply_overrides(
             continue
 
         # Step 5: natural MANUAL_REVIEW + override=manual_review → redundant, warn-skip
-        if natural_status is RuleStatus.MANUAL_REVIEW and override.status == "manual_review":
+        if (
+            natural_status is RuleStatus.MANUAL_REVIEW
+            and override.status == "manual_review"
+        ):
             print(
                 f"hasscheck: warning: rule '{rule_id}' is already MANUAL_REVIEW; "
                 f"override in hasscheck.yaml is redundant.",
@@ -160,14 +181,16 @@ def apply_overrides(
             new_app_status = ApplicabilityStatus.MANUAL_REVIEW
 
         idx = new_findings.index(finding)
-        new_findings[idx] = finding.model_copy(update={
-            "status": new_status,
-            "applicability": Applicability(
-                status=new_app_status,
-                reason=override.reason,
-                source="config",
-            ),
-        })
+        new_findings[idx] = finding.model_copy(
+            update={
+                "status": new_status,
+                "applicability": Applicability(
+                    status=new_app_status,
+                    reason=override.reason,
+                    source="config",
+                ),
+            }
+        )
         applied.append(rule_id)
 
     overrides_applied = OverridesApplied(

--- a/src/hasscheck/detect.py
+++ b/src/hasscheck/detect.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from hasscheck.rules.base import ProjectContext
 
+if TYPE_CHECKING:
+    from hasscheck.config import ProjectApplicability
 
-def detect_project(root: Path) -> ProjectContext:
+
+def detect_project(
+    root: Path, applicability: ProjectApplicability | None = None
+) -> ProjectContext:
     root = root.resolve()
     custom_components = root / "custom_components"
     integration_path: Path | None = None
@@ -13,10 +19,17 @@ def detect_project(root: Path) -> ProjectContext:
 
     if custom_components.is_dir():
         integrations = sorted(
-            path for path in custom_components.iterdir() if path.is_dir() and not path.name.startswith(".")
+            path
+            for path in custom_components.iterdir()
+            if path.is_dir() and not path.name.startswith(".")
         )
         if integrations:
             integration_path = integrations[0]
             domain = integration_path.name
 
-    return ProjectContext(root=root, integration_path=integration_path, domain=domain)
+    return ProjectContext(
+        root=root,
+        integration_path=integration_path,
+        domain=domain,
+        applicability=applicability,
+    )

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -6,8 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
-SCHEMA_VERSION = "0.2.0"
+SCHEMA_VERSION = "0.3.0"
 DEFAULT_RULESET_ID = "hasscheck-ha-2026.4"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
 
@@ -81,7 +80,7 @@ class OverridesApplied(BaseModel):
     rule_ids: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _invariant(self) -> "OverridesApplied":
+    def _invariant(self) -> OverridesApplied:
         if self.count != len(self.rule_ids):
             raise ValueError(
                 f"overrides_applied invariant violated: count={self.count} but "
@@ -92,6 +91,29 @@ class OverridesApplied(BaseModel):
         return self
 
 
+class ApplicabilityApplied(BaseModel):
+    count: int = 0
+    rule_ids: list[str] = Field(default_factory=list)
+    flags: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _invariant(self) -> ApplicabilityApplied:
+        if self.count != len(self.rule_ids):
+            raise ValueError(
+                f"applicability_applied invariant violated: count={self.count} but "
+                f"rule_ids has {len(self.rule_ids)} entries"
+            )
+        if self.rule_ids != sorted(self.rule_ids):
+            raise ValueError(
+                "applicability_applied.rule_ids must be alphabetically sorted"
+            )
+        if self.flags != sorted(self.flags):
+            raise ValueError(
+                "applicability_applied.flags must be alphabetically sorted"
+            )
+        return self
+
+
 class ReportSummary(BaseModel):
     overall: Literal["informational_only"] = "informational_only"
     security_review: Literal["not_performed"] = "not_performed"
@@ -99,6 +121,9 @@ class ReportSummary(BaseModel):
     hacs_acceptance: Literal["not_guaranteed"] = "not_guaranteed"
     categories: list[CategorySignal] = Field(default_factory=list)
     overrides_applied: OverridesApplied = Field(default_factory=OverridesApplied)
+    applicability_applied: ApplicabilityApplied = Field(
+        default_factory=ApplicabilityApplied
+    )
 
 
 class ProjectInfo(BaseModel):
@@ -110,7 +135,7 @@ class ProjectInfo(BaseModel):
 
 class ToolInfo(BaseModel):
     name: Literal["hasscheck"] = "hasscheck"
-    version: str = "0.2.1"
+    version: str = "0.3.0"
 
 
 class RulesetInfo(BaseModel):

--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -20,12 +20,16 @@ def report_to_json(report: HassCheckReport) -> str:
     return json.dumps(report.to_json_dict(), indent=2) + "\n"
 
 
-def print_terminal_report(report: HassCheckReport, console: Console | None = None) -> None:
+def print_terminal_report(
+    report: HassCheckReport, console: Console | None = None
+) -> None:
     console = console or Console()
     console.print("[bold]HassCheck Summary[/bold]")
     console.print()
     for category in report.summary.categories:
-        console.print(f"{category.label}: {category.points_awarded} / {category.points_possible}")
+        console.print(
+            f"{category.label}: {category.points_awarded} / {category.points_possible}"
+        )
     console.print()
     console.print("Overall: Informational only")
     console.print("Security Review: Not performed")
@@ -38,11 +42,20 @@ def print_terminal_report(report: HassCheckReport, console: Console | None = Non
         console.print(f"[cyan]{n} override(s) applied from hasscheck.yaml.[/cyan]")
         console.print()
 
+    if report.summary.applicability_applied.count > 0:
+        n = report.summary.applicability_applied.count
+        console.print(
+            f"[cyan]{n} applicability decision(s) applied from hasscheck.yaml.[/cyan]"
+        )
+        console.print()
+
     table = Table(title="Findings")
     table.add_column("Status", no_wrap=True)
     table.add_column("Rule")
     table.add_column("Message")
     for finding in report.findings:
         marker = " (config)" if finding.applicability.source == "config" else ""
-        table.add_row(STATUS_ICON[finding.status], f"{finding.rule_id}{marker}", finding.message)
+        table.add_row(
+            STATUS_ICON[finding.status], f"{finding.rule_id}{marker}", finding.message
+        )
     console.print(table)

--- a/src/hasscheck/rules/base.py
+++ b/src/hasscheck/rules/base.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING
 
-from hasscheck.models import Finding, RuleSource, RuleSeverity, RuleStatus
+if TYPE_CHECKING:
+    from hasscheck.config import ProjectApplicability
+
+from hasscheck.models import Finding, RuleSeverity, RuleSource
 
 
 @dataclass(frozen=True)
@@ -12,6 +16,7 @@ class ProjectContext:
     root: Path
     integration_path: Path | None
     domain: str | None
+    applicability: ProjectApplicability | None = None
 
 
 @dataclass(frozen=True)

--- a/src/hasscheck/rules/brand.py
+++ b/src/hasscheck/rules/brand.py
@@ -13,7 +13,9 @@ from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "hacs_structure"
 HACS_SOURCE = "https://www.hacs.xyz/docs/publish/integration/"
-HA_BRAND_SOURCE = "https://developers.home-assistant.io/docs/core/integration/brand_images/"
+HA_BRAND_SOURCE = (
+    "https://developers.home-assistant.io/docs/core/integration/brand_images/"
+)
 
 
 def brand_icon_exists(context: ProjectContext) -> Finding:
@@ -31,7 +33,9 @@ def brand_icon_exists(context: ProjectContext) -> Finding:
                 reason="custom_components/<domain>/ must exist before HassCheck can inspect brand assets.",
             ),
             source=RuleSource(url=HACS_SOURCE),
-            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding brand/icon.png."),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ before adding brand/icon.png."
+            ),
             path="custom_components/<domain>/brand/icon.png",
         )
 
@@ -49,9 +53,13 @@ def brand_icon_exists(context: ProjectContext) -> Finding:
             if exists
             else "Integration does not include brand/icon.png. HACS and Home Assistant brand image support cannot be fully inspected."
         ),
-        applicability=Applicability(reason="HACS expects integration brand assets, and Home Assistant supports local custom integration brand images."),
+        applicability=Applicability(
+            reason="HACS expects integration brand assets, and Home Assistant supports local custom integration brand images."
+        ),
         source=RuleSource(url=HACS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add custom_components/<domain>/brand/icon.png."),
+        fix=None
+        if exists
+        else FixSuggestion(summary="Add custom_components/<domain>/brand/icon.png."),
         path=str(path.relative_to(context.root)),
     )
 

--- a/src/hasscheck/rules/ci.py
+++ b/src/hasscheck/rules/ci.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
-from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.models import (
+    Applicability,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "tests_ci"
-GITHUB_ACTIONS_SOURCE = "https://docs.github.com/actions/using-workflows/about-workflows"
+GITHUB_ACTIONS_SOURCE = (
+    "https://docs.github.com/actions/using-workflows/about-workflows"
+)
 
 
 def _workflow_files(context: ProjectContext):
     workflows_dir = context.root / ".github" / "workflows"
     if not workflows_dir.is_dir():
         return []
-    return sorted(path for path in workflows_dir.iterdir() if path.is_file() and path.suffix in {".yml", ".yaml"})
+    return sorted(
+        path
+        for path in workflows_dir.iterdir()
+        if path.is_file() and path.suffix in {".yml", ".yaml"}
+    )
 
 
 def github_actions_exists(context: ProjectContext) -> Finding:
@@ -30,9 +43,15 @@ def github_actions_exists(context: ProjectContext) -> Finding:
             if exists
             else "Repository does not contain a GitHub Actions workflow file."
         ),
-        applicability=Applicability(reason="CI helps maintainers catch regressions before releases and pull request merges."),
+        applicability=Applicability(
+            reason="CI helps maintainers catch regressions before releases and pull request merges."
+        ),
         source=RuleSource(url=GITHUB_ACTIONS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add a .github/workflows/*.yml workflow that runs HassCheck and tests."),
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add a .github/workflows/*.yml workflow that runs HassCheck and tests."
+        ),
         path=str(path.relative_to(context.root)) if exists else ".github/workflows",
     )
 

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -15,8 +15,12 @@ from hasscheck.models import (
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "modern_ha_patterns"
-CONFIG_FLOW_SOURCE = "https://developers.home-assistant.io/docs/core/integration/config_flow"
-MANIFEST_SOURCE = "https://developers.home-assistant.io/docs/creating_integration_manifest"
+CONFIG_FLOW_SOURCE = (
+    "https://developers.home-assistant.io/docs/core/integration/config_flow"
+)
+MANIFEST_SOURCE = (
+    "https://developers.home-assistant.io/docs/creating_integration_manifest"
+)
 
 
 def _config_flow_path(context: ProjectContext):
@@ -69,11 +73,38 @@ def config_flow_file_exists(context: ProjectContext) -> Finding:
                 reason="custom_components/<domain>/ must exist before HassCheck can inspect config_flow.py.",
             ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding config_flow.py."),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ before adding config_flow.py."
+            ),
             path="custom_components/<domain>/config_flow.py",
         )
 
     exists = path.is_file()
+    if (
+        not exists
+        and context.applicability
+        and context.applicability.uses_config_flow is False
+    ):
+        return Finding(
+            rule_id="config_flow.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py exists",
+            message="Project config declares this integration does not use config flow UI setup.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares uses_config_flow: false.",
+                source="config",
+            ),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=None,
+            path=_display_path(
+                path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
     return Finding(
         rule_id="config_flow.file.exists",
         rule_version="1.0.0",
@@ -86,11 +117,15 @@ def config_flow_file_exists(context: ProjectContext) -> Finding:
             if exists
             else "Integration does not include config_flow.py; UI setup support cannot be inspected."
         ),
-        applicability=Applicability(reason="Config flows are the standard way to set up integrations via the UI."),
+        applicability=Applicability(
+            reason="Config flows are the standard way to set up integrations via the UI."
+        ),
         source=RuleSource(url=CONFIG_FLOW_SOURCE),
         fix=None
         if exists
-        else FixSuggestion(summary="Add config_flow.py when the integration should support setup via the Home Assistant UI."),
+        else FixSuggestion(
+            summary="Add config_flow.py when the integration should support setup via the Home Assistant UI."
+        ),
         path=_display_path(path, context, "custom_components/<domain>/config_flow.py"),
     )
 
@@ -112,7 +147,9 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
                 reason="custom_components/<domain>/ must exist before HassCheck can inspect config flow consistency.",
             ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Create custom_components/<domain>/ and manifest.json first."),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ and manifest.json first."
+            ),
             path="custom_components/<domain>/",
         )
 
@@ -131,8 +168,12 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
                 reason="manifest.json must exist before HassCheck can inspect config_flow metadata.",
             ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Create manifest.json first, then define config_flow when needed."),
-            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+            fix=FixSuggestion(
+                summary="Create manifest.json first, then define config_flow when needed."
+            ),
+            path=_display_path(
+                manifest_path, context, "custom_components/<domain>/manifest.json"
+            ),
         )
 
     if error is not None:
@@ -144,10 +185,16 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
             severity=RuleSeverity.REQUIRED,
             title="config_flow.py and manifest config_flow flag agree",
             message=f"manifest.json is not valid JSON: {error}.",
-            applicability=Applicability(reason="manifest.json exists but cannot be parsed."),
+            applicability=Applicability(
+                reason="manifest.json exists but cannot be parsed."
+            ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Fix manifest.json syntax, then rerun HassCheck."),
-            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+            fix=FixSuggestion(
+                summary="Fix manifest.json syntax, then rerun HassCheck."
+            ),
+            path=_display_path(
+                manifest_path, context, "custom_components/<domain>/manifest.json"
+            ),
         )
 
     has_file = config_path.is_file()
@@ -162,10 +209,14 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
             severity=RuleSeverity.REQUIRED,
             title="config_flow.py and manifest config_flow flag agree",
             message="config_flow.py exists and manifest.json sets config_flow: true.",
-            applicability=Applicability(reason="Home Assistant needs both config_flow.py and manifest config_flow metadata."),
+            applicability=Applicability(
+                reason="Home Assistant needs both config_flow.py and manifest config_flow metadata."
+            ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
             fix=None,
-            path=_display_path(config_path, context, "custom_components/<domain>/config_flow.py"),
+            path=_display_path(
+                config_path, context, "custom_components/<domain>/config_flow.py"
+            ),
         )
 
     if has_file and not manifest_flag:
@@ -177,10 +228,14 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
             severity=RuleSeverity.REQUIRED,
             title="config_flow.py and manifest config_flow flag agree",
             message="config_flow.py exists, but manifest.json does not set config_flow: true.",
-            applicability=Applicability(reason="Home Assistant activates config flows through manifest config_flow metadata."),
+            applicability=Applicability(
+                reason="Home Assistant activates config flows through manifest config_flow metadata."
+            ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Add \"config_flow\": true to manifest.json."),
-            path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+            fix=FixSuggestion(summary='Add "config_flow": true to manifest.json.'),
+            path=_display_path(
+                manifest_path, context, "custom_components/<domain>/manifest.json"
+            ),
         )
 
     if manifest_flag and not has_file:
@@ -192,10 +247,37 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
             severity=RuleSeverity.REQUIRED,
             title="config_flow.py and manifest config_flow flag agree",
             message="manifest.json sets config_flow: true, but config_flow.py is missing.",
-            applicability=Applicability(reason="Home Assistant docs say config_flow.py needs to exist when config_flow is specified."),
+            applicability=Applicability(
+                reason="Home Assistant docs say config_flow.py needs to exist when config_flow is specified."
+            ),
             source=RuleSource(url=CONFIG_FLOW_SOURCE),
-            fix=FixSuggestion(summary="Add config_flow.py or remove config_flow from manifest.json until UI setup is implemented."),
-            path=_display_path(config_path, context, "custom_components/<domain>/config_flow.py"),
+            fix=FixSuggestion(
+                summary="Add config_flow.py or remove config_flow from manifest.json until UI setup is implemented."
+            ),
+            path=_display_path(
+                config_path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
+    if context.applicability and context.applicability.uses_config_flow is False:
+        return Finding(
+            rule_id="config_flow.manifest_flag_consistent",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title="config_flow.py and manifest config_flow flag agree",
+            message="Project config declares this integration does not use config flow UI setup.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares uses_config_flow: false.",
+                source="config",
+            ),
+            source=RuleSource(url=CONFIG_FLOW_SOURCE),
+            fix=None,
+            path=_display_path(
+                manifest_path, context, "custom_components/<domain>/manifest.json"
+            ),
         )
 
     return Finding(
@@ -211,8 +293,12 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
             reason="The integration does not currently advertise a config flow.",
         ),
         source=RuleSource(url=CONFIG_FLOW_SOURCE),
-        fix=FixSuggestion(summary="Add config_flow.py and set config_flow: true when adding UI setup support."),
-        path=_display_path(manifest_path, context, "custom_components/<domain>/manifest.json"),
+        fix=FixSuggestion(
+            summary="Add config_flow.py and set config_flow: true when adding UI setup support."
+        ),
+        path=_display_path(
+            manifest_path, context, "custom_components/<domain>/manifest.json"
+        ),
     )
 
 

--- a/src/hasscheck/rules/diagnostics.py
+++ b/src/hasscheck/rules/diagnostics.py
@@ -12,7 +12,9 @@ from hasscheck.models import (
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "diagnostics_repairs"
-DIAGNOSTICS_SOURCE = "https://developers.home-assistant.io/docs/core/integration/diagnostics/"
+DIAGNOSTICS_SOURCE = (
+    "https://developers.home-assistant.io/docs/core/integration/diagnostics/"
+)
 
 
 def diagnostics_file_exists(context: ProjectContext) -> Finding:
@@ -30,12 +32,37 @@ def diagnostics_file_exists(context: ProjectContext) -> Finding:
                 reason="custom_components/<domain>/ must exist before HassCheck can inspect diagnostics.py.",
             ),
             source=RuleSource(url=DIAGNOSTICS_SOURCE),
-            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding diagnostics.py."),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ before adding diagnostics.py."
+            ),
             path="custom_components/<domain>/diagnostics.py",
         )
 
     path = context.integration_path / "diagnostics.py"
     exists = path.is_file()
+    if (
+        not exists
+        and context.applicability
+        and context.applicability.supports_diagnostics is False
+    ):
+        return Finding(
+            rule_id="diagnostics.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py exists",
+            message="Project config declares diagnostics are not supported by this integration.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares supports_diagnostics: false.",
+                source="config",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=None,
+            path=str(path.relative_to(context.root)),
+        )
+
     return Finding(
         rule_id="diagnostics.file.exists",
         rule_version="1.0.0",
@@ -48,9 +75,15 @@ def diagnostics_file_exists(context: ProjectContext) -> Finding:
             if exists
             else "Integration does not include diagnostics.py; downloadable troubleshooting data support cannot be inspected."
         ),
-        applicability=Applicability(reason="Diagnostics help users provide support data while redacting sensitive information."),
+        applicability=Applicability(
+            reason="Diagnostics help users provide support data while redacting sensitive information."
+        ),
         source=RuleSource(url=DIAGNOSTICS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add diagnostics.py with redaction for sensitive values."),
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add diagnostics.py with redaction for sensitive values."
+        ),
         path=str(path.relative_to(context.root)),
     )
 

--- a/src/hasscheck/rules/docs.py
+++ b/src/hasscheck/rules/docs.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.models import (
+    Applicability,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "docs_support"
@@ -8,7 +15,11 @@ DOCS_SOURCE = "https://developers.home-assistant.io/docs/core/integration-qualit
 
 
 def readme_exists(context: ProjectContext) -> Finding:
-    candidates = [context.root / "README.md", context.root / "README.rst", context.root / "README.txt"]
+    candidates = [
+        context.root / "README.md",
+        context.root / "README.rst",
+        context.root / "README.txt",
+    ]
     existing = next((path for path in candidates if path.is_file()), None)
     exists = existing is not None
     return Finding(
@@ -23,9 +34,15 @@ def readme_exists(context: ProjectContext) -> Finding:
             if existing
             else "Repository does not contain a README file, so setup/support documentation cannot be inspected."
         ),
-        applicability=Applicability(reason="Custom integration repositories should explain installation, configuration, and support."),
+        applicability=Applicability(
+            reason="Custom integration repositories should explain installation, configuration, and support."
+        ),
         source=RuleSource(url=DOCS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add README.md with installation, configuration, and support notes."),
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add README.md with installation, configuration, and support notes."
+        ),
         path=existing.name if existing else "README.md",
     )
 

--- a/src/hasscheck/rules/hacs_structure.py
+++ b/src/hasscheck/rules/hacs_structure.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import json
 
-from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.models import (
+    Applicability,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 HACS_SOURCE = "https://www.hacs.xyz/docs/publish/integration/"
@@ -23,14 +30,17 @@ def custom_components_exists(context: ProjectContext) -> Finding:
             if exists
             else "Repository does not contain custom_components/, so HassCheck cannot find a custom integration."
         ),
-        applicability=Applicability(reason="HACS custom integration repositories need a custom_components directory."),
+        applicability=Applicability(
+            reason="HACS custom integration repositories need a custom_components directory."
+        ),
         source=RuleSource(url=HACS_SOURCE),
         fix=None
         if exists
-        else FixSuggestion(summary="Create custom_components/<domain>/ and place the integration files there."),
+        else FixSuggestion(
+            summary="Create custom_components/<domain>/ and place the integration files there."
+        ),
         path="custom_components",
     )
-
 
 
 def hacs_file_parseable(context: ProjectContext) -> Finding:
@@ -44,9 +54,13 @@ def hacs_file_parseable(context: ProjectContext) -> Finding:
             severity=RuleSeverity.RECOMMENDED,
             title="hacs.json exists and parses",
             message="hacs.json is missing. HACS metadata cannot be inspected yet.",
-            applicability=Applicability(reason="HACS repositories use hacs.json for repository metadata."),
+            applicability=Applicability(
+                reason="HACS repositories use hacs.json for repository metadata."
+            ),
             source=RuleSource(url=HACS_SOURCE),
-            fix=FixSuggestion(summary="Add a repository-level hacs.json file, even if it starts as an empty JSON object."),
+            fix=FixSuggestion(
+                summary="Add a repository-level hacs.json file, even if it starts as an empty JSON object."
+            ),
             path="hacs.json",
         )
 
@@ -61,7 +75,9 @@ def hacs_file_parseable(context: ProjectContext) -> Finding:
             severity=RuleSeverity.RECOMMENDED,
             title="hacs.json exists and parses",
             message=f"hacs.json is present but is not valid JSON: {exc.msg}.",
-            applicability=Applicability(reason="hacs.json must parse before HassCheck can inspect HACS metadata."),
+            applicability=Applicability(
+                reason="hacs.json must parse before HassCheck can inspect HACS metadata."
+            ),
             source=RuleSource(url=HACS_SOURCE),
             fix=FixSuggestion(summary="Fix hacs.json syntax, then rerun HassCheck."),
             path="hacs.json",
@@ -75,7 +91,9 @@ def hacs_file_parseable(context: ProjectContext) -> Finding:
         severity=RuleSeverity.RECOMMENDED,
         title="hacs.json exists and parses",
         message="hacs.json is present and valid JSON.",
-        applicability=Applicability(reason="HACS repositories use hacs.json for repository metadata."),
+        applicability=Applicability(
+            reason="HACS repositories use hacs.json for repository metadata."
+        ),
         source=RuleSource(url=HACS_SOURCE),
         fix=None,
         path="hacs.json",

--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -27,7 +27,11 @@ def _manifest_path(context: ProjectContext):
 
 def _manifest_display_path(context: ProjectContext) -> str:
     path = _manifest_path(context)
-    return "custom_components/<domain>/manifest.json" if path is None else str(path.relative_to(context.root))
+    return (
+        "custom_components/<domain>/manifest.json"
+        if path is None
+        else str(path.relative_to(context.root))
+    )
 
 
 def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str | None]:
@@ -46,7 +50,9 @@ def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str 
     return payload, None
 
 
-def _not_applicable_for_missing_manifest(rule_id: str, title: str, field_name: str, fix_summary: str) -> Finding:
+def _not_applicable_for_missing_manifest(
+    rule_id: str, title: str, field_name: str, fix_summary: str
+) -> Finding:
     return Finding(
         rule_id=rule_id,
         rule_version="1.0.0",
@@ -65,7 +71,9 @@ def _not_applicable_for_missing_manifest(rule_id: str, title: str, field_name: s
     )
 
 
-def _invalid_manifest_finding(rule_id: str, title: str, error: str, path: str) -> Finding:
+def _invalid_manifest_finding(
+    rule_id: str, title: str, error: str, path: str
+) -> Finding:
     return Finding(
         rule_id=rule_id,
         rule_version="1.0.0",
@@ -74,7 +82,9 @@ def _invalid_manifest_finding(rule_id: str, title: str, error: str, path: str) -
         severity=RuleSeverity.REQUIRED,
         title=title,
         message=f"manifest.json is not valid JSON: {error}.",
-        applicability=Applicability(reason="manifest.json exists but cannot be parsed."),
+        applicability=Applicability(
+            reason="manifest.json exists but cannot be parsed."
+        ),
         source=RuleSource(url=HACS_INTEGRATION_SOURCE),
         fix=FixSuggestion(summary="Fix manifest.json syntax, then rerun HassCheck."),
         path=path,
@@ -95,7 +105,9 @@ def _required_string_field_rule(
         path = _manifest_path(context)
         display_path = _manifest_display_path(context)
         if path is None or not path.is_file():
-            return _not_applicable_for_missing_manifest(rule_id, title, field_name, fix_summary)
+            return _not_applicable_for_missing_manifest(
+                rule_id, title, field_name, fix_summary
+            )
 
         payload, error = _read_manifest(context)
         if error is not None:
@@ -134,10 +146,14 @@ def _codeowners_rule(context: ProjectContext) -> Finding:
 
     payload, error = _read_manifest(context)
     if error is not None:
-        return _invalid_manifest_finding("manifest.codeowners.exists", title, error, display_path)
+        return _invalid_manifest_finding(
+            "manifest.codeowners.exists", title, error, display_path
+        )
 
     value = payload.get("codeowners") if payload else None
-    is_present = isinstance(value, list) and any(isinstance(item, str) and item.strip() for item in value)
+    is_present = isinstance(value, list) and any(
+        isinstance(item, str) and item.strip() for item in value
+    )
     return Finding(
         rule_id="manifest.codeowners.exists",
         rule_version="1.0.0",
@@ -150,9 +166,13 @@ def _codeowners_rule(context: ProjectContext) -> Finding:
             if is_present
             else "manifest.json does not define a non-empty codeowners list."
         ),
-        applicability=Applicability(reason="HACS expects custom integration manifests to define codeowners."),
+        applicability=Applicability(
+            reason="HACS expects custom integration manifests to define codeowners."
+        ),
         source=RuleSource(url=HACS_INTEGRATION_SOURCE),
-        fix=None if is_present else FixSuggestion(summary="Add a non-empty codeowners list to manifest.json."),
+        fix=None
+        if is_present
+        else FixSuggestion(summary="Add a non-empty codeowners list to manifest.json."),
         path=display_path,
     )
 
@@ -221,11 +241,15 @@ def manifest_exists(context: ProjectContext) -> Finding:
             if exists
             else "Integration manifest is missing, so Home Assistant and HACS metadata cannot be inspected."
         ),
-        applicability=Applicability(reason="Every Home Assistant integration needs a manifest.json file."),
+        applicability=Applicability(
+            reason="Every Home Assistant integration needs a manifest.json file."
+        ),
         source=RuleSource(url=HACS_INTEGRATION_SOURCE),
         fix=None
         if exists
-        else FixSuggestion(summary="Add custom_components/<domain>/manifest.json with the required integration metadata."),
+        else FixSuggestion(
+            summary="Add custom_components/<domain>/manifest.json with the required integration metadata."
+        ),
         path=display,
     )
 

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -8,8 +8,19 @@ from hasscheck.rules.docs import RULES as DOCS_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 from hasscheck.rules.repairs import RULES as REPAIRS_RULES
-from hasscheck.rules.tests import RULES as TESTS_RULES
 from hasscheck.rules.repository import RULES as REPOSITORY_RULES
+from hasscheck.rules.tests import RULES as TESTS_RULES
 
-RULES = [*HACS_STRUCTURE_RULES, *BRAND_RULES, *MANIFEST_RULES, *CONFIG_FLOW_RULES, *DIAGNOSTICS_RULES, *REPAIRS_RULES, *DOCS_RULES, *REPOSITORY_RULES, *TESTS_RULES, *CI_RULES]
+RULES = [
+    *HACS_STRUCTURE_RULES,
+    *BRAND_RULES,
+    *MANIFEST_RULES,
+    *CONFIG_FLOW_RULES,
+    *DIAGNOSTICS_RULES,
+    *REPAIRS_RULES,
+    *DOCS_RULES,
+    *REPOSITORY_RULES,
+    *TESTS_RULES,
+    *CI_RULES,
+]
 RULES_BY_ID = {rule.id: rule for rule in RULES}

--- a/src/hasscheck/rules/repairs.py
+++ b/src/hasscheck/rules/repairs.py
@@ -30,12 +30,37 @@ def repairs_file_exists(context: ProjectContext) -> Finding:
                 reason="custom_components/<domain>/ must exist before HassCheck can inspect repairs.py.",
             ),
             source=RuleSource(url=REPAIRS_SOURCE),
-            fix=FixSuggestion(summary="Create custom_components/<domain>/ before adding repairs.py."),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ before adding repairs.py."
+            ),
             path="custom_components/<domain>/repairs.py",
         )
 
     path = context.integration_path / "repairs.py"
     exists = path.is_file()
+    if (
+        not exists
+        and context.applicability
+        and context.applicability.has_user_fixable_repairs is False
+    ):
+        return Finding(
+            rule_id="repairs.file.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="repairs.py exists",
+            message="Project config declares there are no user-fixable repair scenarios.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares has_user_fixable_repairs: false.",
+                source="config",
+            ),
+            source=RuleSource(url=REPAIRS_SOURCE),
+            fix=None,
+            path=str(path.relative_to(context.root)),
+        )
+
     return Finding(
         rule_id="repairs.file.exists",
         rule_version="1.0.0",
@@ -48,9 +73,15 @@ def repairs_file_exists(context: ProjectContext) -> Finding:
             if exists
             else "Integration does not include repairs.py; user-fixable repair flows cannot be inspected."
         ),
-        applicability=Applicability(reason="Repair flows are useful when integrations have user-fixable problems."),
+        applicability=Applicability(
+            reason="Repair flows are useful when integrations have user-fixable problems."
+        ),
         source=RuleSource(url=REPAIRS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add repairs.py when the integration has user-fixable repair scenarios."),
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add repairs.py when the integration has user-fixable repair scenarios."
+        ),
         path=str(path.relative_to(context.root)),
     )
 

--- a/src/hasscheck/rules/repository.py
+++ b/src/hasscheck/rules/repository.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.models import (
+    Applicability,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "maintenance_signals"
@@ -8,7 +15,12 @@ LICENSE_SOURCE = "https://www.hacs.xyz/docs/publish/integration/"
 
 
 def license_exists(context: ProjectContext) -> Finding:
-    candidates = [context.root / "LICENSE", context.root / "LICENSE.md", context.root / "LICENSE.txt", context.root / "COPYING"]
+    candidates = [
+        context.root / "LICENSE",
+        context.root / "LICENSE.md",
+        context.root / "LICENSE.txt",
+        context.root / "COPYING",
+    ]
     existing = next((path for path in candidates if path.is_file()), None)
     exists = existing is not None
     return Finding(
@@ -23,9 +35,13 @@ def license_exists(context: ProjectContext) -> Finding:
             if existing
             else "Repository does not contain a recognized license file."
         ),
-        applicability=Applicability(reason="A license makes reuse and distribution terms explicit."),
+        applicability=Applicability(
+            reason="A license makes reuse and distribution terms explicit."
+        ),
         source=RuleSource(url=LICENSE_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add a repository license file such as LICENSE."),
+        fix=None
+        if exists
+        else FixSuggestion(summary="Add a repository license file such as LICENSE."),
         path=existing.name if existing else "LICENSE",
     )
 

--- a/src/hasscheck/rules/tests.py
+++ b/src/hasscheck/rules/tests.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from hasscheck.models import Applicability, Finding, FixSuggestion, RuleSeverity, RuleSource, RuleStatus
+from hasscheck.models import (
+    Applicability,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "tests_ci"
@@ -22,9 +29,15 @@ def tests_folder_exists(context: ProjectContext) -> Finding:
             if exists
             else "Repository does not contain a tests directory; automated test coverage cannot be inspected."
         ),
-        applicability=Applicability(reason="Tests help maintainers keep integration behavior stable as Home Assistant evolves."),
+        applicability=Applicability(
+            reason="Tests help maintainers keep integration behavior stable as Home Assistant evolves."
+        ),
         source=RuleSource(url=TESTS_SOURCE),
-        fix=None if exists else FixSuggestion(summary="Add a tests/ directory with pytest-based integration tests."),
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add a tests/ directory with pytest-based integration tests."
+        ),
         path="tests",
     )
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -43,6 +43,7 @@ def test_manifest_domain_passes_for_custom_integration(tmp_path) -> None:
 
 # ---------- Phase 4: config kwarg + discovery ----------
 
+
 def test_run_check_config_and_no_config_conflict(tmp_path) -> None:
     with pytest.raises(ValueError, match="no_config"):
         run_check(tmp_path, config=HassCheckConfig(), no_config=True)
@@ -76,7 +77,9 @@ def test_run_check_discovers_yaml_at_root(tmp_path) -> None:
 def test_run_check_applies_overrides_from_config_kwarg(tmp_path) -> None:
     # tests.folder.exists is WARN in empty dir — confirms source="config" is set
     config = HassCheckConfig(
-        rules={"tests.folder.exists": RuleOverride(status="not_applicable", reason="test")}
+        rules={
+            "tests.folder.exists": RuleOverride(status="not_applicable", reason="test")
+        }
     )
     report = run_check(tmp_path, config=config)
     findings = {f.rule_id: f for f in report.findings}
@@ -91,6 +94,6 @@ def test_run_check_no_yaml_overrides_applied_is_empty(tmp_path) -> None:
     assert report.summary.overrides_applied.rule_ids == []
 
 
-def test_run_check_schema_version_is_0_2_0(tmp_path) -> None:
+def test_run_check_schema_version_is_0_3_0(tmp_path) -> None:
     report = run_check(tmp_path)
-    assert report.schema_version == "0.2.0"
+    assert report.schema_version == "0.3.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,20 @@
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
 from hasscheck.cli import app
 
-
 runner = CliRunner()
+
+
+def write_minimal_integration(root: Path) -> None:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(
+        json.dumps({"domain": "demo"}),
+        encoding="utf-8",
+    )
 
 
 def test_check_json_outputs_report(tmp_path) -> None:
@@ -13,7 +22,7 @@ def test_check_json_outputs_report(tmp_path) -> None:
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "0.2.0"
+    assert payload["schema_version"] == "0.3.0"
     assert payload["summary"]["security_review"] == "not_performed"
     assert payload["summary"]["official_ha_tier"] == "not_assigned"
     assert payload["summary"]["hacs_acceptance"] == "not_guaranteed"
@@ -50,6 +59,7 @@ def test_explain_shows_overridable_true_for_softable_rule() -> None:
 
 # ---------- Phase 5: --no-config flag + ConfigError handling ----------
 
+
 def test_no_config_flag_exists_in_help(tmp_path) -> None:
     result = runner.invoke(app, ["check", "--help"])
     assert result.exit_code == 0
@@ -63,7 +73,9 @@ def test_no_config_flag_skips_yaml(tmp_path) -> None:
         "    status: not_applicable\n"
         "    reason: no tests needed\n"
     )
-    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json", "--no-config"])
+    result = runner.invoke(
+        app, ["check", "--path", str(tmp_path), "--json", "--no-config"]
+    )
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["summary"]["overrides_applied"]["count"] == 0
@@ -97,7 +109,19 @@ def test_json_output_includes_overrides_applied(tmp_path) -> None:
     assert "rule_ids" in payload["summary"]["overrides_applied"]
 
 
+def test_json_output_includes_applicability_applied(tmp_path) -> None:
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["applicability_applied"] == {
+        "count": 0,
+        "rule_ids": [],
+        "flags": [],
+    }
+
+
 # ---------- Phase 6: terminal banner + JSON source field ----------
+
 
 def test_json_finding_applicability_source_present(tmp_path) -> None:
     result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
@@ -141,3 +165,41 @@ def test_terminal_non_overridden_finding_no_config_marker(tmp_path) -> None:
     result = runner.invoke(app, ["check", "--path", str(tmp_path)])
     assert result.exit_code == 0
     assert "(config)" not in result.output
+
+
+# ---------- v0.3: project applicability disclosure ----------
+
+
+def test_terminal_banner_shown_when_applicability_applied(tmp_path) -> None:
+    write_minimal_integration(tmp_path)
+    (tmp_path / "hasscheck.yaml").write_text(
+        "applicability:\n"
+        "  supports_diagnostics: false\n"
+        "  has_user_fixable_repairs: false\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["check", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "2 applicability decision(s) applied from hasscheck.yaml." in result.output
+
+
+def test_terminal_banner_not_shown_when_no_applicability_applied(tmp_path) -> None:
+    result = runner.invoke(app, ["check", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "applicability decision" not in result.output.lower()
+
+
+def test_terminal_applicability_finding_has_config_marker(tmp_path) -> None:
+    write_minimal_integration(tmp_path)
+    (tmp_path / "hasscheck.yaml").write_text(
+        "applicability:\n  supports_diagnostics: false\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["check", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "diagnostics.file.exists (config)" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Tests for hasscheck.config — YAML schema models and override engine."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -15,9 +16,10 @@ from hasscheck.config import (
     discover_config,
     load_config_file,
 )
-
+from hasscheck.models import Finding
 
 # ---------- RuleOverride ----------
+
 
 def test_rule_override_valid_not_applicable() -> None:
     ro = RuleOverride(status="not_applicable", reason="legitimately does not apply")
@@ -71,6 +73,7 @@ def test_rule_override_rejects_extra_fields() -> None:
 
 # ---------- ProjectConfig ----------
 
+
 def test_project_config_defaults_to_integration() -> None:
     pc = ProjectConfig()
     assert pc.type == "integration"
@@ -88,10 +91,12 @@ def test_project_config_rejects_extra_fields() -> None:
 
 # ---------- HassCheckConfig ----------
 
+
 def test_hasscheck_config_empty_defaults() -> None:
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.2.0"
+    assert cfg.schema_version == "0.3.0"
     assert cfg.project is None
+    assert cfg.applicability is None
     assert cfg.rules == {}
 
 
@@ -114,10 +119,9 @@ def test_hasscheck_config_with_project_block() -> None:
 
 
 def test_hasscheck_config_rejects_unknown_top_level_key() -> None:
-    """Block A's `applicability:` block is deferred to v0.3 — extra=forbid rejects it."""
     with pytest.raises(ValidationError):
         HassCheckConfig(
-            applicability={"auth_required": False},  # type: ignore[call-arg]
+            unexpected={"value": False},  # type: ignore[call-arg]
         )
 
 
@@ -127,6 +131,7 @@ def test_hasscheck_config_rejects_wrong_schema_version() -> None:
 
 
 # ---------- ConfigError ----------
+
 
 def test_config_error_is_exception() -> None:
     assert issubclass(ConfigError, Exception)
@@ -138,6 +143,7 @@ def test_config_error_carries_message() -> None:
 
 
 # ---------- load_config_file ----------
+
 
 def test_load_config_file_minimal_valid(tmp_path: Path) -> None:
     (tmp_path / "hasscheck.yaml").write_text("schema_version: '0.2.0'\n")
@@ -182,10 +188,7 @@ def test_load_config_file_non_mapping_raises_config_error(tmp_path: Path) -> Non
 
 def test_load_config_file_forbidden_status_raises_config_error(tmp_path: Path) -> None:
     (tmp_path / "hasscheck.yaml").write_text(
-        "rules:\n"
-        "  repairs.file.exists:\n"
-        "    status: pass\n"
-        "    reason: some reason\n"
+        "rules:\n  repairs.file.exists:\n    status: pass\n    reason: some reason\n"
     )
     with pytest.raises(ConfigError):
         load_config_file(tmp_path / "hasscheck.yaml")
@@ -193,9 +196,7 @@ def test_load_config_file_forbidden_status_raises_config_error(tmp_path: Path) -
 
 def test_load_config_file_missing_reason_raises_config_error(tmp_path: Path) -> None:
     (tmp_path / "hasscheck.yaml").write_text(
-        "rules:\n"
-        "  repairs.file.exists:\n"
-        "    status: not_applicable\n"
+        "rules:\n  repairs.file.exists:\n    status: not_applicable\n"
     )
     with pytest.raises(ConfigError):
         load_config_file(tmp_path / "hasscheck.yaml")
@@ -214,6 +215,7 @@ def test_load_config_file_extra_fields_raises_config_error(tmp_path: Path) -> No
 
 
 # ---------- discover_config ----------
+
 
 def test_discover_config_returns_none_when_file_absent(tmp_path: Path) -> None:
     assert discover_config(tmp_path) is None
@@ -241,18 +243,19 @@ def test_discover_config_looks_only_at_repo_root_not_parents(tmp_path: Path) -> 
 
 # ---------- apply_overrides helpers ----------
 
+
 def _make_finding(
     rule_id: str = "repairs.file.exists",
     status: str = "warn",
-) -> "Finding":
+) -> Finding:
     from hasscheck.models import (
         Applicability,
         ApplicabilityStatus,
-        Finding,
         RuleSeverity,
         RuleSource,
         RuleStatus,
     )
+
     app_status = {
         "warn": ApplicabilityStatus.APPLICABLE,
         "fail": ApplicabilityStatus.APPLICABLE,
@@ -285,8 +288,10 @@ def _config_with_rule(
 
 # ---------- apply_overrides — Task 3.1: happy path ----------
 
+
 def test_apply_overrides_warn_to_not_applicable() -> None:
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "warn")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "no repairs")
     new_findings, applied = apply_overrides([finding], config)
@@ -297,6 +302,7 @@ def test_apply_overrides_warn_to_not_applicable() -> None:
 
 def test_apply_overrides_warn_to_manual_review() -> None:
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "warn")
     config = _config_with_rule("repairs.file.exists", "manual_review", "needs human")
     new_findings, applied = apply_overrides([finding], config)
@@ -313,13 +319,16 @@ def test_apply_overrides_overridden_source_is_config() -> None:
 
 def test_apply_overrides_overridden_reason_from_config() -> None:
     finding = _make_finding("repairs.file.exists", "warn")
-    config = _config_with_rule("repairs.file.exists", "not_applicable", "my custom reason")
+    config = _config_with_rule(
+        "repairs.file.exists", "not_applicable", "my custom reason"
+    )
     new_findings, _ = apply_overrides([finding], config)
     assert new_findings[0].applicability.reason == "my custom reason"
 
 
 def test_apply_overrides_fail_to_not_applicable() -> None:
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "fail")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "no repairs")
     new_findings, applied = apply_overrides([finding], config)
@@ -327,7 +336,9 @@ def test_apply_overrides_fail_to_not_applicable() -> None:
     assert applied.count == 1
 
 
-def test_apply_overrides_empty_config_returns_unchanged(capsys: pytest.CaptureFixture) -> None:
+def test_apply_overrides_empty_config_returns_unchanged(
+    capsys: pytest.CaptureFixture,
+) -> None:
     finding = _make_finding("repairs.file.exists", "warn")
     config = HassCheckConfig()
     new_findings, applied = apply_overrides([finding], config)
@@ -338,7 +349,10 @@ def test_apply_overrides_empty_config_returns_unchanged(capsys: pytest.CaptureFi
 
 # ---------- apply_overrides — Task 3.2: unknown rule_id ----------
 
-def test_apply_overrides_unknown_rule_id_warns_stderr(capsys: pytest.CaptureFixture) -> None:
+
+def test_apply_overrides_unknown_rule_id_warns_stderr(
+    capsys: pytest.CaptureFixture,
+) -> None:
     finding = _make_finding("repairs.file.exists", "warn")
     config = _config_with_rule("nonexistent.rule.id", "not_applicable", "no such rule")
     apply_overrides([finding], config)
@@ -347,7 +361,9 @@ def test_apply_overrides_unknown_rule_id_warns_stderr(capsys: pytest.CaptureFixt
     assert "unknown" in err.lower()
 
 
-def test_apply_overrides_unknown_rule_id_not_counted(capsys: pytest.CaptureFixture) -> None:
+def test_apply_overrides_unknown_rule_id_not_counted(
+    capsys: pytest.CaptureFixture,
+) -> None:
     finding = _make_finding("repairs.file.exists", "warn")
     config = _config_with_rule("nonexistent.rule.id", "not_applicable", "no such rule")
     _, applied = apply_overrides([finding], config)
@@ -357,9 +373,12 @@ def test_apply_overrides_unknown_rule_id_not_counted(capsys: pytest.CaptureFixtu
 
 # ---------- apply_overrides — Task 3.3: locked rule ----------
 
+
 def test_apply_overrides_locked_rule_raises_config_error() -> None:
     finding = _make_finding("manifest.exists", "fail")
-    config = _config_with_rule("manifest.exists", "not_applicable", "we don't need this")
+    config = _config_with_rule(
+        "manifest.exists", "not_applicable", "we don't need this"
+    )
     with pytest.raises(ConfigError) as exc_info:
         apply_overrides([finding], config)
     assert "manifest.exists" in str(exc_info.value)
@@ -369,15 +388,21 @@ def test_apply_overrides_locked_rule_raises_config_error() -> None:
 def test_apply_overrides_locked_rule_error_even_when_passing() -> None:
     """Locked rule precedence: hard fail even if natural status is PASS."""
     finding = _make_finding("manifest.exists", "pass")
-    config = _config_with_rule("manifest.exists", "not_applicable", "we don't need this")
+    config = _config_with_rule(
+        "manifest.exists", "not_applicable", "we don't need this"
+    )
     with pytest.raises(ConfigError):
         apply_overrides([finding], config)
 
 
 # ---------- apply_overrides — Task 3.4: PASS-skip ----------
 
-def test_apply_overrides_natural_pass_not_applied(capsys: pytest.CaptureFixture) -> None:
+
+def test_apply_overrides_natural_pass_not_applied(
+    capsys: pytest.CaptureFixture,
+) -> None:
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "pass")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "no repairs")
     new_findings, applied = apply_overrides([finding], config)
@@ -386,7 +411,9 @@ def test_apply_overrides_natural_pass_not_applied(capsys: pytest.CaptureFixture)
     assert applied.count == 0
 
 
-def test_apply_overrides_natural_pass_emits_stale_warning(capsys: pytest.CaptureFixture) -> None:
+def test_apply_overrides_natural_pass_emits_stale_warning(
+    capsys: pytest.CaptureFixture,
+) -> None:
     finding = _make_finding("repairs.file.exists", "pass")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "no repairs")
     apply_overrides([finding], config)
@@ -397,8 +424,12 @@ def test_apply_overrides_natural_pass_emits_stale_warning(capsys: pytest.Capture
 
 # ---------- apply_overrides — Task 3.5: NA-noop ----------
 
-def test_apply_overrides_natural_not_applicable_silent_noop(capsys: pytest.CaptureFixture) -> None:
+
+def test_apply_overrides_natural_not_applicable_silent_noop(
+    capsys: pytest.CaptureFixture,
+) -> None:
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "not_applicable")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "no repairs")
     new_findings, applied = apply_overrides([finding], config)
@@ -409,7 +440,10 @@ def test_apply_overrides_natural_not_applicable_silent_noop(capsys: pytest.Captu
 
 # ---------- apply_overrides — Task 3.6: MR-redundant-skip ----------
 
-def test_apply_overrides_mr_override_mr_warns_redundant(capsys: pytest.CaptureFixture) -> None:
+
+def test_apply_overrides_mr_override_mr_warns_redundant(
+    capsys: pytest.CaptureFixture,
+) -> None:
     finding = _make_finding("repairs.file.exists", "manual_review")
     config = _config_with_rule("repairs.file.exists", "manual_review", "needs human")
     _, applied = apply_overrides([finding], config)
@@ -421,6 +455,7 @@ def test_apply_overrides_mr_override_mr_warns_redundant(capsys: pytest.CaptureFi
 def test_apply_overrides_mr_to_na_is_applied() -> None:
     """MR + override=not_applicable → APPLY (not redundant, step 5 only blocks MR→MR)."""
     from hasscheck.models import RuleStatus
+
     finding = _make_finding("repairs.file.exists", "manual_review")
     config = _config_with_rule("repairs.file.exists", "not_applicable", "superseded")
     new_findings, applied = apply_overrides([finding], config)
@@ -429,6 +464,7 @@ def test_apply_overrides_mr_to_na_is_applied() -> None:
 
 
 # ---------- apply_overrides — multiple rules / alphabetical ----------
+
 
 def test_apply_overrides_rule_ids_alphabetical() -> None:
     findings = [
@@ -446,3 +482,72 @@ def test_apply_overrides_rule_ids_alphabetical() -> None:
     _, applied = apply_overrides(findings, config)
     assert applied.rule_ids == sorted(applied.rule_ids)
     assert applied.count == 3
+
+
+# ---------- v0.3 ProjectApplicability ----------
+
+
+def test_project_applicability_accepts_initial_v03_flags() -> None:
+    from hasscheck.config import ProjectApplicability
+
+    app = ProjectApplicability(
+        supports_diagnostics=False,
+        has_user_fixable_repairs=False,
+        uses_config_flow=False,
+    )
+
+    assert app.supports_diagnostics is False
+    assert app.has_user_fixable_repairs is False
+    assert app.uses_config_flow is False
+
+
+def test_project_applicability_rejects_unknown_flags() -> None:
+    from hasscheck.config import ProjectApplicability
+
+    with pytest.raises(ValidationError):
+        ProjectApplicability(auth_required=False)  # type: ignore[call-arg]
+
+
+def test_hasscheck_config_accepts_applicability_block() -> None:
+    from hasscheck.config import ProjectApplicability
+
+    cfg = HassCheckConfig(
+        applicability=ProjectApplicability(supports_diagnostics=False)
+    )
+
+    assert cfg.schema_version == "0.3.0"
+    assert cfg.applicability is not None
+    assert cfg.applicability.supports_diagnostics is False
+
+
+def test_hasscheck_config_accepts_v02_schema_when_no_applicability_block() -> None:
+    cfg = HassCheckConfig(schema_version="0.2.0")
+
+    assert cfg.schema_version == "0.2.0"
+    assert cfg.rules == {}
+
+
+def test_hasscheck_config_rejects_v02_schema_with_applicability_block() -> None:
+    from hasscheck.config import ProjectApplicability
+
+    with pytest.raises(ValidationError):
+        HassCheckConfig(
+            schema_version="0.2.0",
+            applicability=ProjectApplicability(supports_diagnostics=False),
+        )
+
+
+def test_load_config_file_with_v03_applicability(tmp_path: Path) -> None:
+    (tmp_path / "hasscheck.yaml").write_text(
+        "schema_version: '0.3.0'\n"
+        "applicability:\n"
+        "  supports_diagnostics: false\n"
+        "  has_user_fixable_repairs: false\n"
+        "  uses_config_flow: false\n"
+    )
+
+    cfg = load_config_file(tmp_path / "hasscheck.yaml")
+
+    assert cfg.schema_version == "0.3.0"
+    assert cfg.applicability is not None
+    assert cfg.applicability.supports_diagnostics is False

--- a/tests/test_config_flow_rules.py
+++ b/tests/test_config_flow_rules.py
@@ -9,7 +9,9 @@ def write_integration(root, manifest: dict, *, config_flow: bool = False) -> Non
     integration.mkdir(parents=True)
     (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     if config_flow:
-        (integration / "config_flow.py").write_text("class DemoConfigFlow: ...\n", encoding="utf-8")
+        (integration / "config_flow.py").write_text(
+            "class DemoConfigFlow: ...\n", encoding="utf-8"
+        )
 
 
 def findings_for(root):
@@ -17,7 +19,9 @@ def findings_for(root):
 
 
 def test_config_flow_file_presence_passes_when_file_exists(tmp_path) -> None:
-    write_integration(tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True)
+    write_integration(
+        tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True
+    )
 
     findings = findings_for(tmp_path)
 
@@ -33,8 +37,12 @@ def test_config_flow_file_presence_warns_when_file_missing(tmp_path) -> None:
     assert findings["config_flow.file.exists"].fix is not None
 
 
-def test_config_flow_manifest_consistency_passes_when_file_and_manifest_flag_match(tmp_path) -> None:
-    write_integration(tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True)
+def test_config_flow_manifest_consistency_passes_when_file_and_manifest_flag_match(
+    tmp_path,
+) -> None:
+    write_integration(
+        tmp_path, {"domain": "demo", "config_flow": True}, config_flow=True
+    )
 
     findings = findings_for(tmp_path)
 
@@ -44,16 +52,22 @@ def test_config_flow_manifest_consistency_passes_when_file_and_manifest_flag_mat
     )
 
 
-def test_config_flow_manifest_consistency_fails_when_file_exists_but_flag_is_not_true(tmp_path) -> None:
+def test_config_flow_manifest_consistency_fails_when_file_exists_but_flag_is_not_true(
+    tmp_path,
+) -> None:
     write_integration(tmp_path, {"domain": "demo"}, config_flow=True)
 
     findings = findings_for(tmp_path)
 
     assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.FAIL
-    assert "config_flow: true" in findings["config_flow.manifest_flag_consistent"].message
+    assert (
+        "config_flow: true" in findings["config_flow.manifest_flag_consistent"].message
+    )
 
 
-def test_config_flow_manifest_consistency_fails_when_manifest_flag_true_but_file_missing(tmp_path) -> None:
+def test_config_flow_manifest_consistency_fails_when_manifest_flag_true_but_file_missing(
+    tmp_path,
+) -> None:
     write_integration(tmp_path, {"domain": "demo", "config_flow": True})
 
     findings = findings_for(tmp_path)
@@ -62,16 +76,24 @@ def test_config_flow_manifest_consistency_fails_when_manifest_flag_true_but_file
     assert "config_flow.py" in findings["config_flow.manifest_flag_consistent"].message
 
 
-def test_config_flow_manifest_consistency_not_applicable_when_no_config_flow_signal(tmp_path) -> None:
+def test_config_flow_manifest_consistency_not_applicable_when_no_config_flow_signal(
+    tmp_path,
+) -> None:
     write_integration(tmp_path, {"domain": "demo"})
 
     findings = findings_for(tmp_path)
 
-    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.NOT_APPLICABLE
+    assert (
+        findings["config_flow.manifest_flag_consistent"].status
+        is RuleStatus.NOT_APPLICABLE
+    )
 
 
 def test_config_flow_rules_not_applicable_without_integration(tmp_path) -> None:
     findings = findings_for(tmp_path)
 
     assert findings["config_flow.file.exists"].status is RuleStatus.NOT_APPLICABLE
-    assert findings["config_flow.manifest_flag_consistent"].status is RuleStatus.NOT_APPLICABLE
+    assert (
+        findings["config_flow.manifest_flag_consistent"].status
+        is RuleStatus.NOT_APPLICABLE
+    )

--- a/tests/test_diagnostics_repairs_rules.py
+++ b/tests/test_diagnostics_repairs_rules.py
@@ -2,14 +2,20 @@ from hasscheck.checker import run_check
 from hasscheck.models import RuleStatus
 
 
-def write_integration(root, *, diagnostics: bool = False, repairs: bool = False) -> None:
+def write_integration(
+    root, *, diagnostics: bool = False, repairs: bool = False
+) -> None:
     integration = root / "custom_components" / "demo"
     integration.mkdir(parents=True)
     (integration / "manifest.json").write_text('{"domain":"demo"}', encoding="utf-8")
     if diagnostics:
-        (integration / "diagnostics.py").write_text('"""Diagnostics fixture."""\n', encoding="utf-8")
+        (integration / "diagnostics.py").write_text(
+            '"""Diagnostics fixture."""\n', encoding="utf-8"
+        )
     if repairs:
-        (integration / "repairs.py").write_text('"""Repairs fixture."""\n', encoding="utf-8")
+        (integration / "repairs.py").write_text(
+            '"""Repairs fixture."""\n', encoding="utf-8"
+        )
 
 
 def findings_for(root):

--- a/tests/test_hacs_rules.py
+++ b/tests/test_hacs_rules.py
@@ -16,7 +16,7 @@ def test_invalid_hacs_json_fails_when_present(tmp_path) -> None:
     integration = tmp_path / "custom_components" / "demo"
     integration.mkdir(parents=True)
     (integration / "manifest.json").write_text('{"domain":"demo"}', encoding="utf-8")
-    (tmp_path / "hacs.json").write_text('{not-json', encoding="utf-8")
+    (tmp_path / "hacs.json").write_text("{not-json", encoding="utf-8")
 
     findings = {finding.rule_id: finding for finding in run_check(tmp_path).findings}
 
@@ -27,7 +27,7 @@ def test_valid_hacs_json_passes(tmp_path) -> None:
     integration = tmp_path / "custom_components" / "demo"
     integration.mkdir(parents=True)
     (integration / "manifest.json").write_text('{"domain":"demo"}', encoding="utf-8")
-    (tmp_path / "hacs.json").write_text('{}', encoding="utf-8")
+    (tmp_path / "hacs.json").write_text("{}", encoding="utf-8")
 
     findings = {finding.rule_id: finding for finding in run_check(tmp_path).findings}
 

--- a/tests/test_manifest_metadata_rules.py
+++ b/tests/test_manifest_metadata_rules.py
@@ -39,7 +39,10 @@ def test_required_manifest_metadata_fields_pass_when_present(tmp_path) -> None:
 
     for rule_id in REQUIRED_FIELD_RULES.values():
         assert findings[rule_id].status is RuleStatus.PASS
-        assert findings[rule_id].source.url == "https://www.hacs.xyz/docs/publish/integration/"
+        assert (
+            findings[rule_id].source.url
+            == "https://www.hacs.xyz/docs/publish/integration/"
+        )
         assert findings[rule_id].rule_version == "1.0.0"
 
 
@@ -53,7 +56,9 @@ def test_required_manifest_metadata_fields_fail_when_missing(tmp_path) -> None:
         assert findings[rule_id].fix is not None
 
 
-def test_required_manifest_metadata_fields_are_not_applicable_without_manifest(tmp_path) -> None:
+def test_required_manifest_metadata_fields_are_not_applicable_without_manifest(
+    tmp_path,
+) -> None:
     findings = findings_for(tmp_path)
 
     for rule_id in REQUIRED_FIELD_RULES.values():
@@ -74,4 +79,6 @@ def test_codeowners_requires_non_empty_list_of_strings(tmp_path) -> None:
         },
     )
 
-    assert findings_for(tmp_path)["manifest.codeowners.exists"].status is RuleStatus.FAIL
+    assert (
+        findings_for(tmp_path)["manifest.codeowners.exists"].status is RuleStatus.FAIL
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,10 +3,10 @@ from pydantic import ValidationError
 
 from hasscheck.models import (
     Applicability,
+    HassCheckReport,
     OverridesApplied,
     ReportSummary,
     RuleStatus,
-    HassCheckReport,
 )
 
 
@@ -76,9 +76,11 @@ def test_report_summary_overrides_applied_default_is_empty_overrides_applied() -
 
 # ---------- Phase 8.2: JSON contract — additive-only verification ----------
 
+
 def test_json_contract_v01_fields_still_present(tmp_path) -> None:
     """All v0.1 JSON paths must exist in v0.2 output — no breaking changes."""
     import json
+
     from hasscheck.checker import run_check
     from hasscheck.output import report_to_json
 
@@ -108,9 +110,13 @@ def test_json_contract_v01_fields_still_present(tmp_path) -> None:
 def test_pyproject_version_matches_tool_info() -> None:
     import tomllib
     from pathlib import Path
+
     from hasscheck.models import ToolInfo
-    pyproject = tomllib.loads((Path(__file__).parent.parent / "pyproject.toml").read_text())
-    assert pyproject["project"]["version"] == ToolInfo().version == "0.2.1"
+
+    pyproject = tomllib.loads(
+        (Path(__file__).parent.parent / "pyproject.toml").read_text()
+    )
+    assert pyproject["project"]["version"] == ToolInfo().version == "0.3.0"
 
 
 def test_yaml_importable() -> None:
@@ -120,6 +126,7 @@ def test_yaml_importable() -> None:
 def test_json_contract_v02_additive_fields_present(tmp_path) -> None:
     """New v0.2 fields present without breaking v0.1 consumers."""
     import json
+
     from hasscheck.checker import run_check
     from hasscheck.output import report_to_json
 
@@ -131,3 +138,46 @@ def test_json_contract_v02_additive_fields_present(tmp_path) -> None:
     assert "rule_ids" in payload["summary"]["overrides_applied"]
     finding = payload["findings"][0]
     assert "source" in finding["applicability"]
+
+
+def test_applicability_applied_default_is_empty() -> None:
+    from hasscheck.models import ApplicabilityApplied
+
+    applied = ApplicabilityApplied()
+
+    assert applied.count == 0
+    assert applied.rule_ids == []
+    assert applied.flags == []
+
+
+def test_applicability_applied_enforces_count_and_sorting() -> None:
+    from hasscheck.models import ApplicabilityApplied
+
+    ApplicabilityApplied(
+        count=2,
+        rule_ids=["diagnostics.file.exists", "repairs.file.exists"],
+        flags=["has_user_fixable_repairs", "supports_diagnostics"],
+    )
+
+    with pytest.raises(ValidationError):
+        ApplicabilityApplied(count=2, rule_ids=["diagnostics.file.exists"], flags=[])
+
+    with pytest.raises(ValidationError):
+        ApplicabilityApplied(
+            count=2,
+            rule_ids=["repairs.file.exists", "diagnostics.file.exists"],
+            flags=[],
+        )
+
+    with pytest.raises(ValidationError):
+        ApplicabilityApplied(
+            count=1, rule_ids=["diagnostics.file.exists"], flags=["z", "a"]
+        )
+
+
+def test_report_summary_applicability_applied_default_is_empty() -> None:
+    from hasscheck.models import ApplicabilityApplied
+
+    summary = ReportSummary()
+
+    assert summary.applicability_applied == ApplicabilityApplied()

--- a/tests/test_project_applicability_context.py
+++ b/tests/test_project_applicability_context.py
@@ -1,0 +1,116 @@
+import json
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.config import HassCheckConfig, ProjectApplicability
+from hasscheck.models import RuleStatus
+
+
+def write_integration(root: Path, manifest: dict | None = None) -> Path:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(
+        json.dumps(manifest or {"domain": "demo"}), encoding="utf-8"
+    )
+    return integration
+
+
+def findings_for(root: Path, config: HassCheckConfig | None = None):
+    return {
+        finding.rule_id: finding for finding in run_check(root, config=config).findings
+    }
+
+
+def test_project_applicability_softens_missing_optional_files(tmp_path: Path) -> None:
+    write_integration(tmp_path)
+    config = HassCheckConfig(
+        applicability=ProjectApplicability(
+            supports_diagnostics=False,
+            has_user_fixable_repairs=False,
+            uses_config_flow=False,
+        )
+    )
+
+    report = run_check(tmp_path, config=config)
+    findings = {finding.rule_id: finding for finding in report.findings}
+
+    for rule_id in (
+        "diagnostics.file.exists",
+        "repairs.file.exists",
+        "config_flow.file.exists",
+        "config_flow.manifest_flag_consistent",
+    ):
+        assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
+        assert findings[rule_id].applicability.source == "config"
+
+    assert report.summary.applicability_applied.count == 4
+    assert report.summary.applicability_applied.rule_ids == [
+        "config_flow.file.exists",
+        "config_flow.manifest_flag_consistent",
+        "diagnostics.file.exists",
+        "repairs.file.exists",
+    ]
+    assert report.summary.applicability_applied.flags == [
+        "has_user_fixable_repairs",
+        "supports_diagnostics",
+        "uses_config_flow",
+    ]
+
+
+def test_project_applicability_natural_pass_wins(tmp_path: Path) -> None:
+    integration = write_integration(tmp_path, {"domain": "demo", "config_flow": True})
+    (integration / "diagnostics.py").write_text('"""diagnostics"""\n', encoding="utf-8")
+    (integration / "repairs.py").write_text('"""repairs"""\n', encoding="utf-8")
+    (integration / "config_flow.py").write_text('"""config flow"""\n', encoding="utf-8")
+    config = HassCheckConfig(
+        applicability=ProjectApplicability(
+            supports_diagnostics=False,
+            has_user_fixable_repairs=False,
+            uses_config_flow=False,
+        )
+    )
+
+    report = run_check(tmp_path, config=config)
+    findings = {finding.rule_id: finding for finding in report.findings}
+
+    for rule_id in (
+        "diagnostics.file.exists",
+        "repairs.file.exists",
+        "config_flow.file.exists",
+        "config_flow.manifest_flag_consistent",
+    ):
+        assert findings[rule_id].status is RuleStatus.PASS
+        assert findings[rule_id].applicability.source == "default"
+
+    assert report.summary.applicability_applied.count == 0
+
+
+def test_project_applicability_does_not_hide_config_flow_mismatch(
+    tmp_path: Path,
+) -> None:
+    integration = write_integration(tmp_path, {"domain": "demo"})
+    (integration / "config_flow.py").write_text('"""config flow"""\n', encoding="utf-8")
+    config = HassCheckConfig(applicability=ProjectApplicability(uses_config_flow=False))
+
+    finding = findings_for(tmp_path, config=config)[
+        "config_flow.manifest_flag_consistent"
+    ]
+
+    assert finding.status is RuleStatus.FAIL
+    assert finding.applicability.source == "default"
+
+
+def test_project_applicability_loaded_from_disk(tmp_path: Path) -> None:
+    write_integration(tmp_path)
+    (tmp_path / "hasscheck.yaml").write_text(
+        "applicability:\n"
+        "  supports_diagnostics: false\n"
+        "  has_user_fixable_repairs: false\n"
+    )
+
+    report = run_check(tmp_path)
+    findings = {finding.rule_id: finding for finding in report.findings}
+
+    assert findings["diagnostics.file.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["repairs.file.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert report.summary.applicability_applied.count == 2

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -7,9 +7,10 @@ if the set of locked rules drifts from the canonical audit.
 If a future PR sets overridable inconsistently with the audit, this test
 fails — by design.
 """
+
 from __future__ import annotations
 
-from hasscheck.rules.registry import RULES, RULES_BY_ID
+from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
 # 18 rules total, 10 locked overridable=False, 8 overridable=True.
@@ -44,7 +45,9 @@ def test_total_rule_count_is_eighteen() -> None:
 
 def test_every_rule_declares_overridable_bool() -> None:
     for rule in RULES:
-        assert hasattr(rule, "overridable"), f"{rule.id} is missing the overridable field"
+        assert hasattr(rule, "overridable"), (
+            f"{rule.id} is missing the overridable field"
+        )
         assert isinstance(rule.overridable, bool), (
             f"{rule.id}.overridable must be bool, got {type(rule.overridable).__name__}"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -42,8 +51,26 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "hasscheck"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -54,7 +81,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -66,7 +95,20 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -99,6 +141,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -108,12 +159,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -232,6 +308,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -291,6 +380,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -333,4 +447,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]


### PR DESCRIPTION
Closes #9

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds v0.3 project applicability context via `hasscheck.yaml`.
- Keeps config applicability separate from per-rule overrides with explicit JSON and terminal disclosure.
- Adds pre-commit/ruff tooling plus docs, fixtures, and version alignment for `0.3.0`.

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/config.py` | Adds `ProjectApplicability` and v0.3 config validation. |
| `src/hasscheck/checker.py` | Threads applicability into rule execution and report summaries. |
| `src/hasscheck/models.py` | Adds `ApplicabilityApplied` and aligns report/tool version metadata. |
| `src/hasscheck/output.py` | Adds terminal disclosure for applicability decisions. |
| `src/hasscheck/rules/*` | Updates rule metadata/formatting and adds applicability consumers for diagnostics, repairs, and config flow. |
| `tests/*` | Adds coverage for applicability behavior, schema disclosures, and version contracts. |
| `README.md`, `hasscheck.example.yaml`, `docs/*` | Documents v0.3 behavior and ADR/architecture decisions. |
| `.pre-commit-config.yaml`, `pyproject.toml`, `uv.lock` | Adds pre-commit and ruff development tooling. |

## Test Plan

- [x] `.venv/bin/python -m pytest -q` → `136 passed`
- [x] Pre-commit hooks passed during commit
- [x] `.venv/bin/python -m hasscheck --version` → `hasscheck 0.3.0`

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified; shellcheck not applicable
- [x] Docs updated for behavior changes
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
