### PR TITLE
chore(rules,cli,docs): registry guard, schema docstring fix, ruleset versioning ADR

### DIFF
--- a/docs/decisions/0006-ruleset-versioning.md
+++ b/docs/decisions/0006-ruleset-versioning.md
@@ -1,0 +1,113 @@
+# ADR 0006 — Ruleset versioning: DEFAULT_RULESET_ID and DEFAULT_SOURCE_CHECKED_AT bump policy
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Tag**: v0.6 stability
+
+## Context
+
+`models.py` exposes two module-level constants that appear in every JSON report
+and in the `ruleset` block of the schema:
+
+```python
+DEFAULT_RULESET_ID = "hasscheck-ha-YYYY.MINOR"
+DEFAULT_SOURCE_CHECKED_AT = "YYYY-MM-DD"
+```
+
+Without a documented policy, contributors bump these on every PR that touches
+rules — or never bump them at all. Both outcomes corrupt downstream consumers
+(badges, hosted reports, diffs) that rely on these values to detect meaningful
+changes in rule coverage or source accuracy.
+
+## Decisions
+
+### DEFAULT_RULESET_ID
+
+**Format:** `hasscheck-ha-YYYY.MINOR`
+
+- `YYYY` = calendar year the bump happens.
+- `MINOR` = integer, increments on each substantive update within that year.
+  Resets to `1` when the year changes.
+
+**Bump when (and only when):**
+
+1. A new rule is added to any rules module.
+2. An existing rule is updated because the underlying Home Assistant or HACS
+   documentation it is sourced from has changed — i.e. the *rule intent* or
+   *applicability logic* changed, not just the code around it.
+
+The bump signals to JSON consumers: "the set of checks or their meaning has
+changed since the last version."
+
+### DEFAULT_SOURCE_CHECKED_AT
+
+**Format:** `YYYY-MM-DD` (ISO 8601)
+
+**Bump when (and only when):**
+
+Someone manually re-verifies that every `source_url` referenced by the current
+ruleset is still live, still accurate, and still the canonical reference for
+the rule it backs. This is a deliberate human action, not a code change.
+
+The date signals to consumers: "as of this date, all source URLs were verified
+accurate."
+
+## What does NOT trigger a bump
+
+The following changes MUST NOT update either constant:
+
+- Refactoring `models.py`, `checker.py`, `output.py`, or any other non-rule
+  module.
+- Fixing a checker bug where the rule logic was wrong but the rule *intent*
+  did not change (e.g. a regex error, a wrong path comparison).
+- Adding a new field to `HassCheckReport`, `Finding`, or `RulesetInfo`.
+- Reformatting or linting rule files (black, ruff, isort).
+- Adding or updating tests, documentation, or ADRs.
+- Changing CLI help text, error messages, or exit codes.
+- Adding a new scaffold subcommand.
+
+## Reasoning
+
+- **Semantic signal, not syntactic trigger.** Bumping on every code change
+  makes the version meaningless — consumers cannot tell whether the rule
+  surface changed or someone just ran a linter. Both constants must carry
+  semantic weight.
+- **Source accuracy is a separate concern from rule coverage.** A rule can
+  exist and be correct even if its source URL moved. Conflating the two would
+  require bumping `DEFAULT_RULESET_ID` every time a docs URL changes, which
+  again destroys the semantic signal.
+- **Human gate on source verification.** `DEFAULT_SOURCE_CHECKED_AT` is
+  intentionally not automated. A CI job cannot verify that the *content* of a
+  source URL still matches the rule. A human must read the source and confirm.
+
+## Consequences
+
+### Positive
+
+- JSON consumers can use `ruleset.id` to detect meaningful rule surface changes
+  and update their dashboards, badges, or stored reports accordingly.
+- `ruleset.source_checked_at` gives consumers a freshness signal for rule
+  sourcing independent of rule coverage.
+- Contributors have a clear checklist: "did I add or meaningfully change a
+  rule? If yes, bump the ID."
+
+### Negative
+
+- Requires contributor discipline to bump correctly. Reviewers must check.
+- The MINOR counter is per-year and resets, so `hasscheck-ha-2027.1` is newer
+  than `hasscheck-ha-2026.12`. Consumers that sort lexicographically will get
+  the wrong order across year boundaries (they must parse YYYY and MINOR
+  separately).
+
+## Alternatives considered
+
+- **Semver for ruleset ID** — rejected. Semver implies backward compatibility
+  semantics that do not map cleanly onto "a new check was added." The current
+  format is more self-documenting and ties the version to a calendar year,
+  which matches the HA/HACS release cadence.
+- **Auto-bump on any rules/ file change** — rejected. Refactors and bug fixes
+  in rule checkers do not change what the rule checks for. Auto-bump would
+  inflate the version and break the semantic contract.
+- **Bump both constants together** — rejected. Source URL accuracy and rule
+  coverage are independent. Forcing a co-bump creates false precision (e.g.
+  "sources were verified" when only a new rule was added).

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -106,7 +106,7 @@ def check(
 
 @app.command()
 def schema() -> None:
-    """Print the v0.1 JSON schema used by HassCheck reports."""
+    """Print the JSON schema for HassCheck reports."""
     typer.echo(json.dumps(HassCheckReport.model_json_schema(), indent=2))
 
 

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from hasscheck import __version__
 
 SCHEMA_VERSION = "0.3.0"
+# See docs/decisions/0006-ruleset-versioning.md for bump policy.
 DEFAULT_RULESET_ID = "hasscheck-ha-2026.4"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
 

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hasscheck.rules.base import RuleDefinition
 from hasscheck.rules.brand import RULES as BRAND_RULES
 from hasscheck.rules.ci import RULES as CI_RULES
 from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
@@ -23,4 +24,11 @@ RULES = [
     *TESTS_RULES,
     *CI_RULES,
 ]
-RULES_BY_ID = {rule.id: rule for rule in RULES}
+RULES_BY_ID: dict[str, RuleDefinition] = {}
+for _rule in RULES:
+    if _rule.id in RULES_BY_ID:
+        raise RuntimeError(
+            f"Duplicate rule ID '{_rule.id}' — "
+            f"each rule must have a unique ID across all modules."
+        )
+    RULES_BY_ID[_rule.id] = _rule

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,11 @@ def test_schema_command_outputs_json_schema() -> None:
     assert payload["title"] == "HassCheckReport"
 
 
+def test_schema_help_does_not_reference_v01() -> None:
+    result = runner.invoke(app, ["schema", "--help"])
+    assert "v0.1" not in result.output
+
+
 def test_explain_known_rule() -> None:
     result = runner.invoke(app, ["explain", "manifest.domain.exists"])
 

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -87,3 +87,12 @@ def test_locked_set_and_overridable_set_partition_all_rules() -> None:
     all_ids = {rule.id for rule in RULES}
     assert all_ids == EXPECTED_LOCKED_RULE_IDS | EXPECTED_OVERRIDABLE_RULE_IDS
     assert not (EXPECTED_LOCKED_RULE_IDS & EXPECTED_OVERRIDABLE_RULE_IDS)
+
+
+def test_no_duplicate_rule_ids() -> None:
+    from hasscheck.rules.registry import RULES
+
+    ids = [rule.id for rule in RULES]
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate rule IDs: {[id for id in ids if ids.count(id) > 1]}"
+    )


### PR DESCRIPTION
## Issue

Closes #31
Closes #29
Closes #32

## Summary

- Adds a duplicate-ID guard in `registry.py` that raises `RuntimeError` at import time if two rules share the same ID
- Fixes the `schema` command docstring which incorrectly referenced `v0.1`
- Adds ADR 0006 documenting the `DEFAULT_RULESET_ID` and `DEFAULT_SOURCE_CHECKED_AT` bump policy, and an inline pointer comment in `models.py`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/rules/registry.py` | Replace dict comprehension with explicit loop; raise `RuntimeError` on duplicate ID; import `RuleDefinition` |
| `src/hasscheck/cli.py` | Remove `v0.1` from `schema()` docstring |
| `src/hasscheck/models.py` | Add inline comment pointing to ADR 0006 above the two constants |
| `docs/decisions/0006-ruleset-versioning.md` | New ADR documenting when and how to bump `DEFAULT_RULESET_ID` and `DEFAULT_SOURCE_CHECKED_AT` |
| `tests/test_rules_meta.py` | Add `test_no_duplicate_rule_ids` to guard against future regressions |
| `tests/test_cli.py` | Add `test_schema_help_does_not_reference_v01` to lock the docstring fix |

## Test plan

- [x] Ran unit tests: `uv run pytest tests/test_rules_meta.py tests/test_cli.py -v` — 34 passed
- [ ] Ran pre-commit:
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [ ] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.