### PR TITLE
chore(release): bump to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ HassCheck starts as a local CLI. Public badges, hosted reports, and any future h
 
 ## Current status
 
-HassCheck is at **v0.3.0**.
+HassCheck is at **v0.4.0**.
 
 It includes:
 
-- Typer CLI with `check`, `explain`, and `schema` commands
-- Rich terminal output
+- Typer CLI with `check`, `explain`, `schema`, and `scaffold` commands
+- Rich terminal output with per-finding fix suggestions
+- `scaffold github-action` — generate a GitHub Actions CI workflow
+- `scaffold diagnostics` — generate a `diagnostics.py` starter with redaction helpers
+- `scaffold repairs` — generate a `repairs.py` starter with `ConfirmRepairFlow` skeleton
+- Applicability-aware scaffold refusal (respects `hasscheck.yaml` flags)
 - Pydantic JSON report schema (stable, additive-only versioning)
 - Rule IDs and rule versions
 - Source links and source timestamps
@@ -87,6 +91,26 @@ Run the CLI without installing globally:
 ```bash
 .venv/bin/python -m hasscheck explain manifest.domain.exists
 ```
+
+### Scaffold a GitHub Actions workflow
+
+```bash
+.venv/bin/python -m hasscheck scaffold github-action --path .
+```
+
+### Scaffold a diagnostics.py starter
+
+```bash
+.venv/bin/python -m hasscheck scaffold diagnostics --path .
+```
+
+### Scaffold a repairs.py starter
+
+```bash
+.venv/bin/python -m hasscheck scaffold repairs --path .
+```
+
+Use `--dry-run` to preview without writing, `--force` to overwrite an existing file.
 
 ## Configuration
 
@@ -284,9 +308,9 @@ Pushing a tag that matches `v*.*.*` triggers the release workflow. The workflow 
 
 This workflow does **not** publish to PyPI and does **not** attach built package artifacts. PyPI publishing is a separate release step.
 
-## Non-goals for v0.3.0
+## Non-goals for v0.4.0
 
-HassCheck v0.3.0 does not attempt:
+HassCheck v0.4.0 does not attempt:
 
 - Security certification
 - Official Home Assistant quality tier assignment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.3.0"
+version = "0.4.0"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from hasscheck import __version__
+
 SCHEMA_VERSION = "0.3.0"
 DEFAULT_RULESET_ID = "hasscheck-ha-2026.4"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
@@ -135,7 +137,7 @@ class ProjectInfo(BaseModel):
 
 class ToolInfo(BaseModel):
     name: Literal["hasscheck"] = "hasscheck"
-    version: str = "0.3.0"
+    version: str = __version__
 
 
 class RulesetInfo(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,7 +116,7 @@ def test_pyproject_version_matches_tool_info() -> None:
     pyproject = tomllib.loads(
         (Path(__file__).parent.parent / "pyproject.toml").read_text()
     )
-    assert pyproject["project"]["version"] == ToolInfo().version == "0.3.0"
+    assert pyproject["project"]["version"] == ToolInfo().version == "0.4.0"
 
 
 def test_yaml_importable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #25
Closes #28
Closes #19

## Summary

- Bump `pyproject.toml` and `__init__.py` to `0.4.0`
- Wire `ToolInfo.version` to `__version__` — eliminates future version drift between the JSON report and pyproject.toml
- Update `test_pyproject_version_matches_tool_info` to assert `0.4.0`
- README: update current status section with v0.4.0 features, add scaffold commands section, update non-goals heading

## Verification

- `scripts/check_version.py` passes
- `pytest -q` passes (206 tests)
- `hasscheck check --path examples/good_integration --json | jq .tool.version` → `"0.4.0"`