### PR TITLE
feat(cli): add hasscheck badge subcommand

### DIFF
--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -8,6 +8,8 @@ import typer
 from rich.console import Console
 
 from hasscheck import __version__
+from hasscheck.badges import generate_badges
+from hasscheck.badges.policy import BadgePolicyError
 from hasscheck.checker import run_check
 from hasscheck.config import ConfigError
 from hasscheck.models import HassCheckReport, RuleStatus
@@ -132,6 +134,67 @@ def explain(
     console.print(f"Overridable: {'true' if rule.overridable else 'false'}")
     console.print(f"Why: {rule.why}")
     console.print(f"Source: {rule.source_url}")
+
+
+@app.command()
+def badge(
+    path: Path = typer.Option(
+        Path("."), "--path", "-p", help="Path to integration repo."
+    ),
+    out_dir: Path = typer.Option(
+        Path("badges"), "--out-dir", help="Directory to write badge JSON files."
+    ),
+    include: str = typer.Option(
+        "all", "--include", help="Comma-separated category IDs, or 'all'."
+    ),
+    no_umbrella: bool = typer.Option(
+        False, "--no-umbrella", help="Omit the umbrella HassCheck badge."
+    ),
+    no_config: bool = typer.Option(
+        False,
+        "--no-config",
+        help="Ignore hasscheck.yaml even if present (useful for CI debugging).",
+    ),
+) -> None:
+    """Generate shields.io endpoint JSON badge files for a custom integration.
+
+    Badge color reflects integration health. Exit code is always 0 even when
+    checks have FAIL findings — the badge color communicates the state instead.
+
+    Examples:
+      hasscheck badge --path . --out-dir badges/
+      hasscheck badge --path . --include hacs_structure,tests_ci
+      hasscheck badge --path . --no-umbrella
+    """
+    if not path.exists():
+        console.print(f"[red]Error:[/] Path '{path}' does not exist.")
+        console.print(
+            "[yellow]Suggestion:[/] Pass an existing repository path with --path."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        report = run_check(path, no_config=no_config)
+    except ConfigError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    include_set: set[str] | None = None if include == "all" else set(include.split(","))
+
+    try:
+        artifacts = generate_badges(
+            report,
+            out_dir=out_dir,
+            include=include_set,
+            emit_umbrella=not no_umbrella,
+        )
+    except BadgePolicyError as exc:
+        typer.echo(f"hasscheck: badge policy error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Wrote {len(artifacts)} badge(s) to {out_dir}")
+    for a in artifacts:
+        typer.echo(f"  {a.filename}: {a.label_left} — {a.label_right}")
 
 
 app.add_typer(scaffold_app, name="scaffold")

--- a/tests/test_badge_cli.py
+++ b/tests/test_badge_cli.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from hasscheck.cli import app
+
+runner = CliRunner()
+
+EXAMPLES = Path(__file__).parent.parent / "examples"
+examples_good_integration = EXAMPLES / "good_integration"
+examples_bad_integration = EXAMPLES / "bad_integration"
+
+
+# 1. Basic invocation — writes badges to tmp dir
+def test_badge_command_writes_files(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["badge", "--path", str(examples_good_integration), "--out-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    assert (tmp_path / "manifest.json").exists()
+    json_files = list(tmp_path.glob("*.json"))
+    assert len(json_files) >= 2  # at least 1 category + manifest
+
+
+# 2. Exit code 0 even when check has FAILs (bad integration example)
+def test_badge_command_exits_0_on_fail_findings(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["badge", "--path", str(examples_bad_integration), "--out-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+
+
+# 3. --no-umbrella omits hasscheck.json
+def test_badge_command_no_umbrella(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "badge",
+            "--path",
+            str(examples_good_integration),
+            "--out-dir",
+            str(tmp_path),
+            "--no-umbrella",
+        ],
+    )
+    assert result.exit_code == 0
+    assert not (tmp_path / "hasscheck.json").exists()
+
+
+# 4. --include filters to specific categories
+def test_badge_command_include_filter(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "badge",
+            "--path",
+            str(examples_good_integration),
+            "--out-dir",
+            str(tmp_path),
+            "--include",
+            "hacs_structure",
+            "--no-umbrella",
+        ],
+    )
+    assert result.exit_code == 0
+    json_files = [f for f in tmp_path.glob("*.json") if f.name != "manifest.json"]
+    assert all("hacs_structure" in f.name for f in json_files)
+
+
+# 5. Output summary line is printed
+def test_badge_command_prints_summary(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["badge", "--path", str(examples_good_integration), "--out-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    assert "badge(s) to" in result.output
+
+
+# 6. --no-config flag is wired
+def test_badge_command_no_config_flag(tmp_path: Path) -> None:
+    (
+        examples_good_integration.parent.parent / "hasscheck.yaml"
+    ) if False else None  # just ensure flag exists
+    result = runner.invoke(
+        app,
+        [
+            "badge",
+            "--path",
+            str(examples_good_integration),
+            "--out-dir",
+            str(tmp_path),
+            "--no-config",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+# 7. Non-existent path exits 1
+def test_badge_command_nonexistent_path_exits_1(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "badge",
+            "--path",
+            str(tmp_path / "does_not_exist"),
+            "--out-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 1

--- a/tests/test_badge_cli.py
+++ b/tests/test_badge_cli.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 
 EXAMPLES = Path(__file__).parent.parent / "examples"
 examples_good_integration = EXAMPLES / "good_integration"
-examples_bad_integration = EXAMPLES / "bad_integration"
+examples_partial_integration = EXAMPLES / "partial_integration"
 
 
 # 1. Basic invocation — writes badges to tmp dir
@@ -29,7 +29,13 @@ def test_badge_command_writes_files(tmp_path: Path) -> None:
 def test_badge_command_exits_0_on_fail_findings(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
-        ["badge", "--path", str(examples_bad_integration), "--out-dir", str(tmp_path)],
+        [
+            "badge",
+            "--path",
+            str(examples_partial_integration),
+            "--out-dir",
+            str(tmp_path),
+        ],
     )
     assert result.exit_code == 0
 


### PR DESCRIPTION
## Issue

Closes #61

## Summary

- New `hasscheck badge` CLI command writes shields.io endpoint JSON files to `--out-dir`
- Supports `--path/-p`, `--out-dir`, `--include`, `--no-umbrella`, `--no-config` flags
- Exit code is always 0 on FAIL findings — badge color communicates integration health instead

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/cli.py` | Added `badge` command; imported `generate_badges` and `BadgePolicyError` |
| `tests/test_badge_cli.py` | 7 new tests covering writes, exit codes, `--no-umbrella`, `--include`, `--no-config`, error path |

## Test plan

- [x] Ran unit tests: `uv run pytest tests/test_badge_cli.py -v` — 7/7 passed
- [x] Ran full suite: `uv run pytest --ignore=tests/test_check_version.py` — 261/261 passed (pre-existing `scripts` module import error in `test_check_version.py` unrelated to this change)
- [x] Ran pre-commit: hooks passed after ruff-format auto-fix
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #61`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.