### PR TITLE
docs(readme): refresh through v0.6 + v0.7 in-planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,26 @@ HassCheck starts as a local CLI. Public badges, hosted reports, and any future h
 
 ## Current status
 
-HassCheck is at **v0.5.0**.
+- **Latest release:** v0.6.0 — opt-in shields.io badge generator
+- **Current development target:** v0.7.0 — opt-in hosted reports (planning phase; see ADR 0008)
 
-It includes:
+v0.6.0 includes:
 
-- GitHub Action (`uses: Daily-Nerd/hasscheck@v0.5.0`) with PR comment and JSON artifact upload
-- Typer CLI with `check`, `explain`, `schema`, and `scaffold` commands
+- GitHub Action (`uses: Daily-Nerd/hasscheck@v0.6.0`) with PR comment, JSON artifact upload, and opt-in badge artifact
+- Typer CLI with `check`, `explain`, `schema`, `scaffold`, and `badge` commands
 - Rich terminal output with per-finding fix suggestions
 - `scaffold github-action` — generate a GitHub Actions CI workflow
 - `scaffold diagnostics` — generate a `diagnostics.py` starter with redaction helpers
 - `scaffold repairs` — generate a `repairs.py` starter with `ConfirmRepairFlow` skeleton
 - Applicability-aware scaffold refusal (respects `hasscheck.yaml` flags)
+- `hasscheck badge` — opt-in shields.io endpoint JSON for per-category quality signals
 - Pydantic JSON report schema (stable, additive-only versioning)
 - Rule IDs and rule versions
 - Source links and source timestamps
 - Applicability-aware statuses
 - Per-rule config overrides via `hasscheck.yaml`
 - Project applicability context via `hasscheck.yaml`
-- Example good/partial/bad integration fixtures
+- Example good and partial integration fixtures
 - Pytest coverage for the current rule set
 
 ## GitHub Action
@@ -64,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Daily-Nerd/hasscheck@v0.5.0
+      - uses: Daily-Nerd/hasscheck@v0.6.0
         with:
           comment-pr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,7 +102,7 @@ This writes per-category JSON files and a `manifest.json` to `badges/`. Commit t
 Add `emit-badges: 'true'` to your HassCheck action step:
 
 ```yaml
-- uses: Daily-Nerd/hasscheck@v1
+- uses: Daily-Nerd/hasscheck@v0.6.0
   with:
     emit-badges: 'true'
     badges-out-dir: 'badges'
@@ -387,9 +389,9 @@ Pushing a tag that matches `v*.*.*` triggers the release workflow. The workflow 
 
 This workflow does **not** publish to PyPI and does **not** attach built package artifacts. PyPI publishing is a separate release step.
 
-## Non-goals for v0.4.0
+## Non-goals
 
-HassCheck v0.4.0 does not attempt:
+HassCheck does not attempt:
 
 - Security certification
 - Official Home Assistant quality tier assignment

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,14 +15,44 @@ and per-feature design.
 
 ## Project status
 
-| Version | Status | Branch / tag | Notes |
+| Version | Status | Tag | Theme |
 |---|---|---|---|
-| v0.1.0 | Shipped | `v0.1.0` (`56b9cc5`) | Local CLI, JSON contract, 23 rules across 7 categories, fixture-based tests. |
-| v0.2.0 | In progress | `feature/config-file-support` | Adds `hasscheck.yaml` for per-rule applicability overrides. |
+| v0.1.0 | Shipped | `v0.1.0` | Local CLI, JSON contract, initial rule set |
+| v0.2.0 | Shipped | `v0.2.0` | `hasscheck.yaml` per-rule overrides |
+| v0.2.1 | Shipped | `v0.2.1` | Maintenance |
+| v0.3.0 | Shipped | `v0.3.0` | Project applicability context |
+| v0.4.0 | Shipped | `v0.4.0` | Scaffolding helpers + fix rendering |
+| v0.5.0 | Shipped | `v0.5.0` | Composite GitHub Action + markdown report |
+| v0.6.0 | Shipped | `v0.6.0` | Opt-in shields.io badge generator |
+| v0.7.0 | In planning | — | Opt-in hosted reports (separate `hasscheck-web` private service) |
 
-## v0.2 entry points
+## Architecture docs
 
-- Architecture: [`architecture/config-file.md`](./architecture/config-file.md)
-- Decisions:
-  - [ADR 0001 — Config override policy](./decisions/0001-config-override-policy.md)
-  - [ADR 0002 — Block A deferred to v0.3](./decisions/0002-block-a-deferred-to-v03.md)
+- [`architecture/config-file.md`](./architecture/config-file.md) — `hasscheck.yaml` shape and override merging
+- [`architecture/project-applicability-context.md`](./architecture/project-applicability-context.md) — `applicability:` block design
+- [`architecture/scaffolding.md`](./architecture/scaffolding.md) — Scaffolding engine and templates
+- [`architecture/badges.md`](./architecture/badges.md) — Badge generator + GitHub Pages recipe
+- [`architecture/publish-handshake.md`](./architecture/publish-handshake.md) — v0.7 publish client (OIDC, request/response, error semantics)
+
+## Decision records
+
+- [ADR 0001 — Config override policy](./decisions/0001-config-override-policy.md)
+- [ADR 0002 — Block A deferred to v0.3](./decisions/0002-block-a-deferred-to-v03.md)
+- [ADR 0003 — `hasscheck.yaml` config-file override policy](./decisions/0003-config-file-override-policy.md)
+- [ADR 0004 — Project applicability context for v0.3](./decisions/0004-project-applicability-context.md)
+- [ADR 0005 — Scaffolding policy for v0.4](./decisions/0005-scaffolding-policy.md)
+- [ADR 0006 — Ruleset versioning policy](./decisions/0006-ruleset-versioning.md)
+- [ADR 0007 — Badge policy: opt-in only, forbidden language, layered status](./decisions/0007-badge-policy.md)
+- [ADR 0008 — Hosted reports publish contract](./decisions/0008-hosted-reports-publish-contract.md)
+
+## A note on v0.7 and the OSS/proprietary split
+
+v0.7 introduces an opt-in hosted reports service. The hosted service ships
+as a sibling **private** repository, `hasscheck-web`, not as part of this
+OSS repository. This repository continues to ship the CLI, GitHub Action,
+rules, scaffolds, and badge generator that maintainers run locally or in
+their own CI. ADR 0008 documents the contract between the two repos.
+
+The free local-CLI / GitHub-Action / committed-badge-JSON path remains
+fully functional and is permanent; v0.7's hosted service is purely additive
+and opt-in.


### PR DESCRIPTION
## Summary
- README \"Current status\" section now reflects v0.6.0 (latest) + v0.7.0 (in-planning)
- Action example versions bumped to v0.6.0
- Drops the \"/bad\" claim from fixture description (no tracked files; #50 covers adding)
- \"Non-goals for v0.4.0\" → \"Non-goals\" (stale version dropped)
- docs/README.md project status table refreshed through v0.6
- docs/README.md adds links to all architecture docs and ADRs 0001-0008
- docs/README.md adds note about v0.7 OSS/proprietary split (ADR 0008)

Closes #49

## Test plan
- [ ] CI passes (markdown / yaml / version-consistency)
- [ ] No code changes; docs-only PR