### PR TITLE
chore(release): bump to v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.5.0"
+version = "0.6.0"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Issue

Closes #68

## Summary

- Bump `pyproject.toml` version `0.5.0` → `0.6.0`
- Bump `src/hasscheck/__init__.py` `__version__` `0.5.0` → `0.6.0`
- Update `uv.lock` to reflect new version

## v0.6.0 PRs shipped

- Registry duplicate-ID guard (#31, PR #46)
- Schema command docstring fix (#29, PR #46)
- Ruleset versioning ADR 0006 (#32, PR #46)
- Core badge generator module — shields.io endpoint JSON, policy enforcement (PR #60)
- `hasscheck badge` CLI subcommand (PR #62)
- GitHub Action `emit-badges` opt-in input (PR #64)
- Badge policy ADR 0007, architecture docs, README badge section (PR #66)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `version = "0.5.0"` → `version = "0.6.0"` |
| `src/hasscheck/__init__.py` | `__version__ = "0.5.0"` → `__version__ = "0.6.0"` |
| `uv.lock` | package version entry updated |

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore
- [ ] Breaking change

## Test plan

- [x] Ran unit tests: `uv run pytest -v` — 267 passed
- [x] Ran pre-commit: all hooks passed including `hasscheck version consistency`
- [ ] Manual verification:

## Checklist

- [x] Linked the required issue above using `Closes #68`.
- [x] Added or updated tests, or explained why tests are not needed.
- [x] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.