### PR TITLE
feat(badges): add core badge generator module

### DIFF
--- a/src/hasscheck/badges/__init__.py
+++ b/src/hasscheck/badges/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from hasscheck.badges.generator import BadgeArtifact, generate_badges
+from hasscheck.badges.policy import FORBIDDEN_LABEL_TOKENS
+
+__all__ = ["generate_badges", "BadgeArtifact", "FORBIDDEN_LABEL_TOKENS"]

--- a/src/hasscheck/badges/endpoint.py
+++ b/src/hasscheck/badges/endpoint.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hasscheck.badges.status import BadgeStatus
+
+
+def to_shields_endpoint(status: BadgeStatus) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "label": status.label_left,
+        "message": status.label_right,
+        "color": status.color,
+        "cacheSeconds": 300,
+    }

--- a/src/hasscheck/badges/generator.py
+++ b/src/hasscheck/badges/generator.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from hasscheck.badges.endpoint import to_shields_endpoint
+from hasscheck.badges.policy import assert_label_is_clean
+from hasscheck.badges.status import category_to_status, umbrella_status
+from hasscheck.models import HassCheckReport
+
+
+class BadgeArtifact(BaseModel):
+    category_id: str
+    filename: str
+    label_left: str
+    label_right: str
+    color: str
+    points_awarded: int
+    points_possible: int
+
+
+def generate_badges(
+    report: HassCheckReport,
+    *,
+    out_dir: Path,
+    include: set[str] | None = None,
+    emit_umbrella: bool = True,
+) -> list[BadgeArtifact]:
+    """
+    Write shields.io endpoint JSON files to out_dir.
+    Returns list of BadgeArtifact for each file written.
+    include=None means all categories.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifacts: list[BadgeArtifact] = []
+
+    for cat in report.summary.categories:
+        if include is not None and cat.id not in include:
+            continue
+
+        status = category_to_status(cat)
+        if status is None:
+            continue  # fully N/A — omit
+
+        assert_label_is_clean(status.label_left)
+        assert_label_is_clean(status.label_right)
+
+        filename = f"{cat.id}.json"
+        payload = to_shields_endpoint(status)
+        (out_dir / filename).write_text(
+            json.dumps(payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        artifacts.append(
+            BadgeArtifact(
+                category_id=cat.id,
+                filename=filename,
+                label_left=status.label_left,
+                label_right=status.label_right,
+                color=status.color,
+                points_awarded=cat.points_awarded,
+                points_possible=cat.points_possible,
+            )
+        )
+
+    if emit_umbrella:
+        umb = umbrella_status()
+        assert_label_is_clean(umb.label_left)
+        assert_label_is_clean(umb.label_right)
+        filename = "hasscheck.json"
+        payload = to_shields_endpoint(umb)
+        (out_dir / filename).write_text(
+            json.dumps(payload, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        artifacts.append(
+            BadgeArtifact(
+                category_id="umbrella",
+                filename=filename,
+                label_left=umb.label_left,
+                label_right=umb.label_right,
+                color=umb.color,
+                points_awarded=0,
+                points_possible=0,
+            )
+        )
+
+    # Write manifest
+    manifest = {
+        "schema_version": "0.6.0",
+        "artifacts": [a.model_dump() for a in artifacts],
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    return artifacts

--- a/src/hasscheck/badges/generator.py
+++ b/src/hasscheck/badges/generator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from hasscheck.badges.endpoint import to_shields_endpoint
-from hasscheck.badges.policy import assert_label_is_clean
+from hasscheck.badges.policy import BADGE_MANIFEST_SCHEMA_VERSION, assert_label_is_clean
 from hasscheck.badges.status import category_to_status, umbrella_status
 from hasscheck.models import HassCheckReport
 
@@ -89,7 +89,7 @@ def generate_badges(
 
     # Write manifest
     manifest = {
-        "schema_version": "0.6.0",
+        "schema_version": BADGE_MANIFEST_SCHEMA_VERSION,
         "artifacts": [a.model_dump() for a in artifacts],
     }
     (out_dir / "manifest.json").write_text(

--- a/src/hasscheck/badges/policy.py
+++ b/src/hasscheck/badges/policy.py
@@ -33,6 +33,9 @@ PRESENT_ABSENT_CATEGORIES: frozenset[str] = frozenset(
     }
 )
 
+# Bump only when badge manifest JSON structure changes.
+BADGE_MANIFEST_SCHEMA_VERSION: str = "0.6.0"
+
 
 def assert_label_is_clean(label: str) -> None:
     lower = label.lower()

--- a/src/hasscheck/badges/policy.py
+++ b/src/hasscheck/badges/policy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+class BadgePolicyError(Exception):
+    pass
+
+
+FORBIDDEN_LABEL_TOKENS: frozenset[str] = frozenset(
+    {"certified", "safe", "approved", "hacs ready", "community ready"}
+)
+
+ALLOWED_SUFFIXES: frozenset[str] = frozenset(
+    {"Passing", "Partial", "Issues", "Present", "Signals Available"}
+)
+
+# Maps category_id → left-hand badge label (human readable)
+# Must match CATEGORY_LABELS in checker.py exactly
+CATEGORY_LABELS: dict[str, str] = {
+    "hacs_structure": "HACS Structure",
+    "manifest_metadata": "Manifest",
+    "modern_ha_patterns": "Config Flow",
+    "diagnostics_repairs": "Diagnostics",
+    "docs_support": "Docs",
+    "maintenance_signals": "Maintenance",
+    "tests_ci": "Tests & CI",
+}
+
+# These categories use "Present"/"Missing" instead of "Passing"/"Issues"
+PRESENT_ABSENT_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "diagnostics_repairs",
+        "modern_ha_patterns",
+    }
+)
+
+
+def assert_label_is_clean(label: str) -> None:
+    lower = label.lower()
+    for token in FORBIDDEN_LABEL_TOKENS:
+        if token in lower:
+            raise BadgePolicyError(
+                f"Badge label {label!r} contains forbidden token {token!r}. "
+                f"See idea.md §12 for allowed language."
+            )

--- a/src/hasscheck/badges/status.py
+++ b/src/hasscheck/badges/status.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from hasscheck.badges.policy import (
+    CATEGORY_LABELS,
+    PRESENT_ABSENT_CATEGORIES,
+    assert_label_is_clean,
+)
+from hasscheck.models import CategorySignal
+
+
+class BadgeStatus(BaseModel):
+    category_id: str
+    label_left: str
+    label_right: str
+    color: str
+
+
+def category_to_status(cat: CategorySignal) -> BadgeStatus | None:
+    """Return None when all rules are N/A (points_possible == 0) — omit badge."""
+    if cat.points_possible == 0:
+        return None
+
+    label_left = CATEGORY_LABELS.get(cat.id, cat.label)
+    use_present = cat.id in PRESENT_ABSENT_CATEGORIES
+
+    if cat.points_awarded == cat.points_possible:
+        label_right = "Present" if use_present else "Passing"
+        color = "brightgreen"
+    elif cat.points_awarded == 0:
+        label_right = "Missing" if use_present else "Issues"
+        color = "red"
+    else:
+        label_right = "Partial"
+        color = "yellow"
+
+    assert_label_is_clean(label_right)
+    return BadgeStatus(
+        category_id=cat.id,
+        label_left=label_left,
+        label_right=label_right,
+        color=color,
+    )
+
+
+def umbrella_status() -> BadgeStatus:
+    return BadgeStatus(
+        category_id="umbrella",
+        label_left="HassCheck",
+        label_right="Signals Available",
+        color="lightgrey",
+    )

--- a/tests/badges_golden/endpoint/hacs_structure__issues.json
+++ b/tests/badges_golden/endpoint/hacs_structure__issues.json
@@ -1,0 +1,7 @@
+{
+  "cacheSeconds": 300,
+  "color": "red",
+  "label": "HACS Structure",
+  "message": "Issues",
+  "schemaVersion": 1
+}

--- a/tests/badges_golden/endpoint/hacs_structure__partial.json
+++ b/tests/badges_golden/endpoint/hacs_structure__partial.json
@@ -1,0 +1,7 @@
+{
+  "cacheSeconds": 300,
+  "color": "yellow",
+  "label": "HACS Structure",
+  "message": "Partial",
+  "schemaVersion": 1
+}

--- a/tests/badges_golden/endpoint/hacs_structure__passing.json
+++ b/tests/badges_golden/endpoint/hacs_structure__passing.json
@@ -1,0 +1,7 @@
+{
+  "cacheSeconds": 300,
+  "color": "brightgreen",
+  "label": "HACS Structure",
+  "message": "Passing",
+  "schemaVersion": 1
+}

--- a/tests/test_badges_endpoint.py
+++ b/tests/test_badges_endpoint.py
@@ -1,0 +1,65 @@
+"""Golden-file tests for to_shields_endpoint()."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hasscheck.badges.endpoint import to_shields_endpoint
+from hasscheck.badges.status import BadgeStatus
+
+GOLDEN_DIR = Path(__file__).parent / "badges_golden" / "endpoint"
+
+CASES = [
+    (
+        "hacs_structure__passing",
+        BadgeStatus(
+            category_id="hacs_structure",
+            label_left="HACS Structure",
+            label_right="Passing",
+            color="brightgreen",
+        ),
+    ),
+    (
+        "hacs_structure__partial",
+        BadgeStatus(
+            category_id="hacs_structure",
+            label_left="HACS Structure",
+            label_right="Partial",
+            color="yellow",
+        ),
+    ),
+    (
+        "hacs_structure__issues",
+        BadgeStatus(
+            category_id="hacs_structure",
+            label_left="HACS Structure",
+            label_right="Issues",
+            color="red",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("name,status", CASES)
+def test_endpoint_matches_golden(name: str, status: BadgeStatus) -> None:
+    golden_path = GOLDEN_DIR / f"{name}.json"
+    actual = json.dumps(to_shields_endpoint(status), sort_keys=True, indent=2) + "\n"
+
+    if os.environ.get("UPDATE_GOLDENS") == "1":
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden_path.write_text(actual, encoding="utf-8")
+        return
+
+    assert golden_path.exists(), (
+        f"Golden file {golden_path} not found. "
+        "Run with UPDATE_GOLDENS=1 to generate it."
+    )
+    expected = golden_path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"Output for {name!r} does not match golden.\n"
+        f"Expected:\n{expected}\nActual:\n{actual}"
+    )

--- a/tests/test_badges_generator.py
+++ b/tests/test_badges_generator.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from hasscheck.badges.generator import generate_badges
+from hasscheck.badges.policy import BADGE_MANIFEST_SCHEMA_VERSION
 from hasscheck.models import (
     CategorySignal,
     HassCheckReport,
@@ -35,7 +36,7 @@ def test_generate_badges_writes_manifest(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.json"
     assert manifest_path.exists()
     data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert data["schema_version"] == "0.6.0"
+    assert data["schema_version"] == BADGE_MANIFEST_SCHEMA_VERSION
     assert isinstance(data["artifacts"], list)
 
 
@@ -128,7 +129,7 @@ def test_generate_badges_manifest_schema_version(tmp_path: Path) -> None:
     )
     generate_badges(report, out_dir=tmp_path)
     data = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
-    assert data["schema_version"] == "0.6.0"
+    assert data["schema_version"] == BADGE_MANIFEST_SCHEMA_VERSION
 
 
 def test_generate_badges_endpoint_json_valid(tmp_path: Path) -> None:

--- a/tests/test_badges_generator.py
+++ b/tests/test_badges_generator.py
@@ -1,0 +1,151 @@
+"""End-to-end tests for generate_badges()."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hasscheck.badges.generator import generate_badges
+from hasscheck.models import (
+    CategorySignal,
+    HassCheckReport,
+    ProjectInfo,
+    ReportSummary,
+)
+
+
+def _make_report(*categories: CategorySignal) -> HassCheckReport:
+    return HassCheckReport(
+        project=ProjectInfo(path="/tmp/test"),
+        summary=ReportSummary(categories=list(categories)),
+        findings=[],
+    )
+
+
+def test_generate_badges_writes_manifest(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=10,
+            points_possible=10,
+        ),
+    )
+    generate_badges(report, out_dir=tmp_path)
+    manifest_path = tmp_path / "manifest.json"
+    assert manifest_path.exists()
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "0.6.0"
+    assert isinstance(data["artifacts"], list)
+
+
+def test_generate_badges_na_category_omitted(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=5,
+            points_possible=10,
+        ),
+        CategorySignal(
+            id="manifest_metadata",
+            label="Manifest",
+            points_awarded=0,
+            points_possible=0,
+        ),  # fully N/A — should be omitted
+    )
+    artifacts = generate_badges(report, out_dir=tmp_path)
+    artifact_ids = [a.category_id for a in artifacts]
+    assert "hacs_structure" in artifact_ids
+    assert "manifest_metadata" not in artifact_ids
+    assert not (tmp_path / "manifest_metadata.json").exists()
+
+
+def test_generate_badges_correct_file_count(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=10,
+            points_possible=10,
+        ),
+        CategorySignal(
+            id="tests_ci", label="Tests & CI", points_awarded=3, points_possible=5
+        ),
+    )
+    artifacts = generate_badges(report, out_dir=tmp_path)
+    # 2 categories + 1 umbrella = 3 artifacts
+    assert len(artifacts) == 3
+    assert (tmp_path / "hacs_structure.json").exists()
+    assert (tmp_path / "tests_ci.json").exists()
+    assert (tmp_path / "hasscheck.json").exists()
+
+
+def test_generate_badges_emit_umbrella_false(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=10,
+            points_possible=10,
+        ),
+    )
+    artifacts = generate_badges(report, out_dir=tmp_path, emit_umbrella=False)
+    artifact_ids = [a.category_id for a in artifacts]
+    assert "umbrella" not in artifact_ids
+    assert not (tmp_path / "hasscheck.json").exists()
+
+
+def test_generate_badges_include_filter(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=10,
+            points_possible=10,
+        ),
+        CategorySignal(
+            id="tests_ci", label="Tests & CI", points_awarded=3, points_possible=5
+        ),
+    )
+    artifacts = generate_badges(
+        report, out_dir=tmp_path, include={"hacs_structure"}, emit_umbrella=False
+    )
+    artifact_ids = [a.category_id for a in artifacts]
+    assert artifact_ids == ["hacs_structure"]
+    assert (tmp_path / "hacs_structure.json").exists()
+    assert not (tmp_path / "tests_ci.json").exists()
+
+
+def test_generate_badges_manifest_schema_version(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=5,
+            points_possible=10,
+        ),
+    )
+    generate_badges(report, out_dir=tmp_path)
+    data = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    assert data["schema_version"] == "0.6.0"
+
+
+def test_generate_badges_endpoint_json_valid(tmp_path: Path) -> None:
+    report = _make_report(
+        CategorySignal(
+            id="hacs_structure",
+            label="HACS Structure",
+            points_awarded=10,
+            points_possible=10,
+        ),
+    )
+    generate_badges(report, out_dir=tmp_path, emit_umbrella=False)
+    endpoint = json.loads(
+        (tmp_path / "hacs_structure.json").read_text(encoding="utf-8")
+    )
+    assert endpoint["schemaVersion"] == 1
+    assert endpoint["label"] == "HACS Structure"
+    assert endpoint["message"] == "Passing"
+    assert endpoint["color"] == "brightgreen"
+    assert endpoint["cacheSeconds"] == 300

--- a/tests/test_badges_policy.py
+++ b/tests/test_badges_policy.py
@@ -1,0 +1,37 @@
+import pytest
+
+from hasscheck.badges.policy import (
+    ALLOWED_SUFFIXES,
+    CATEGORY_LABELS,
+    FORBIDDEN_LABEL_TOKENS,
+    BadgePolicyError,
+    assert_label_is_clean,
+)
+
+
+def test_category_labels_are_clean():
+    for label in CATEGORY_LABELS.values():
+        assert_label_is_clean(label)  # must not raise
+
+
+def test_allowed_suffixes_are_clean():
+    for suffix in ALLOWED_SUFFIXES:
+        assert_label_is_clean(suffix)  # must not raise
+
+
+@pytest.mark.parametrize("token", sorted(FORBIDDEN_LABEL_TOKENS))
+def test_forbidden_tokens_rejected(token):
+    with pytest.raises(BadgePolicyError):
+        assert_label_is_clean(token)
+
+
+@pytest.mark.parametrize("token", sorted(FORBIDDEN_LABEL_TOKENS))
+def test_forbidden_tokens_rejected_case_insensitive(token):
+    with pytest.raises(BadgePolicyError):
+        assert_label_is_clean(token.upper())
+
+
+def test_clean_label_passes():
+    assert_label_is_clean("HACS Structure")
+    assert_label_is_clean("Passing")
+    assert_label_is_clean("Partial")

--- a/tests/test_badges_status.py
+++ b/tests/test_badges_status.py
@@ -1,0 +1,58 @@
+from hasscheck.badges.status import category_to_status, umbrella_status
+from hasscheck.models import CategorySignal
+
+
+def make_cat(cat_id: str, awarded: int, possible: int) -> CategorySignal:
+    return CategorySignal(
+        id=cat_id, label=cat_id, points_awarded=awarded, points_possible=possible
+    )
+
+
+def test_passing_returns_brightgreen():
+    status = category_to_status(make_cat("hacs_structure", 10, 10))
+    assert status is not None
+    assert status.label_right == "Passing"
+    assert status.color == "brightgreen"
+
+
+def test_partial_returns_yellow():
+    status = category_to_status(make_cat("hacs_structure", 5, 10))
+    assert status is not None
+    assert status.label_right == "Partial"
+    assert status.color == "yellow"
+
+
+def test_issues_returns_red():
+    status = category_to_status(make_cat("hacs_structure", 0, 10))
+    assert status is not None
+    assert status.label_right == "Issues"
+    assert status.color == "red"
+
+
+def test_fully_na_returns_none():
+    status = category_to_status(make_cat("hacs_structure", 0, 0))
+    assert status is None
+
+
+def test_diagnostics_passing_uses_present():
+    status = category_to_status(make_cat("diagnostics_repairs", 5, 5))
+    assert status is not None
+    assert status.label_right == "Present"
+
+
+def test_diagnostics_zero_uses_missing():
+    status = category_to_status(make_cat("diagnostics_repairs", 0, 5))
+    assert status is not None
+    assert status.label_right == "Missing"
+
+
+def test_config_flow_passing_uses_present():
+    status = category_to_status(make_cat("modern_ha_patterns", 10, 10))
+    assert status is not None
+    assert status.label_right == "Present"
+
+
+def test_umbrella_always_lightgrey():
+    umb = umbrella_status()
+    assert umb.color == "lightgrey"
+    assert umb.label_right == "Signals Available"


### PR DESCRIPTION
## Issue

Closes #47

## Summary

- Adds `src/hasscheck/badges/` with `policy.py`, `status.py`, `endpoint.py`, `generator.py`, and `__init__.py`
- Forbidden-language blocklist (`FORBIDDEN_LABEL_TOKENS`) enforces safe badge language at runtime and in tests
- `generate_badges()` writes shields.io endpoint JSON files and a `manifest.json` to any output directory

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Changes

| File | Description |
|------|-------------|
| `src/hasscheck/badges/policy.py` | Forbidden-token blocklist, `CATEGORY_LABELS`, `PRESENT_ABSENT_CATEGORIES`, `assert_label_is_clean` |
| `src/hasscheck/badges/status.py` | `CategorySignal → BadgeStatus` mapping; color logic; `umbrella_status()` |
| `src/hasscheck/badges/endpoint.py` | `to_shields_endpoint()` — serialises `BadgeStatus` to shields.io JSON dict |
| `src/hasscheck/badges/generator.py` | `generate_badges()` — writes per-category JSON files + `manifest.json` |
| `src/hasscheck/badges/__init__.py` | Public API: `generate_badges`, `BadgeArtifact`, `FORBIDDEN_LABEL_TOKENS` |
| `tests/test_badges_policy.py` | Policy enforcement: forbidden tokens, case insensitivity, allowed labels |
| `tests/test_badges_status.py` | Status mapping: Passing/Partial/Issues, Present/Missing, N/A → None |
| `tests/test_badges_endpoint.py` | Golden-file tests for shields.io JSON output (UPDATE_GOLDENS=1 supported) |
| `tests/test_badges_generator.py` | End-to-end generator: manifest written, N/A omitted, include filter, umbrella flag |
| `tests/badges_golden/endpoint/*.json` | Golden files for 3 endpoint states |

## Test plan

- [x] Ran unit tests: `uv run pytest tests/test_badges_policy.py tests/test_badges_status.py tests/test_badges_endpoint.py tests/test_badges_generator.py -v` — 31 passed
- [x] Ran pre-commit: passed (ruff auto-fixed imports and formatting, re-staged cleanly)
- [ ] Not run (explain why):
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #47`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.