### PR TITLE
feat(output): add markdown report renderer

### DIFF
--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -70,6 +70,73 @@ def print_terminal_report(
     _print_fix_suggestions(report.findings, console)
 
 
+def report_to_md(report: HassCheckReport) -> str:
+    lines: list[str] = []
+
+    lines.append("## HassCheck Signals")
+    lines.append("")
+    lines.append(f"**Project:** {report.project.path}  ")
+    lines.append(f"**Domain:** {report.project.domain or 'unknown'}  ")
+    lines.append(f"**Tool:** hasscheck {report.tool.version}  ")
+    lines.append(f"**Ruleset:** {report.ruleset.id}")
+    lines.append("")
+
+    lines.append("### Category Summary")
+    lines.append("")
+    lines.append("| Category | Score | Points |")
+    lines.append("|---|---|---|")
+    for category in report.summary.categories:
+        if category.points_awarded == category.points_possible:
+            icon = "✅"
+        elif category.points_awarded > 0:
+            icon = "⚠️"
+        else:
+            icon = "❌"
+        lines.append(
+            f"| {category.label} | {icon} | {category.points_awarded} / {category.points_possible} |"
+        )
+    lines.append("")
+
+    lines.append("### Findings")
+    lines.append("")
+    lines.append("| Status | Rule | Message |")
+    lines.append("|---|---|---|")
+    for finding in report.findings:
+        marker = " *(config)*" if finding.applicability.source == "config" else ""
+        lines.append(
+            f"| {STATUS_ICON[finding.status]} | {finding.rule_id}{marker} | {finding.message} |"
+        )
+    lines.append("")
+
+    fixable = [
+        f
+        for f in report.findings
+        if f.status in _NON_PASS_STATUSES and f.fix is not None
+    ]
+    if fixable:
+        lines.append("### Fix Suggestions")
+        lines.append("")
+        for finding in fixable:
+            fix = finding.fix
+            if fix is None:
+                continue
+            lines.append(f"**{finding.rule_id}**  ")
+            lines.append(f"{fix.summary}  ")
+            if fix.command is not None:
+                lines.append(f"Run: `{fix.command}`  ")
+            if fix.docs_url is not None:
+                lines.append(f"Docs: {fix.docs_url}  ")
+            lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "> Security Review: Not performed. Official HA Tier: Not assigned. HACS Acceptance: Not guaranteed."
+    )
+
+    return "\n".join(lines) + "\n"
+
+
 def _print_fix_suggestions(findings: list[Finding], console: Console) -> None:
     fixable = [
         f for f in findings if f.status in _NON_PASS_STATUSES and f.fix is not None

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from hasscheck.models import (
     Applicability,
     ApplicabilityStatus,
+    CategorySignal,
     Finding,
     FixSuggestion,
     HassCheckReport,
@@ -17,7 +18,7 @@ from hasscheck.models import (
     RuleSource,
     RuleStatus,
 )
-from hasscheck.output import print_terminal_report
+from hasscheck.output import print_terminal_report, report_to_md
 
 
 def make_finding(
@@ -196,3 +197,143 @@ def test_fix_section_shows_all_qualifying_findings() -> None:
     assert "repairs.file.exists" in output
     assert "hasscheck scaffold diagnostics" in output
     assert "hasscheck scaffold repairs" in output
+
+
+def make_finding_with_source(
+    status: RuleStatus,
+    fix: FixSuggestion | None = None,
+    rule_id: str = "test.rule",
+    applicability_source: str = "default",
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category="test",
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title="Test Rule",
+        message="Test message",
+        applicability=Applicability(
+            status=ApplicabilityStatus.APPLICABLE,
+            reason="applicable",
+            source=applicability_source,
+        ),
+        source=RuleSource(url="https://example.com"),
+        fix=fix,
+    )
+
+
+def make_md_report(
+    findings: list[Finding],
+    categories: list[CategorySignal] | None = None,
+) -> HassCheckReport:
+    return HassCheckReport(
+        project=ProjectInfo(path="/some/path", domain="my_integration"),
+        summary=ReportSummary(categories=categories or []),
+        findings=findings,
+    )
+
+
+def test_report_to_md_basic_structure() -> None:
+    report = make_md_report([make_finding(RuleStatus.PASS)])
+    output = report_to_md(report)
+
+    assert "## HassCheck Signals" in output
+    assert "| Category | Score | Points |" in output
+    assert "| Status | Rule | Message |" in output
+    assert "Security Review: Not performed." in output
+
+
+def test_report_to_md_category_score_all_points() -> None:
+    categories = [
+        CategorySignal(
+            id="cat1", label="Structure", points_awarded=10, points_possible=10
+        )
+    ]
+    report = make_md_report([], categories=categories)
+    output = report_to_md(report)
+
+    assert "✅" in output
+    assert "10 / 10" in output
+
+
+def test_report_to_md_category_score_partial_points() -> None:
+    categories = [
+        CategorySignal(
+            id="cat1", label="Structure", points_awarded=5, points_possible=10
+        )
+    ]
+    report = make_md_report([], categories=categories)
+    output = report_to_md(report)
+
+    assert "⚠️" in output
+    assert "5 / 10" in output
+
+
+def test_report_to_md_category_score_zero_points() -> None:
+    categories = [
+        CategorySignal(
+            id="cat1", label="Structure", points_awarded=0, points_possible=10
+        )
+    ]
+    report = make_md_report([], categories=categories)
+    output = report_to_md(report)
+
+    assert "❌" in output
+    assert "0 / 10" in output
+
+
+def test_report_to_md_fix_suggestions_shown_for_non_pass_with_fix() -> None:
+    fix = FixSuggestion(summary="Do the thing.", command="hasscheck scaffold thing")
+    report = make_md_report(
+        [make_finding(RuleStatus.WARN, fix=fix, rule_id="some.rule")]
+    )
+    output = report_to_md(report)
+
+    assert "### Fix Suggestions" in output
+    assert "some.rule" in output
+    assert "Do the thing." in output
+    assert "`hasscheck scaffold thing`" in output
+
+
+def test_report_to_md_fix_suggestions_omitted_when_all_fixes_none() -> None:
+    report = make_md_report(
+        [
+            make_finding(RuleStatus.WARN, fix=None, rule_id="warn.rule"),
+            make_finding(RuleStatus.FAIL, fix=None, rule_id="fail.rule"),
+        ]
+    )
+    output = report_to_md(report)
+
+    assert "### Fix Suggestions" not in output
+
+
+def test_report_to_md_fix_suggestions_omitted_for_pass_findings() -> None:
+    fix = FixSuggestion(summary="Should not appear.", command="hasscheck scaffold pass")
+    report = make_md_report(
+        [make_finding(RuleStatus.PASS, fix=fix, rule_id="pass.rule")]
+    )
+    output = report_to_md(report)
+
+    assert "### Fix Suggestions" not in output
+    assert "Should not appear." not in output
+
+
+def test_report_to_md_config_applicability_marker() -> None:
+    finding = make_finding_with_source(
+        RuleStatus.PASS, rule_id="config.rule", applicability_source="config"
+    )
+    report = make_md_report([finding])
+    output = report_to_md(report)
+
+    assert "config.rule *(config)*" in output
+
+
+def test_report_to_md_no_config_marker_for_default_source() -> None:
+    finding = make_finding_with_source(
+        RuleStatus.PASS, rule_id="default.rule", applicability_source="default"
+    )
+    report = make_md_report([finding])
+    output = report_to_md(report)
+
+    assert "*(config)*" not in output


### PR DESCRIPTION
## Issue

Closes #38

## Summary

- Adds `report_to_md(report: HassCheckReport) -> str` to `output.py` producing GitHub-Flavored Markdown
- Output includes: header block, category summary table (with ✅/⚠️/❌ score icons), findings table, fix suggestions section, and disclaimer footer
- 9 new tests covering structure, score icons, fix suggestions logic, and config applicability marker

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: `uv run pytest tests/test_output.py -v` — 21/21 passed
- [x] Ran pre-commit: ran automatically on commit, ruff formatting applied
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.