### PR TITLE
feat(action): add emit-badges opt-in input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,14 @@ inputs:
   github-token:
     description: GitHub token for posting PR comments. Required when comment-pr is true.
     default: ''
+  emit-badges:
+    description: 'Emit shields.io endpoint JSON badge files (opt-in). Set to "true" to enable.'
+    required: false
+    default: 'false'
+  badges-out-dir:
+    description: 'Directory to write badge JSON files when emit-badges is true.'
+    required: false
+    default: 'badges'
 
 outputs:
   exit-code:
@@ -67,6 +75,23 @@ runs:
           --edit-last 2>/dev/null || \
         gh pr comment "${{ github.event.pull_request.number }}" \
           --body-file hasscheck-report.md
+
+    - name: Generate badges
+      if: inputs.emit-badges == 'true'
+      shell: bash
+      run: |
+        .venv/bin/python -m hasscheck badge \
+          --path "${{ inputs.path }}" \
+          --out-dir "${{ inputs.badges-out-dir }}" \
+          ${{ inputs.no-config == 'true' && '--no-config' || '' }}
+
+    - name: Upload badges artifact
+      if: inputs.emit-badges == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: hasscheck-badges
+        path: ${{ inputs.badges-out-dir }}/
+        if-no-files-found: warn
 
     - name: Assert result
       shell: bash

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_emit_badges_input_exists():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert "emit-badges" in cfg["inputs"]
+
+
+def test_emit_badges_default_is_false():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert cfg["inputs"]["emit-badges"]["default"] == "false"
+
+
+def test_badges_out_dir_input_exists():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert "badges-out-dir" in cfg["inputs"]
+
+
+def test_badges_out_dir_default_is_badges():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert cfg["inputs"]["badges-out-dir"]["default"] == "badges"
+
+
+def test_generate_badges_step_is_conditional():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    badge_step = next((s for s in steps if s.get("name") == "Generate badges"), None)
+    assert badge_step is not None
+    assert "emit-badges" in badge_step.get("if", "")
+
+
+def test_upload_badges_artifact_step_exists():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    upload_step = next(
+        (s for s in steps if s.get("name") == "Upload badges artifact"), None
+    )
+    assert upload_step is not None
+    assert upload_step["with"]["name"] == "hasscheck-badges"


### PR DESCRIPTION
## Issue

Closes #63

## Summary

- Adds `emit-badges` input (default `'false'`) as opt-in flag to the composite action
- Adds `badges-out-dir` input (default `'badges'`) to configure output directory
- New conditional step runs `hasscheck badge` when `emit-badges == 'true'`
- New conditional step uploads a separate `hasscheck-badges` artifact

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Changes

| File | What changed |
|------|-------------|
| `action.yml` | Added `emit-badges` and `badges-out-dir` inputs; added `Generate badges` and `Upload badges artifact` conditional steps |
| `tests/test_action_yml.py` | New test module — 6 tests covering inputs, defaults, and conditional step logic |

## Test plan

- [x] Ran unit tests: `uv run pytest tests/test_action_yml.py -v` — 6 passed
- [x] Ran pre-commit: passed (ruff-format, check-yaml, trim-whitespace all green)
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #63`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.