### PR TITLE
feat(cli): replace --json with unified --format flag

### DIFF
--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from enum import StrEnum
 from pathlib import Path
 
 import typer
@@ -10,12 +11,20 @@ from hasscheck import __version__
 from hasscheck.checker import run_check
 from hasscheck.config import ConfigError
 from hasscheck.models import HassCheckReport
-from hasscheck.output import print_terminal_report, report_to_json
+from hasscheck.output import print_terminal_report, report_to_json, report_to_md
 from hasscheck.rules.registry import RULES_BY_ID
 from hasscheck.scaffold.cli import scaffold_app
 
 # CLI philosophy: developer-friendly but scriptable. Human output is explanatory;
-# --json is stable and machine-readable for CI, badges, and future hosted reports.
+# --format controls output: terminal (default), json (machine-readable), or md (Markdown).
+
+
+class OutputFormat(StrEnum):
+    TERMINAL = "terminal"
+    JSON = "json"
+    MD = "md"
+
+
 app = typer.Typer(
     name="hasscheck",
     help="Unofficial sourced checks for Home Assistant custom integration repos.",
@@ -48,8 +57,11 @@ def check(
     path: Path = typer.Option(
         Path("."), "--path", "-p", help="Repository path to inspect."
     ),
-    json_output: bool = typer.Option(
-        False, "--json", help="Emit the stable JSON report."
+    format: OutputFormat = typer.Option(
+        OutputFormat.TERMINAL,
+        "--format",
+        "-f",
+        help="Output format: terminal, json, or md.",
     ),
     no_config: bool = typer.Option(
         False,
@@ -64,7 +76,8 @@ def check(
 
     Examples:
       hasscheck check --path .
-      hasscheck check --path . --json
+      hasscheck check --path . --format json
+      hasscheck check --path . --format md
       hasscheck check --path . --no-config
     """
     if not path.exists():
@@ -80,11 +93,12 @@ def check(
         typer.echo(f"hasscheck: error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    if json_output:
+    if format == OutputFormat.JSON:
         typer.echo(report_to_json(report), nl=False)
-        return
-
-    print_terminal_report(report, console)
+    elif format == OutputFormat.MD:
+        typer.echo(report_to_md(report), nl=False)
+    else:
+        print_terminal_report(report, console)
 
 
 @app.command()
@@ -104,7 +118,7 @@ def explain(
     if rule is None:
         console.print(f"[red]Error:[/] Unknown rule '{rule_id}'.")
         console.print(
-            "[yellow]Suggestion:[/] Run 'hasscheck check --json' to see emitted rule IDs."
+            "[yellow]Suggestion:[/] Run 'hasscheck check --format json' to see emitted rule IDs."
         )
         raise typer.Exit(code=1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def write_minimal_integration(root: Path) -> None:
 
 
 def test_check_json_outputs_report(tmp_path) -> None:
-    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -81,7 +81,7 @@ def test_no_config_flag_skips_yaml(tmp_path) -> None:
         "    reason: no tests needed\n"
     )
     result = runner.invoke(
-        app, ["check", "--path", str(tmp_path), "--json", "--no-config"]
+        app, ["check", "--path", str(tmp_path), "--format", "json", "--no-config"]
     )
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
@@ -108,7 +108,7 @@ def test_locked_rule_override_exits_nonzero(tmp_path) -> None:
 
 
 def test_json_output_includes_overrides_applied(tmp_path) -> None:
-    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert "overrides_applied" in payload["summary"]
@@ -117,7 +117,7 @@ def test_json_output_includes_overrides_applied(tmp_path) -> None:
 
 
 def test_json_output_includes_applicability_applied(tmp_path) -> None:
-    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["summary"]["applicability_applied"] == {
@@ -131,7 +131,7 @@ def test_json_output_includes_applicability_applied(tmp_path) -> None:
 
 
 def test_json_finding_applicability_source_present(tmp_path) -> None:
-    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--json"])
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     for finding in payload["findings"]:
@@ -210,3 +210,30 @@ def test_terminal_applicability_finding_has_config_marker(tmp_path) -> None:
 
     assert result.exit_code == 0
     assert "diagnostics.file.exists (config)" in result.output
+
+
+# ---------- --format option ----------
+
+
+def test_format_md_outputs_markdown_heading(tmp_path) -> None:
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "md"])
+
+    assert result.exit_code == 0
+    assert "## HassCheck Signals" in result.output
+
+
+def test_format_terminal_explicit_does_not_output_markdown(tmp_path) -> None:
+    result = runner.invoke(
+        app, ["check", "--path", str(tmp_path), "--format", "terminal"]
+    )
+
+    assert result.exit_code == 0
+    assert "## HassCheck Signals" not in result.output
+
+
+def test_format_json_shortflag_outputs_json(tmp_path) -> None:
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "-f", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "0.3.0"


### PR DESCRIPTION
## Issue

Closes #37

## Summary

- Removes boolean `--json` flag; replaces with `--format {terminal,json,md}` (breaking change)
- `terminal` is default — existing UX unchanged for human users
- `--format json` replaces `--json`; `--format md` uses the new `report_to_md` renderer from #38
- 3 new tests: `--format md` heading check, explicit `--format terminal`, `-f json` short flag

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [x] Breaking change

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: `uv run pytest tests/test_cli.py -v` — 23/23 passed; full suite 213/213 passed
- [x] Ran pre-commit: ran automatically on commit, ruff formatting applied
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.