### PR TITLE
ci(release): create releases from version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ jobs:
           cache-dependency-glob: uv.lock
 
       - name: Install dependencies
-        run: uv sync --locked --dev --python ${{ matrix.python-version }}
+        run: uv sync --locked --dev --python ${{ matrix.python-version }} --no-install-project
 
       - name: Run pre-commit
         run: .venv/bin/pre-commit run --all-files --show-diff-on-failure
+
+      - name: Check version consistency
+        run: .venv/bin/python scripts/check_version.py
 
       - name: Run tests
         run: .venv/bin/python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "scripts/**"
+      - "tests/**"
+      - "pre-commit-config.yaml"
   push:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "scripts/**"
+      - "tests/**"
+      - "pre-commit-config.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --locked --dev --python 3.13 --no-install-project
+
+      - name: Check version consistency
+        run: .venv/bin/python scripts/check_version.py --tag "${{ github.ref_name }}"
+
+      - name: Create source-only release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists; nothing to create."
+            exit 0
+          fi
+
+          gh release create "$TAG_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "hasscheck $TAG_NAME" \
+            --notes "Source-only release. No PyPI package or build artifacts are published by this workflow." \
+            --generate-notes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,12 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: hasscheck-version-consistency
+        name: hasscheck version consistency
+        entry: .venv/bin/python scripts/check_version.py
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|src/hasscheck/__init__\.py|src/hasscheck/models\.py|src/hasscheck/cli\.py|scripts/check_version\.py)$

--- a/README.md
+++ b/README.md
@@ -253,9 +253,17 @@ Run HassCheck against the current repository:
 .venv/bin/python -m hasscheck check --path .
 ```
 
-## Release checklist for v0.3.0
+## Release process
 
-Before tagging v0.3.0:
+Releases are source-only GitHub Releases created from version tags.
+
+Before tagging a new version, make sure all version declarations match `pyproject.toml`:
+
+```bash
+.venv/bin/python scripts/check_version.py
+```
+
+Then run the release checks:
 
 ```bash
 .venv/bin/python -m pytest -q
@@ -265,12 +273,16 @@ Before tagging v0.3.0:
 .venv/bin/python -m hasscheck explain manifest.domain.exists
 ```
 
-Then tag:
+Then create and push an annotated version tag:
 
 ```bash
-git tag v0.3.0
-git push origin v0.3.0
+git tag -a vX.Y.Z -m "vX.Y.Z — short release summary"
+git push origin vX.Y.Z
 ```
+
+Pushing a tag that matches `v*.*.*` triggers the release workflow. The workflow creates a GitHub Release for that tag with generated notes and a source-only artifact notice.
+
+This workflow does **not** publish to PyPI and does **not** attach built package artifacts. PyPI publishing is a separate release step.
 
 ## Non-goals for v0.3.0
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Validate that HassCheck version declarations cannot drift.
+
+The project version in pyproject.toml is the source of truth. Runtime metadata,
+CLI output, and optional release tags must match it exactly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Final
+
+from typer.testing import CliRunner
+
+ROOT: Final = Path(__file__).resolve().parents[1]
+VERSION_PATTERN: Final = re.compile(r"\d+\.\d+\.\d+")
+
+
+def read_pyproject_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as file:
+        pyproject = tomllib.load(file)
+
+    version = pyproject["project"]["version"]
+    if not isinstance(version, str):
+        raise TypeError("project.version in pyproject.toml must be a string")
+    return version
+
+
+def validate_semver(version: str, source: str) -> None:
+    if VERSION_PATTERN.fullmatch(version) is None:
+        raise ValueError(f"{source} must use X.Y.Z format, got {version!r}")
+
+
+def read_runtime_versions() -> dict[str, str]:
+    sys.path.insert(0, str(ROOT / "src"))
+
+    from hasscheck import __version__  # noqa: PLC0415
+    from hasscheck.cli import app  # noqa: PLC0415
+    from hasscheck.models import ToolInfo  # noqa: PLC0415
+
+    result = CliRunner().invoke(app, ["--version"])
+    if result.exit_code != 0:
+        raise RuntimeError(f"hasscheck --version failed: {result.output}")
+
+    return {
+        "src/hasscheck/__init__.py __version__": __version__,
+        "ToolInfo.version": ToolInfo().version,
+        "hasscheck --version": result.output.strip().removeprefix("hasscheck "),
+    }
+
+
+def tag_to_version(tag: str) -> str:
+    if not tag.startswith("v"):
+        raise ValueError(f"release tag must start with 'v', got {tag!r}")
+    version = tag[1:]
+    validate_semver(version, "release tag")
+    return version
+
+
+def check_versions(tag: str | None = None) -> list[str]:
+    errors: list[str] = []
+
+    pyproject_version = read_pyproject_version()
+
+    versions = {"pyproject.toml project.version": pyproject_version}
+    versions.update(read_runtime_versions())
+
+    for source, version in versions.items():
+        try:
+            validate_semver(version, source)
+        except ValueError as exc:
+            errors.append(str(exc))
+
+        if version != pyproject_version:
+            errors.append(
+                f"{source} is {version!r}, expected {pyproject_version!r} "
+                "from pyproject.toml"
+            )
+
+    if tag is not None:
+        try:
+            tag_version = tag_to_version(tag)
+        except ValueError as exc:
+            errors.append(str(exc))
+        else:
+            if tag_version != pyproject_version:
+                errors.append(
+                    f"release tag {tag!r} points to version {tag_version!r}, "
+                    f"expected 'v{pyproject_version}'"
+                )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that package, runtime, CLI, and optional tag versions match."
+    )
+    parser.add_argument(
+        "--tag",
+        help="Optional release tag to validate, for example v0.3.0.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        errors = check_versions(tag=args.tag)
+    except Exception as exc:  # pragma: no cover - defensive CLI guard
+        print(f"version check failed: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        for error in errors:
+            print(f"version mismatch: {error}", file=sys.stderr)
+        return 1
+
+    print("version check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -1,0 +1,28 @@
+import pytest
+
+from scripts.check_version import check_versions, read_pyproject_version, tag_to_version
+
+
+def test_versions_do_not_drift() -> None:
+    assert check_versions() == []
+
+
+def test_matching_release_tag_passes() -> None:
+    assert check_versions(tag=f"v{read_pyproject_version()}") == []
+
+
+def test_mismatched_release_tag_fails() -> None:
+    errors = check_versions(tag="v9.9.9")
+
+    assert any("release tag" in error for error in errors)
+
+
+def test_release_tag_must_start_with_v() -> None:
+    errors = check_versions(tag="0.3.0")
+
+    assert "release tag must start with 'v'" in errors[0]
+
+
+def test_tag_to_version_rejects_non_semver_tag() -> None:
+    with pytest.raises(ValueError, match="X.Y.Z"):
+        tag_to_version("vnext")


### PR DESCRIPTION
## Issue

Closes #14

## Summary

- Add a tag-triggered GitHub Release workflow for `v*.*.*` version tags.
- Generate release notes automatically while keeping releases source-only.
- Add reusable version consistency checks so tags cannot drift from project/runtime/CLI versions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Creates source-only GitHub Releases on `v*.*.*` tag pushes after validating version consistency. |
| `.github/workflows/ci.yml` | Adds version consistency validation to CI and avoids installing the local project during dependency sync. |
| `.pre-commit-config.yaml` | Adds a local version consistency pre-commit hook. |
| `scripts/check_version.py` | Adds reusable validation for `pyproject.toml`, `__version__`, `ToolInfo.version`, CLI `--version`, and optional release tags. |
| `tests/test_check_version.py` | Adds coverage for version drift and tag mismatch guardrails. |
| `README.md` | Documents the release tag flow and version check. |

## Test plan

- [x] Ran `.venv/bin/python scripts/check_version.py`.
- [x] Ran `.venv/bin/python scripts/check_version.py --tag v0.3.0`.
- [x] Ran `.venv/bin/python -m pytest tests/test_check_version.py -q`.
- [x] Ran `.venv/bin/python -m pytest -q` — 141 passed.
- [x] Parsed workflow YAML with `python3`.
- [x] Ran `actionlint .github/workflows/ci.yml .github/workflows/release.yml`.
- [x] Ran `pre-commit run --all-files`.
- [x] Pre-commit hooks passed during commit.
- [x] No explicit build command was run.

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.
