### PR TITLE
feat(cli): hasscheck publish — opt-in upload via GitHub OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CHANGELOG.md` — Keep a Changelog 1.1.0 format, populated retroactively from v0.1.0 through v0.6.0
 - `src/hasscheck/slug.py` — best-effort `owner/repo` detection from git remote with manifest `issue_tracker` fallback
 - `ProjectInfo.repo_slug: str | None` field on the JSON report (additive per ADR 0006)
+- `hasscheck publish` CLI command — opt-in upload to a hosted service via GitHub OIDC. Supports `--withdraw --report-id <id>` and `--withdraw-all`. Endpoint and token resolution: CLI flag > env var (`HASSCHECK_PUBLISH_ENDPOINT`, `HASSCHECK_OIDC_TOKEN`) > default (`https://hasscheck.io`).
+- `httpx>=0.27` runtime dependency (publish client only)
 
 ### Changed
 - README "Current status" reflects v0.6.0 latest + v0.7.0 in-planning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Unofficial sourced checks for Home Assistant custom integration r
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "httpx>=0.27",
     "pydantic>=2.8",
     "pyyaml>=6.0.3",
     "rich>=13.7",

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -14,8 +14,17 @@ from hasscheck.checker import run_check
 from hasscheck.config import ConfigError
 from hasscheck.models import HassCheckReport, RuleStatus
 from hasscheck.output import print_terminal_report, report_to_json, report_to_md
+from hasscheck.publish import (
+    PublishError,
+    publish_report,
+    resolve_endpoint,
+    resolve_oidc_token,
+    split_slug,
+    withdraw_report,
+)
 from hasscheck.rules.registry import RULES_BY_ID
 from hasscheck.scaffold.cli import scaffold_app
+from hasscheck.slug import detect_repo_slug
 
 # CLI philosophy: developer-friendly but scriptable. Human output is explanatory;
 # --format controls output: terminal (default), json (machine-readable), or md (Markdown).
@@ -195,6 +204,128 @@ def badge(
     typer.echo(f"Wrote {len(artifacts)} badge(s) to {out_dir}")
     for a in artifacts:
         typer.echo(f"  {a.filename}: {a.label_left} — {a.label_right}")
+
+
+@app.command()
+def publish(
+    path: Path = typer.Option(
+        Path("."), "--path", "-p", help="Repository path to inspect and publish."
+    ),
+    to: str | None = typer.Option(
+        None,
+        "--to",
+        help=(
+            "Publish endpoint URL. Defaults to $HASSCHECK_PUBLISH_ENDPOINT or "
+            "https://hasscheck.io."
+        ),
+    ),
+    oidc_token: str | None = typer.Option(
+        None,
+        "--oidc-token",
+        help="GitHub OIDC token. Falls back to $HASSCHECK_OIDC_TOKEN.",
+    ),
+    no_config: bool = typer.Option(
+        False,
+        "--no-config",
+        help="Ignore hasscheck.yaml even if present (useful for CI debugging).",
+    ),
+    withdraw: bool = typer.Option(
+        False,
+        "--withdraw",
+        help="Withdraw a single report. Requires --report-id.",
+    ),
+    withdraw_all: bool = typer.Option(
+        False,
+        "--withdraw-all",
+        help="Withdraw all reports for the slug. Mutually exclusive with --withdraw.",
+    ),
+    report_id: str | None = typer.Option(
+        None, "--report-id", help="Report ID to withdraw (with --withdraw)."
+    ),
+    slug: str | None = typer.Option(
+        None,
+        "--slug",
+        help=(
+            "owner/repo slug for withdrawal commands. Auto-detected from git "
+            "remote when omitted."
+        ),
+    ),
+) -> None:
+    """Opt-in upload of a HassCheck report to a hosted service.
+
+    Publishing requires a GitHub Actions OIDC token. The CLI never publishes
+    by default — invoke this command explicitly or set the action input
+    `emit-publish: 'true'`.
+
+    Examples:
+      hasscheck publish --path .
+      hasscheck publish --path . --to https://my-host.example
+      hasscheck publish --withdraw --report-id abc123
+      hasscheck publish --withdraw-all
+    """
+    if withdraw and withdraw_all:
+        typer.echo(
+            "hasscheck: error: --withdraw and --withdraw-all are mutually exclusive.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if withdraw and report_id is None:
+        typer.echo("hasscheck: error: --withdraw requires --report-id.", err=True)
+        raise typer.Exit(code=1)
+
+    if not path.exists():
+        console.print(f"[red]Error:[/] Path '{path}' does not exist.")
+        raise typer.Exit(code=1)
+
+    try:
+        endpoint = resolve_endpoint(to)
+        token = resolve_oidc_token(oidc_token)
+    except PublishError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if withdraw or withdraw_all:
+        resolved_slug = slug or detect_repo_slug(path.resolve())
+        if resolved_slug is None:
+            typer.echo(
+                "hasscheck: error: could not detect repo slug; pass --slug owner/repo.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        try:
+            owner, repo = split_slug(resolved_slug)
+            withdraw_report(
+                endpoint=endpoint,
+                oidc_token=token,
+                owner=owner,
+                repo=repo,
+                report_id=report_id,
+            )
+        except PublishError as exc:
+            typer.echo(f"hasscheck: error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        target = (
+            f"report {report_id}" if report_id else f"all reports for {resolved_slug}"
+        )
+        typer.echo(f"Withdrew {target} from {endpoint}.")
+        return
+
+    try:
+        result = publish_report(
+            path,
+            endpoint=endpoint,
+            oidc_token=token,
+            no_config=no_config,
+        )
+    except ConfigError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except PublishError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Published report {result.report_id} to {result.report_url}")
 
 
 app.add_typer(scaffold_app, name="scaffold")

--- a/src/hasscheck/publish.py
+++ b/src/hasscheck/publish.py
@@ -1,0 +1,178 @@
+"""Opt-in client for uploading HassCheck reports to a hosted service.
+
+See ADR 0008 (publish contract) and docs/architecture/publish-handshake.md.
+The CLI never publishes by default — `hasscheck publish` must be invoked
+explicitly, or `emit-publish: 'true'` set on the composite GitHub Action.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from hasscheck import __version__
+from hasscheck.checker import run_check
+from hasscheck.config import HassCheckConfig
+
+DEFAULT_ENDPOINT = "https://hasscheck.io"
+ENDPOINT_ENV_VAR = "HASSCHECK_PUBLISH_ENDPOINT"
+OIDC_TOKEN_ENV_VAR = "HASSCHECK_OIDC_TOKEN"
+USER_AGENT = f"hasscheck/{__version__}"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class PublishError(Exception):
+    """Base error raised when the publish flow cannot complete."""
+
+
+class MissingTokenError(PublishError):
+    """Raised when no OIDC token is available."""
+
+
+class PublishRequestError(PublishError):
+    """Raised when the server returns a non-2xx response."""
+
+    def __init__(self, status_code: int, body: dict[str, Any] | str):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        if isinstance(self.body, dict):
+            error = self.body.get("error") or "unknown"
+            message = self.body.get("message") or ""
+            return f"HTTP {self.status_code} {error}: {message}".rstrip(": ")
+        return f"HTTP {self.status_code}: {self.body}"
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    report_id: str
+    report_url: str
+    badge_url_template: str
+    schema_version: str
+
+
+def resolve_endpoint(cli_value: str | None) -> str:
+    """Resolve publish endpoint with precedence: CLI flag > env var > default."""
+    if cli_value:
+        return cli_value.rstrip("/")
+    env_value = os.environ.get(ENDPOINT_ENV_VAR)
+    if env_value:
+        return env_value.rstrip("/")
+    return DEFAULT_ENDPOINT
+
+
+def resolve_oidc_token(cli_value: str | None) -> str:
+    """Resolve OIDC token with precedence: CLI flag > env var. Raises if absent."""
+    if cli_value:
+        return cli_value
+    env_value = os.environ.get(OIDC_TOKEN_ENV_VAR)
+    if env_value:
+        return env_value
+    raise MissingTokenError(
+        "no OIDC token available — pass --oidc-token or set "
+        f"{OIDC_TOKEN_ENV_VAR}. Publishing requires GitHub Actions OIDC."
+    )
+
+
+def _headers(oidc_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {oidc_token}",
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+
+
+def _parse_body(response: httpx.Response) -> dict[str, Any] | str:
+    try:
+        parsed = response.json()
+    except json.JSONDecodeError:
+        return response.text
+    if not isinstance(parsed, dict):
+        return response.text
+    return parsed
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if 200 <= response.status_code < 300:
+        return
+    raise PublishRequestError(response.status_code, _parse_body(response))
+
+
+def publish_report(
+    path: Path,
+    *,
+    endpoint: str,
+    oidc_token: str,
+    config: HassCheckConfig | None = None,
+    no_config: bool = False,
+    client: httpx.Client | None = None,
+) -> PublishResult:
+    """Run a check and POST the resulting JSON report to the hosted service."""
+    report = run_check(path, config=config, no_config=no_config)
+    body = report.to_json_dict()
+
+    owns_client = client is None
+    client = client or httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS)
+    try:
+        response = client.post(
+            f"{endpoint}/api/reports",
+            json=body,
+            headers=_headers(oidc_token),
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+    _raise_for_status(response)
+
+    parsed = _parse_body(response)
+    if not isinstance(parsed, dict):
+        raise PublishRequestError(response.status_code, parsed)
+
+    return PublishResult(
+        report_id=str(parsed.get("report_id", "")),
+        report_url=str(parsed.get("report_url", "")),
+        badge_url_template=str(parsed.get("badge_url_template", "")),
+        schema_version=str(parsed.get("schema_version", "")),
+    )
+
+
+def withdraw_report(
+    *,
+    endpoint: str,
+    oidc_token: str,
+    owner: str,
+    repo: str,
+    report_id: str | None = None,
+    client: httpx.Client | None = None,
+) -> None:
+    """Delete one report (when report_id is given) or all reports for a slug."""
+    if report_id is not None:
+        url = f"{endpoint}/api/projects/{owner}/{repo}/reports/{report_id}"
+    else:
+        url = f"{endpoint}/api/projects/{owner}/{repo}"
+
+    owns_client = client is None
+    client = client or httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS)
+    try:
+        response = client.delete(url, headers=_headers(oidc_token))
+    finally:
+        if owns_client:
+            client.close()
+
+    _raise_for_status(response)
+
+
+def split_slug(slug: str) -> tuple[str, str]:
+    """Split `owner/repo` into `(owner, repo)` or raise PublishError."""
+    parts = slug.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise PublishError(f"invalid slug '{slug}'; expected 'owner/repo'")
+    return parts[0], parts[1]

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,263 @@
+import json
+import os
+
+import httpx
+import pytest
+
+from hasscheck.publish import (
+    DEFAULT_ENDPOINT,
+    ENDPOINT_ENV_VAR,
+    OIDC_TOKEN_ENV_VAR,
+    MissingTokenError,
+    PublishError,
+    PublishRequestError,
+    publish_report,
+    resolve_endpoint,
+    resolve_oidc_token,
+    split_slug,
+    withdraw_report,
+)
+
+# ---------------------------------------------------------------------------
+# Endpoint + token resolution
+
+
+def test_resolve_endpoint_uses_cli_flag(monkeypatch):
+    monkeypatch.setenv(ENDPOINT_ENV_VAR, "https://env.example")
+    assert resolve_endpoint("https://cli.example") == "https://cli.example"
+
+
+def test_resolve_endpoint_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv(ENDPOINT_ENV_VAR, "https://env.example/")
+    assert resolve_endpoint(None) == "https://env.example"
+
+
+def test_resolve_endpoint_default(monkeypatch):
+    monkeypatch.delenv(ENDPOINT_ENV_VAR, raising=False)
+    assert resolve_endpoint(None) == DEFAULT_ENDPOINT
+
+
+def test_resolve_endpoint_strips_trailing_slash():
+    assert resolve_endpoint("https://example.com/") == "https://example.com"
+
+
+def test_resolve_oidc_token_from_cli(monkeypatch):
+    monkeypatch.delenv(OIDC_TOKEN_ENV_VAR, raising=False)
+    assert resolve_oidc_token("cli-tok") == "cli-tok"
+
+
+def test_resolve_oidc_token_from_env(monkeypatch):
+    monkeypatch.setenv(OIDC_TOKEN_ENV_VAR, "env-tok")
+    assert resolve_oidc_token(None) == "env-tok"
+
+
+def test_resolve_oidc_token_missing_raises(monkeypatch):
+    monkeypatch.delenv(OIDC_TOKEN_ENV_VAR, raising=False)
+    with pytest.raises(MissingTokenError):
+        resolve_oidc_token(None)
+
+
+# ---------------------------------------------------------------------------
+# Slug splitting
+
+
+def test_split_slug_valid():
+    assert split_slug("owner/repo") == ("owner", "repo")
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "no-slash", "/repo", "owner/", "a/b/c", "owner//repo"]
+)
+def test_split_slug_invalid(bad):
+    with pytest.raises(PublishError):
+        split_slug(bad)
+
+
+# ---------------------------------------------------------------------------
+# publish_report — uses MockTransport
+
+
+def _good_fixture(path):
+    return path / "examples" / "good_integration"
+
+
+def _make_client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_publish_report_success(tmp_path, monkeypatch):
+    # Use the in-tree good fixture by resolving relative to repo root.
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["auth"] = request.headers.get("Authorization")
+        captured["ua"] = request.headers.get("User-Agent")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "report_id": "rep_abc",
+                "report_url": "https://hasscheck.io/owner/repo/reports/rep_abc",
+                "badge_url_template": "https://hasscheck.io/api/projects/owner/repo/badge/{category}.json",
+                "schema_version": "0.3.0",
+            },
+        )
+
+    with _make_client(handler) as client:
+        result = publish_report(
+            fixture,
+            endpoint="https://hasscheck.io",
+            oidc_token="tok-abc",
+            no_config=True,
+            client=client,
+        )
+
+    assert result.report_id == "rep_abc"
+    assert result.report_url.endswith("/rep_abc")
+    assert result.schema_version == "0.3.0"
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://hasscheck.io/api/reports"
+    assert captured["auth"] == "Bearer tok-abc"
+    assert captured["ua"].startswith("hasscheck/")
+    assert captured["body"]["schema_version"] == "0.3.0"
+    assert captured["body"]["tool"]["name"] == "hasscheck"
+
+
+def test_publish_report_raises_on_4xx():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={
+                "error": "schema_version_mismatch",
+                "expected": "0.4.0",
+                "received": "0.3.0",
+                "message": "Server does not support this report schema.",
+            },
+        )
+
+    with _make_client(handler) as client:
+        with pytest.raises(PublishRequestError) as ex:
+            publish_report(
+                fixture,
+                endpoint="https://hasscheck.io",
+                oidc_token="tok",
+                no_config=True,
+                client=client,
+            )
+    assert ex.value.status_code == 422
+    assert "schema_version_mismatch" in str(ex.value)
+
+
+def test_publish_report_raises_on_5xx():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="server unavailable")
+
+    with _make_client(handler) as client:
+        with pytest.raises(PublishRequestError) as ex:
+            publish_report(
+                fixture,
+                endpoint="https://hasscheck.io",
+                oidc_token="tok",
+                no_config=True,
+                client=client,
+            )
+    assert ex.value.status_code == 503
+
+
+def test_publish_report_unauthorized_returns_401():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "missing_token"})
+
+    with _make_client(handler) as client:
+        with pytest.raises(PublishRequestError) as ex:
+            publish_report(
+                fixture,
+                endpoint="https://hasscheck.io",
+                oidc_token="tok",
+                no_config=True,
+                client=client,
+            )
+    assert ex.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# withdraw_report
+
+
+def test_withdraw_single_report():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        return httpx.Response(204)
+
+    with _make_client(handler) as client:
+        withdraw_report(
+            endpoint="https://hasscheck.io",
+            oidc_token="tok",
+            owner="owner",
+            repo="repo",
+            report_id="rep_abc",
+            client=client,
+        )
+
+    assert captured["method"] == "DELETE"
+    assert (
+        captured["url"]
+        == "https://hasscheck.io/api/projects/owner/repo/reports/rep_abc"
+    )
+
+
+def test_withdraw_all_reports_for_slug():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        return httpx.Response(204)
+
+    with _make_client(handler) as client:
+        withdraw_report(
+            endpoint="https://hasscheck.io",
+            oidc_token="tok",
+            owner="owner",
+            repo="repo",
+            report_id=None,
+            client=client,
+        )
+
+    assert captured["method"] == "DELETE"
+    assert captured["url"] == "https://hasscheck.io/api/projects/owner/repo"
+
+
+def test_withdraw_raises_on_403():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "forbidden"})
+
+    with _make_client(handler) as client:
+        with pytest.raises(PublishRequestError) as ex:
+            withdraw_report(
+                endpoint="https://hasscheck.io",
+                oidc_token="tok",
+                owner="owner",
+                repo="repo",
+                report_id="rep_abc",
+                client=client,
+            )
+    assert ex.value.status_code == 403

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,28 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -69,10 +91,20 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hasscheck"
 version = "0.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -88,6 +120,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.7" },
@@ -102,12 +135,49 @@ dev = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New \`hasscheck publish\` command — POST to \`{endpoint}/api/reports\` with OIDC token
- \`--withdraw --report-id <id>\` / \`--withdraw-all\` for un-publish
- New runtime dep: \`httpx>=0.27\` (publish client only)
- New module \`src/hasscheck/publish.py\`
- 21 tests covering endpoint/token resolution, success, 4xx/5xx, withdrawal — all using \`httpx.MockTransport\` (no network)

Closes #77

## Test plan
- [ ] CI passes (Python 3.12 + 3.13)
- [ ] \`uv run python -m pytest -q\` — 343 tests pass locally
- [ ] CLI never publishes by default (other commands emit zero network calls)