### PR TITLE
feat(output): render fix suggestions in terminal output

### DIFF
--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -5,7 +5,7 @@ import json
 from rich.console import Console
 from rich.table import Table
 
-from hasscheck.models import HassCheckReport, RuleStatus
+from hasscheck.models import Finding, HassCheckReport, RuleStatus
 
 STATUS_ICON = {
     RuleStatus.PASS: "✅ PASS",
@@ -59,3 +59,33 @@ def print_terminal_report(
             STATUS_ICON[finding.status], f"{finding.rule_id}{marker}", finding.message
         )
     console.print(table)
+
+    _print_fix_suggestions(report.findings, console)
+
+
+_NON_PASS_STATUSES = {
+    RuleStatus.WARN,
+    RuleStatus.FAIL,
+    RuleStatus.NOT_APPLICABLE,
+    RuleStatus.MANUAL_REVIEW,
+}
+
+
+def _print_fix_suggestions(findings: list[Finding], console: Console) -> None:
+    fixable = [
+        f for f in findings if f.status in _NON_PASS_STATUSES and f.fix is not None
+    ]
+    if not fixable:
+        return
+
+    console.print()
+    console.print("[bold]Fix suggestions[/bold]")
+    for finding in fixable:
+        fix = finding.fix
+        assert fix is not None  # narrowing — guaranteed by the filter above
+        console.print(f"  {finding.rule_id}")
+        console.print(f"    {fix.summary}")
+        if fix.command is not None:
+            console.print(f"    Run: {fix.command}")
+        if fix.docs_url is not None:
+            console.print(f"    Docs: {fix.docs_url}")

--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -7,6 +7,13 @@ from rich.table import Table
 
 from hasscheck.models import Finding, HassCheckReport, RuleStatus
 
+_NON_PASS_STATUSES = {
+    RuleStatus.WARN,
+    RuleStatus.FAIL,
+    RuleStatus.NOT_APPLICABLE,
+    RuleStatus.MANUAL_REVIEW,
+}
+
 STATUS_ICON = {
     RuleStatus.PASS: "✅ PASS",
     RuleStatus.WARN: "⚠️ WARN",
@@ -63,14 +70,6 @@ def print_terminal_report(
     _print_fix_suggestions(report.findings, console)
 
 
-_NON_PASS_STATUSES = {
-    RuleStatus.WARN,
-    RuleStatus.FAIL,
-    RuleStatus.NOT_APPLICABLE,
-    RuleStatus.MANUAL_REVIEW,
-}
-
-
 def _print_fix_suggestions(findings: list[Finding], console: Console) -> None:
     fixable = [
         f for f in findings if f.status in _NON_PASS_STATUSES and f.fix is not None
@@ -82,8 +81,9 @@ def _print_fix_suggestions(findings: list[Finding], console: Console) -> None:
     console.print("[bold]Fix suggestions[/bold]")
     for finding in fixable:
         fix = finding.fix
-        assert fix is not None  # narrowing — guaranteed by the filter above
-        console.print(f"  {finding.rule_id}")
+        if fix is None:
+            continue
+        console.print(f"  [bold]{finding.rule_id}[/bold]")
         console.print(f"    {fix.summary}")
         if fix.command is not None:
             console.print(f"    Run: {fix.command}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import StringIO
 
+import pytest
 from rich.console import Console
 
 from hasscheck.models import (
@@ -160,3 +161,38 @@ def test_fix_section_only_lists_non_pass_findings() -> None:
 
     assert "Pass fix — should not appear." not in output
     assert "Run: hasscheck scaffold pass" not in output
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RuleStatus.WARN,
+        RuleStatus.FAIL,
+        RuleStatus.NOT_APPLICABLE,
+        RuleStatus.MANUAL_REVIEW,
+    ],
+)
+def test_fix_section_shown_for_all_non_pass_statuses(status: RuleStatus) -> None:
+    fix = FixSuggestion(summary="Fix this.", command="hasscheck scaffold x")
+    report = make_report([make_finding(status, fix=fix)])
+    output = capture_output(report)
+    assert "Fix suggestions" in output
+    assert "Fix this." in output
+
+
+def test_fix_section_shows_all_qualifying_findings() -> None:
+    fix1 = FixSuggestion(
+        summary="Add diagnostics.py", command="hasscheck scaffold diagnostics"
+    )
+    fix2 = FixSuggestion(summary="Add repairs.py", command="hasscheck scaffold repairs")
+    report = make_report(
+        [
+            make_finding(RuleStatus.WARN, fix=fix1, rule_id="diagnostics.file.exists"),
+            make_finding(RuleStatus.WARN, fix=fix2, rule_id="repairs.file.exists"),
+        ]
+    )
+    output = capture_output(report)
+    assert "diagnostics.file.exists" in output
+    assert "repairs.file.exists" in output
+    assert "hasscheck scaffold diagnostics" in output
+    assert "hasscheck scaffold repairs" in output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    HassCheckReport,
+    ProjectInfo,
+    ReportSummary,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.output import print_terminal_report
+
+
+def make_finding(
+    status: RuleStatus,
+    fix: FixSuggestion | None = None,
+    rule_id: str = "test.rule",
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category="test",
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title="Test Rule",
+        message="Test message",
+        applicability=Applicability(
+            status=ApplicabilityStatus.APPLICABLE, reason="applicable"
+        ),
+        source=RuleSource(url="https://example.com"),
+        fix=fix,
+    )
+
+
+def make_report(findings: list[Finding]) -> HassCheckReport:
+    return HassCheckReport(
+        project=ProjectInfo(path="."),
+        summary=ReportSummary(),
+        findings=findings,
+    )
+
+
+def capture_output(report: HassCheckReport) -> str:
+    sio = StringIO()
+    console = Console(file=sio, no_color=True, highlight=False)
+    print_terminal_report(report, console)
+    return sio.getvalue()
+
+
+def test_fix_section_shown_for_warn_finding_with_fix() -> None:
+    fix = FixSuggestion(
+        summary="Add diagnostics.py with redaction for sensitive values.",
+        command="hasscheck scaffold diagnostics",
+    )
+    report = make_report(
+        [make_finding(RuleStatus.WARN, fix=fix, rule_id="diagnostics.file.exists")]
+    )
+    output = capture_output(report)
+
+    assert "Fix suggestions" in output
+    assert "diagnostics.file.exists" in output
+    assert "Add diagnostics.py with redaction for sensitive values." in output
+    assert "Run: hasscheck scaffold diagnostics" in output
+
+
+def test_fix_section_shown_for_fail_finding_with_fix() -> None:
+    fix = FixSuggestion(
+        summary="Create the missing file.",
+        command="hasscheck scaffold missing",
+    )
+    report = make_report([make_finding(RuleStatus.FAIL, fix=fix, rule_id="some.rule")])
+    output = capture_output(report)
+
+    assert "Fix suggestions" in output
+    assert "some.rule" in output
+    assert "Create the missing file." in output
+    assert "Run: hasscheck scaffold missing" in output
+
+
+def test_fix_section_shows_summary_only_when_no_command() -> None:
+    fix = FixSuggestion(
+        summary="Review your configuration manually.",
+        command=None,
+    )
+    report = make_report(
+        [make_finding(RuleStatus.WARN, fix=fix, rule_id="config.rule")]
+    )
+    output = capture_output(report)
+
+    assert "Fix suggestions" in output
+    assert "Review your configuration manually." in output
+    assert "Run:" not in output
+
+
+def test_fix_section_shows_docs_url_when_present() -> None:
+    fix = FixSuggestion(
+        summary="See the docs for details.",
+        docs_url="https://developers.home-assistant.io/docs/example",
+    )
+    report = make_report([make_finding(RuleStatus.FAIL, fix=fix, rule_id="docs.rule")])
+    output = capture_output(report)
+
+    assert "Fix suggestions" in output
+    assert "Docs: https://developers.home-assistant.io/docs/example" in output
+
+
+def test_fix_section_not_shown_for_pass_finding() -> None:
+    fix = FixSuggestion(
+        summary="This should not appear.",
+        command="hasscheck scaffold pass",
+    )
+    report = make_report([make_finding(RuleStatus.PASS, fix=fix, rule_id="pass.rule")])
+    output = capture_output(report)
+
+    assert "Fix suggestions" not in output
+    assert "This should not appear." not in output
+    assert "Run: hasscheck scaffold pass" not in output
+
+
+def test_fix_section_not_shown_when_no_findings_have_fix() -> None:
+    report = make_report(
+        [
+            make_finding(RuleStatus.WARN, fix=None, rule_id="warn.rule"),
+            make_finding(RuleStatus.FAIL, fix=None, rule_id="fail.rule"),
+        ]
+    )
+    output = capture_output(report)
+
+    assert "Fix suggestions" not in output
+
+
+def test_fix_section_only_lists_non_pass_findings() -> None:
+    pass_fix = FixSuggestion(
+        summary="Pass fix — should not appear.", command="hasscheck scaffold pass"
+    )
+    warn_fix = FixSuggestion(
+        summary="Warn fix — should appear.", command="hasscheck scaffold warn"
+    )
+
+    report = make_report(
+        [
+            make_finding(RuleStatus.PASS, fix=pass_fix, rule_id="pass.rule"),
+            make_finding(RuleStatus.WARN, fix=warn_fix, rule_id="warn.rule"),
+        ]
+    )
+    output = capture_output(report)
+
+    assert "Fix suggestions" in output
+    assert "warn.rule" in output
+    assert "Warn fix — should appear." in output
+    assert "Run: hasscheck scaffold warn" in output
+
+    assert "Pass fix — should not appear." not in output
+    assert "Run: hasscheck scaffold pass" not in output


### PR DESCRIPTION
Closes #21
Part of #19 (v0.4.0 umbrella)

## Summary

- Adds "Fix suggestions" section after the findings table in terminal output
- Only renders for WARN/FAIL/NOT_APPLICABLE/MANUAL_REVIEW findings that have `fix` set
- Shows `summary`, optional `Run: <command>`, optional `Docs: <url>`
- Section is skipped entirely when no qualifying findings exist
- JSON output unchanged — `fix.command` already serializes via existing model
- 12 new tests in `tests/test_output.py` (181 total)

Example output after Tasks 3–5 wire `command=` into rules:
```
Fix suggestions
  diagnostics.file.exists
    Add diagnostics.py with redaction for sensitive values.
    Run: hasscheck scaffold diagnostics
```

## Test plan

- [ ] `uv run python -m pytest -q` passes (181 tests)
- [ ] `uv run python -m hasscheck check --path examples/partial_integration` shows no "Fix suggestions" section yet (rules don't have `command=` until Tasks 3-5)
- [ ] `uv run python scripts/check_version.py` passes