### PR TITLE
fix(detect): warn when multiple integrations found

### DIFF
--- a/src/hasscheck/detect.py
+++ b/src/hasscheck/detect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,6 +24,14 @@ def detect_project(
             for path in custom_components.iterdir()
             if path.is_dir() and not path.name.startswith(".")
         )
+        if len(integrations) > 1:
+            names = [p.name for p in integrations]
+            warnings.warn(
+                f"Multiple integrations found in custom_components/: {names}. "
+                f"Using '{integrations[0].name}'. "
+                "Configure a single integration or use hasscheck.yaml to disambiguate.",
+                stacklevel=2,
+            )
         if integrations:
             integration_path = integrations[0]
             domain = integration_path.name

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,45 @@
+import warnings
+
+import pytest
+
+from hasscheck.detect import detect_project
+
+
+def test_single_integration_no_warning(tmp_path):
+    (tmp_path / "custom_components" / "my_integration").mkdir(parents=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ctx = detect_project(tmp_path)
+    assert ctx.domain == "my_integration"
+
+
+def test_no_integrations_no_warning(tmp_path):
+    (tmp_path / "custom_components").mkdir()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ctx = detect_project(tmp_path)
+    assert ctx.domain is None
+
+
+def test_multiple_integrations_emits_warning(tmp_path):
+    (tmp_path / "custom_components" / "alpha").mkdir(parents=True)
+    (tmp_path / "custom_components" / "beta").mkdir(parents=True)
+    with pytest.warns(UserWarning, match="Multiple integrations found"):
+        ctx = detect_project(tmp_path)
+    assert ctx.domain == "alpha"
+
+
+def test_multiple_integrations_picks_first_alphabetically(tmp_path):
+    for name in ("zebra", "alpha", "mango"):
+        (tmp_path / "custom_components" / name).mkdir(parents=True)
+    with pytest.warns(UserWarning):
+        ctx = detect_project(tmp_path)
+    assert ctx.domain == "alpha"
+
+
+def test_multiple_integrations_warning_lists_all_names(tmp_path):
+    (tmp_path / "custom_components" / "alpha").mkdir(parents=True)
+    (tmp_path / "custom_components" / "beta").mkdir(parents=True)
+    with pytest.warns(UserWarning, match="alpha") as record:
+        detect_project(tmp_path)
+    assert "beta" in str(record[0].message)


### PR DESCRIPTION
## Issue

Closes #30

## Summary

- Emits `UserWarning` when `custom_components/` contains more than one integration directory before silently picking the first alphabetically
- Warning message lists all found integration names and names the one selected
- 5 new tests in `tests/test_detect.py` covering: single integration (no warning), no integrations (no warning), multiple integrations (warning emitted, correct domain picked, all names in message)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: `uv run pytest tests/test_detect.py -v` — 5/5 passed; full suite 218/218 passed
- [x] Ran pre-commit: passed on commit
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.