### PR TITLE
docs(badges): add ADR 0007, architecture doc, README badge section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,48 @@ jobs:
 
 The action uploads `hasscheck-report.json` as a build artifact on every run.
 
+## Badges (opt-in)
+
+HassCheck can generate [shields.io](https://shields.io) endpoint JSON files for embedding specific quality signals in your README. Badges are **opt-in only** and show specific signals — not vague trust claims.
+
+### Generate locally
+
+```bash
+hasscheck badge --path . --out-dir badges/
+```
+
+This writes per-category JSON files and a `manifest.json` to `badges/`. Commit these files to your repo.
+
+### Generate in CI
+
+Add `emit-badges: 'true'` to your HassCheck action step:
+
+```yaml
+- uses: Daily-Nerd/hasscheck@v1
+  with:
+    emit-badges: 'true'
+    badges-out-dir: 'badges'
+```
+
+This uploads a `hasscheck-badges` artifact. To embed in your README, publish the JSON files somewhere publicly accessible (e.g. committed to your repo or hosted on GitHub Pages).
+
+### Embed in README
+
+Replace `OWNER/REPO/main` with your repository path:
+
+```markdown
+![HACS Structure](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/hacs_structure.json)
+![Config Flow](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/modern_ha_patterns.json)
+![Diagnostics](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/diagnostics_repairs.json)
+![Tests & CI](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/tests_ci.json)
+![HassCheck](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/hasscheck.json)
+```
+
+Badges show the current state of your integration: `Passing`, `Partial`, or `Issues`. For `Config Flow` and `Diagnostics`, suffixes are `Present` or `Missing`.
+
+> HassCheck is unofficial and not affiliated with Home Assistant, HACS, or Nabu Casa.
+> Security Review: Not performed. HACS Acceptance: Not guaranteed.
+
 ## Install for local development
 
 This repository uses [`uv`](https://docs.astral.sh/uv/) for dependency management.

--- a/docs/architecture/badges.md
+++ b/docs/architecture/badges.md
@@ -1,0 +1,153 @@
+# Badge architecture (v0.6)
+
+## Overview
+
+`hasscheck badge` writes shields.io endpoint JSON files to a local output
+directory. Each file represents one category's aggregate status. The files can
+be committed to a repository or hosted on GitHub Pages so shields.io can read
+them via a public URL.
+
+Badges are **opt-in only** — never emitted by `hasscheck check` or the GitHub
+Action unless the caller explicitly requests them. See ADR 0007 for the policy
+rationale.
+
+## Badge schema (shields.io endpoint format)
+
+Each `.json` file follows the
+[shields.io endpoint schema](https://shields.io/endpoint):
+
+```json
+{
+  "cacheSeconds": 300,
+  "color": "brightgreen",
+  "label": "HACS Structure",
+  "message": "Passing",
+  "schemaVersion": 1
+}
+```
+
+Fields are sorted alphabetically in the output (`sort_keys=True`) so diffs are
+deterministic and git history stays clean.
+
+## Status mapping
+
+| Category ID | Badge label | Passing suffix | Failing suffix |
+|---|---|---|---|
+| `hacs_structure` | HACS Structure | Passing | Issues |
+| `manifest_metadata` | Manifest | Passing | Issues |
+| `modern_ha_patterns` | Config Flow | Present | Missing |
+| `diagnostics_repairs` | Diagnostics | Present | Missing |
+| `docs_support` | Docs | Passing | Issues |
+| `maintenance_signals` | Maintenance | Passing | Issues |
+| `tests_ci` | Tests & CI | Passing | Issues |
+| *(umbrella)* | HassCheck | Signals Available | *(always lightgrey)* |
+
+`Partial` applies as a middle-ground suffix for all non-umbrella categories
+when the aggregate is neither fully passing nor fully failing.
+
+A category where every rule returned `not_applicable` emits no badge file.
+
+Label and suffix values are defined in `src/hasscheck/badges/policy.py`
+(`CATEGORY_LABELS`, `ALLOWED_SUFFIXES`).
+
+## Color mapping
+
+| Status | Color |
+|---|---|
+| Passing / Present | `brightgreen` |
+| Partial | `yellow` |
+| Issues / Missing | `red` |
+| Signals Available (umbrella) | `lightgrey` |
+
+## Manifest file
+
+Alongside the per-category badge files, `hasscheck badge` writes a
+`manifest.json` in the same output directory:
+
+```json
+{
+  "artifacts": [
+    "hacs_structure.json",
+    "manifest_metadata.json",
+    "..."
+  ],
+  "schema_version": "0.6.0"
+}
+```
+
+`schema_version` is defined by `BADGE_MANIFEST_SCHEMA_VERSION` in
+`src/hasscheck/badges/policy.py`. Bump it only when the manifest JSON structure
+changes — not when badge colors or messages change.
+
+## GitHub Pages recipe
+
+### Step 1 — Add to workflow
+
+```yaml
+- uses: Daily-Nerd/hasscheck@v1
+  with:
+    emit-badges: 'true'
+    badges-out-dir: 'badges'
+```
+
+This runs `hasscheck badge` and uploads a `hasscheck-badges` artifact
+containing the JSON files from the `badges/` directory.
+
+### Step 2 — Publish to GitHub Pages (example)
+
+Download the artifact from the previous run and commit the badge files to your
+repository so shields.io can read them via a raw GitHub URL:
+
+```yaml
+- name: Download badges artifact
+  uses: actions/download-artifact@v4
+  with:
+    name: hasscheck-badges
+    path: badges/
+
+- name: Commit badges
+  run: |
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git add badges/
+    git diff --cached --quiet || git commit -m "chore: update hasscheck badges"
+    git push
+```
+
+The exact approach depends on your GitHub Pages setup. Options include:
+
+- Committing to `main` and serving from `main/badges/`
+- Committing to a `gh-pages` branch
+- Using a dedicated Pages deployment action
+
+The only requirement for shields.io is that the JSON file is publicly
+accessible via HTTPS.
+
+### Step 3 — Embed in README
+
+Replace `OWNER/REPO/main` with your actual repository path:
+
+```markdown
+![HACS Structure](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/hacs_structure.json)
+![Config Flow](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/modern_ha_patterns.json)
+![Diagnostics](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/diagnostics_repairs.json)
+![Tests & CI](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/tests_ci.json)
+![HassCheck](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/badges/hasscheck.json)
+```
+
+Badge JSON files must be publicly accessible for shields.io to read them.
+
+## Forbidden language
+
+The following tokens are forbidden in any badge label or message
+(`FORBIDDEN_LABEL_TOKENS` in `src/hasscheck/badges/policy.py`):
+
+```
+certified, safe, approved, hacs ready, community ready
+```
+
+These are enforced at runtime by `assert_label_is_clean()` (raises
+`BadgePolicyError`) and by a property test in `tests/test_badges_policy.py`.
+A violation is a release-blocker.
+
+See ADR 0007 for the full policy rationale.

--- a/docs/decisions/0007-badge-policy.md
+++ b/docs/decisions/0007-badge-policy.md
@@ -1,0 +1,127 @@
+# ADR 0007 — Badge policy: opt-in only, forbidden language, layered-status contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Tag**: v0.6 badges
+
+## Context
+
+v0.6.0 introduces `hasscheck badge`, a command that writes shields.io endpoint
+JSON files so maintainers can embed specific quality signals in their READMEs.
+
+Three design questions are load-bearing:
+
+1. **Should badges be emitted by default?** Running `hasscheck check` or the
+   GitHub Action without opt-in should produce no badge files — they require
+   the maintainer to decide where and how to host JSON files.
+2. **What language is allowed on badge labels and messages?** `idea.md` §12
+   identifies "False authority" as a HIGH-severity risk. Vague terms like
+   "certified" or "safe" must be prevented at the code level, not left to
+   contributor judgment.
+3. **What happens when all rules in a category are `not_applicable`?** Emitting
+   a badge for a category that was never evaluated would misrepresent coverage.
+
+ADR 0001 already commits to honest language (overrides may never force a
+`pass`). ADR 0004 already commits to layered, post-applicability status
+(categories with all rules `not_applicable` produce no meaningful aggregate).
+This ADR extends both contracts to the badge surface.
+
+## Decision
+
+### Opt-in only
+
+Badges are **never** emitted by default. Neither `hasscheck check` nor the
+GitHub Action emits badge files unless the caller explicitly opts in:
+
+- CLI: `hasscheck badge --path . --out-dir badges/`
+- Action: `emit-badges: 'true'` input on `Daily-Nerd/hasscheck`
+
+There is no configuration key in `hasscheck.yaml` that silently enables badge
+generation on every run.
+
+### Frozen forbidden-language blocklist
+
+Badge label and message text is governed by `FORBIDDEN_LABEL_TOKENS` in
+`src/hasscheck/badges/policy.py`:
+
+```
+certified, safe, approved, hacs ready, community ready
+```
+
+`assert_label_is_clean(label)` checks every label string against this list at
+runtime. If any label contains a forbidden token (case-insensitive),
+`BadgePolicyError` is raised immediately. A property test in
+`tests/test_badges_policy.py` enforces this on every release — a violation is
+a release-blocker.
+
+### Allowed message suffixes
+
+The only valid message strings are those in `ALLOWED_SUFFIXES`
+(`src/hasscheck/badges/policy.py`):
+
+```
+Passing, Partial, Issues, Present, Missing, Signals Available
+```
+
+No other message text is permitted. This keeps badge vocabulary small,
+consistent, and honest.
+
+### Present/Missing for binary-presence categories
+
+The `diagnostics_repairs` and `modern_ha_patterns` categories use
+`Present`/`Missing` instead of `Passing`/`Issues`. These categories check for
+the *presence* of files and patterns — "Passing" would imply a quality bar
+that a file-existence check cannot support.
+
+### Post-applicability layered status
+
+Badges consume the post-applicability aggregate status (per ADR 0004). A
+category where every rule returned `not_applicable` emits **no badge file**.
+Emitting a badge for a category that was never evaluated would assert a signal
+that was never produced.
+
+### Config overrides propagate honestly
+
+Config overrides applied via `hasscheck.yaml` are reflected in badge state (per
+ADR 0001). If a finding's status changes because of an override, that change
+propagates through to the category aggregate and therefore to the badge color.
+The badge shows what the tool actually concluded — not what it would have
+concluded without the config.
+
+### Umbrella badge is descriptive only
+
+The umbrella `hasscheck.json` badge always shows `HassCheck: Signals Available`
+in `lightgrey`. It carries no pass/fail signal. It is a presence indicator:
+"this repository has been checked." Any interpretation of quality must come
+from the per-category badges.
+
+## Consequences
+
+### Positive
+
+- Maintainers can embed shields.io badges that show specific, honest signals.
+- The forbidden-language list is enforced at runtime and by a property test —
+  no contributor can accidentally introduce a vague trust claim.
+- The opt-in gate means no badge files appear unexpectedly in repositories that
+  do not want them.
+- N/A categories produce no badge, so the absence of a badge file is
+  informative (the category was not evaluated) rather than misleading.
+
+### Negative
+
+- Maintainers must explicitly invoke `hasscheck badge` or set `emit-badges:
+  'true'` — there is no automatic badge on every run.
+- Badge JSON files must be hosted somewhere publicly accessible (committed to
+  the repository or published to GitHub Pages) for shields.io to read them.
+  This is an operational step the maintainer must own.
+- The blocklist is frozen in code — adding a new forbidden token is a code
+  change, not a configuration change.
+
+## References
+
+- ADR 0001 — Config override policy: locked vs softenable, never force-pass
+- ADR 0004 — Layered applicability status (post-applicability aggregation)
+- `idea.md` §12 — False authority risk (HIGH severity)
+- `src/hasscheck/badges/policy.py` — `FORBIDDEN_LABEL_TOKENS`, `ALLOWED_SUFFIXES`,
+  `CATEGORY_LABELS`, `BADGE_MANIFEST_SCHEMA_VERSION`
+- `tests/test_badges_policy.py` — property test enforcing the blocklist


### PR DESCRIPTION
## Issue

Closes #65

## Summary

- `docs/decisions/0007-badge-policy.md` — ADR locking opt-in default, forbidden-language blocklist, and layered-status contract for badges
- `docs/architecture/badges.md` — shields.io endpoint schema, status mapping table, color mapping, manifest file, GH Pages recipe, and forbidden language reference
- `README.md` — new "Badges (opt-in)" section with generate-locally, generate-in-CI, and embed-in-README instructions

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore
- [ ] Breaking change

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: `uv run pytest -v` — 267 passed, 0 failed
- [ ] Ran pre-commit:
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #65`.
- [x] Added or updated tests, or explained why tests are not needed. (Documentation only — no code changes.)
- [x] Ran pre-commit locally, or explained why it was not run. (Pre-commit ran automatically via commit hook — all checks passed.)
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.