### PR TITLE
ci: run tests and pre-commit on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.13"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --locked --dev --python ${{ matrix.python-version }}
+
+      - name: Run pre-commit
+        run: .venv/bin/pre-commit run --all-files --show-diff-on-failure
+
+      - name: Run tests
+        run: .venv/bin/python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HassCheck
 
+[![CI](https://github.com/Daily-Nerd/hasscheck/actions/workflows/ci.yml/badge.svg)](https://github.com/Daily-Nerd/hasscheck/actions/workflows/ci.yml)
+
 HassCheck is an **unofficial** CLI for Home Assistant community integration maintainers.
 
 It checks custom integration repositories for sourced HA/HACS quality signals and produces explainable, actionable reports.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from typer.main import get_command
 from typer.testing import CliRunner
 
 from hasscheck.cli import app
@@ -60,10 +61,10 @@ def test_explain_shows_overridable_true_for_softable_rule() -> None:
 # ---------- Phase 5: --no-config flag + ConfigError handling ----------
 
 
-def test_no_config_flag_exists_in_help(tmp_path) -> None:
-    result = runner.invoke(app, ["check", "--help"])
-    assert result.exit_code == 0
-    assert "--no-config" in result.stdout
+def test_no_config_flag_is_registered() -> None:
+    command = get_command(app).commands["check"]
+
+    assert any("--no-config" in option.opts for option in command.params)
 
 
 def test_no_config_flag_skips_yaml(tmp_path) -> None:


### PR DESCRIPTION
## Issue

Closes #11

## Summary

- Add a focused CI workflow for pull requests targeting `main` and pushes to `main`.
- Cover Python 3.12 and 3.13 with `uv`, pre-commit, and pytest.
- Add a README status badge and make the existing CLI option test robust under CI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Adds CI triggers, Python matrix, pinned uv setup action, dependency sync, pre-commit, and pytest steps. |
| `README.md` | Adds the CI workflow status badge. |
| `tests/test_cli.py` | Replaces a brittle Rich/Typer help-rendering assertion with direct option-registration validation. |

## Test plan

- [x] Parsed workflow YAML with `python3`.
- [x] Ran `actionlint .github/workflows/ci.yml`.
- [x] Ran `pre-commit run --all-files`.
- [x] Ran `.venv/bin/python -m pytest -q` — 136 passed.
- [x] Pre-commit hooks passed during commits.
- [x] GitHub Actions passed for Python 3.12 and 3.13 on this PR.
- [x] Shellcheck not applicable; no shell scripts changed.
- [x] No explicit build command was run; repository instructions say not to build after changes.

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.
