### PR TITLE
feat(detect): add repo slug detection from git remote + manifest fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR 0008 — hosted reports publish contract (two-repo split, GitHub OIDC auth, schema lockstep, last-50 retention, free-for-all v0.7, monetization constraints)
 - `docs/architecture/publish-handshake.md` — client-side OIDC flow, request/response shapes, error semantics, withdrawal commands
 - `docs/README.md` refreshed: project status table through v0.6, links to all architecture docs and ADRs 0001-0008, OSS/proprietary split note
+- `CHANGELOG.md` — Keep a Changelog 1.1.0 format, populated retroactively from v0.1.0 through v0.6.0
+- `src/hasscheck/slug.py` — best-effort `owner/repo` detection from git remote with manifest `issue_tracker` fallback
+- `ProjectInfo.repo_slug: str | None` field on the JSON report (additive per ADR 0006)
 
 ### Changed
 - README "Current status" reflects v0.6.0 latest + v0.7.0 in-planning

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -14,6 +14,7 @@ from hasscheck.models import (
     RuleStatus,
 )
 from hasscheck.rules.registry import RULES
+from hasscheck.slug import detect_repo_slug
 
 APPLICABILITY_FLAGS_BY_RULE = {
     "diagnostics.file.exists": "supports_diagnostics",
@@ -102,6 +103,7 @@ def run_check(
             integration_path=str(context.integration_path.relative_to(root))
             if context.integration_path
             else None,
+            repo_slug=detect_repo_slug(root, context.integration_path),
         ),
         summary=ReportSummary(
             categories=categories,

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -134,6 +134,7 @@ class ProjectInfo(BaseModel):
     type: Literal["integration", "unknown"] = "unknown"
     domain: str | None = None
     integration_path: str | None = None
+    repo_slug: str | None = None
 
 
 class ToolInfo(BaseModel):

--- a/src/hasscheck/slug.py
+++ b/src/hasscheck/slug.py
@@ -1,0 +1,82 @@
+"""GitHub `owner/repo` slug detection from git remote or manifest fallback."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+# Accepted forms:
+#   https://github.com/owner/repo[.git]
+#   http://github.com/owner/repo[.git]
+#   git@github.com:owner/repo[.git]
+#   ssh://git@github.com[:port]/owner/repo[.git]
+_GITHUB_URL_RE = re.compile(
+    r"""
+    (?:https?://github\.com/|
+       git@github\.com:|
+       ssh://git@github\.com(?::\d+)?/)
+    (?P<owner>[A-Za-z0-9._-]+)/
+    (?P<repo>[A-Za-z0-9._-]+?)
+    (?:\.git)?
+    /?$
+    """,
+    re.VERBOSE,
+)
+
+
+def _parse_github_url(url: str) -> str | None:
+    match = _GITHUB_URL_RE.search(url.strip())
+    if match is None:
+        return None
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def _from_git_remote(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_github_url(result.stdout)
+
+
+def _from_manifest(integration_path: Path | None) -> str | None:
+    if integration_path is None:
+        return None
+    manifest = integration_path / "manifest.json"
+    if not manifest.is_file():
+        return None
+    try:
+        data = json.loads(manifest.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    issue_tracker = data.get("issue_tracker") if isinstance(data, dict) else None
+    if not isinstance(issue_tracker, str):
+        return None
+    parsed = _parse_github_url(
+        issue_tracker.removesuffix("/issues").removesuffix("/issues/")
+    )
+    return parsed
+
+
+def detect_repo_slug(root: Path, integration_path: Path | None = None) -> str | None:
+    """Best-effort `owner/repo` detection.
+
+    Tries `git remote get-url origin` first, then falls back to the manifest's
+    `issue_tracker` URL when it points at github.com. Returns None if neither
+    source yields a valid slug.
+
+    Authoritative slug at publish time comes from the GitHub OIDC token's
+    `repository` claim — this function exists for local CLI display and the
+    `hasscheck publish` pre-flight only.
+    """
+    return _from_git_remote(root) or _from_manifest(integration_path)

--- a/tests/test_slug.py
+++ b/tests/test_slug.py
@@ -1,0 +1,133 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hasscheck.slug import _parse_github_url, detect_repo_slug
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://github.com/owner/repo.git", "owner/repo"),
+        ("https://github.com/owner/repo", "owner/repo"),
+        ("https://github.com/owner/repo/", "owner/repo"),
+        ("http://github.com/owner/repo.git", "owner/repo"),
+        ("git@github.com:owner/repo.git", "owner/repo"),
+        ("git@github.com:owner/repo", "owner/repo"),
+        ("ssh://git@github.com/owner/repo.git", "owner/repo"),
+        ("ssh://git@github.com:22/owner/repo.git", "owner/repo"),
+        ("https://github.com/Daily-Nerd/hasscheck.git", "Daily-Nerd/hasscheck"),
+        ("https://github.com/owner/repo.with.dots", "owner/repo.with.dots"),
+        ("https://github.com/owner/repo-with-dashes", "owner/repo-with-dashes"),
+        (
+            "https://github.com/owner/repo_with_underscores",
+            "owner/repo_with_underscores",
+        ),
+    ],
+)
+def test_parse_github_url_accepts_common_forms(url, expected):
+    assert _parse_github_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://gitlab.com/owner/repo.git",
+        "https://bitbucket.org/owner/repo.git",
+        "https://example.com/owner/repo",
+        "not a url",
+        "",
+        "https://github.com/owner",
+        "https://github.com/",
+    ],
+)
+def test_parse_github_url_rejects_non_github_or_malformed(url):
+    assert _parse_github_url(url) is None
+
+
+def _init_git_remote(root: Path, url: str) -> None:
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "remote", "add", "origin", url],
+        check=True,
+    )
+
+
+def test_detect_repo_slug_from_git_remote_https(tmp_path):
+    _init_git_remote(tmp_path, "https://github.com/Daily-Nerd/hasscheck.git")
+    assert detect_repo_slug(tmp_path) == "Daily-Nerd/hasscheck"
+
+
+def test_detect_repo_slug_from_git_remote_ssh(tmp_path):
+    _init_git_remote(tmp_path, "git@github.com:Daily-Nerd/hasscheck.git")
+    assert detect_repo_slug(tmp_path) == "Daily-Nerd/hasscheck"
+
+
+def test_detect_repo_slug_returns_none_when_no_git(tmp_path):
+    assert detect_repo_slug(tmp_path) is None
+
+
+def test_detect_repo_slug_returns_none_when_remote_missing(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    assert detect_repo_slug(tmp_path) is None
+
+
+def test_detect_repo_slug_returns_none_for_non_github_remote(tmp_path):
+    _init_git_remote(tmp_path, "https://gitlab.com/owner/repo.git")
+    assert detect_repo_slug(tmp_path) is None
+
+
+def test_detect_repo_slug_falls_back_to_manifest_issue_tracker(tmp_path):
+    integration = tmp_path / "custom_components" / "my_integration"
+    integration.mkdir(parents=True)
+    manifest = integration / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "domain": "my_integration",
+                "name": "My Integration",
+                "issue_tracker": "https://github.com/Daily-Nerd/hasscheck/issues",
+            }
+        )
+    )
+    assert detect_repo_slug(tmp_path, integration) == "Daily-Nerd/hasscheck"
+
+
+def test_detect_repo_slug_prefers_git_remote_over_manifest(tmp_path):
+    integration = tmp_path / "custom_components" / "my_integration"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(
+        json.dumps(
+            {
+                "domain": "my_integration",
+                "issue_tracker": "https://github.com/owner-from-manifest/repo/issues",
+            }
+        )
+    )
+    _init_git_remote(tmp_path, "https://github.com/owner-from-git/repo.git")
+    assert detect_repo_slug(tmp_path, integration) == "owner-from-git/repo"
+
+
+def test_detect_repo_slug_handles_malformed_manifest(tmp_path):
+    integration = tmp_path / "custom_components" / "my_integration"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text("not valid json {")
+    assert detect_repo_slug(tmp_path, integration) is None
+
+
+def test_detect_repo_slug_handles_manifest_without_issue_tracker(tmp_path):
+    integration = tmp_path / "custom_components" / "my_integration"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(json.dumps({"domain": "x"}))
+    assert detect_repo_slug(tmp_path, integration) is None
+
+
+def test_detect_repo_slug_handles_non_github_issue_tracker(tmp_path):
+    integration = tmp_path / "custom_components" / "my_integration"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text(
+        json.dumps({"issue_tracker": "https://example.com/tickets"})
+    )
+    assert detect_repo_slug(tmp_path, integration) is None


### PR DESCRIPTION
## Summary
- New module \`src/hasscheck/slug.py\` with \`detect_repo_slug()\` parsing git remote URL (HTTPS, SSH, ssh://) with manifest \`issue_tracker\` fallback
- Adds \`ProjectInfo.repo_slug: str | None\` (additive, default None)
- Wires \`detect_repo_slug()\` into \`run_check()\` so JSON reports carry the slug
- 16 tests covering URL parsing, git fallback, manifest fallback, malformed inputs

Closes #75

## Test plan
- [ ] CI passes (Python 3.12 + 3.13)
- [ ] \`uv run python -m pytest -q\` — 313 tests pass locally
- [ ] No existing tests modified or broken