### PR TITLE
feat(action): emit-publish + publish-endpoint inputs with OIDC forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `httpx>=0.27` runtime dependency (publish client only)
 - `hasscheck init` CLI command — bootstraps a repo with `hasscheck.yaml` and `.github/workflows/hasscheck.yml`. Supports `--dry-run`, `--force`, `--skip-action`. Refuses to overwrite existing files unless `--force`.
 - `src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl` — conservative `hasscheck.yaml` template used by `init`
+- `emit-publish` and `publish-endpoint` inputs on the composite GitHub Action. When `emit-publish: 'true'`, the action requests a workflow OIDC token (audience `hasscheck-web`) and runs `hasscheck publish`. Requires workflow-level `permissions: id-token: write`.
 
 ### Changed
 - README "Current status" reflects v0.6.0 latest + v0.7.0 in-planning

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ jobs:
 | `no-config` | `false` | Ignore `hasscheck.yaml` if present |
 | `comment-pr` | `false` | Post findings as a PR comment |
 | `github-token` | `''` | Required when `comment-pr: true` |
+| `emit-badges` | `false` | Generate shields.io badge JSON and upload as artifact |
+| `badges-out-dir` | `badges` | Directory for badge JSON when `emit-badges: 'true'` |
+| `emit-publish` | `false` | Publish the report to a hosted HassCheck service. Requires workflow `permissions: id-token: write` |
+| `publish-endpoint` | `https://hasscheck.io` | Publish endpoint URL when `emit-publish: 'true'` |
 
 **Outputs:** `exit-code` — `0` when no FAIL findings, `1` when one or more FAIL findings.
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: 'Directory to write badge JSON files when emit-badges is true.'
     required: false
     default: 'badges'
+  emit-publish:
+    description: 'Publish the report to a hosted HassCheck service (opt-in). Set to "true" to enable. Requires `permissions: id-token: write` on the workflow.'
+    required: false
+    default: 'false'
+  publish-endpoint:
+    description: 'Publish endpoint URL when emit-publish is true. Defaults to https://hasscheck.io.'
+    required: false
+    default: 'https://hasscheck.io'
 
 outputs:
   exit-code:
@@ -92,6 +100,37 @@ runs:
         name: hasscheck-badges
         path: ${{ inputs.badges-out-dir }}/
         if-no-files-found: warn
+
+    - name: Request GitHub OIDC token
+      id: oidc
+      if: inputs.emit-publish == 'true'
+      shell: bash
+      run: |
+        if [ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ] || [ -z "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
+          echo "::error::emit-publish requires the workflow to grant 'id-token: write' permission."
+          exit 1
+        fi
+        TOKEN=$(curl -fsSL \
+          -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=hasscheck-web" | \
+          python -c "import json,sys; print(json.load(sys.stdin)['value'])")
+        echo "::add-mask::$TOKEN"
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+    - name: Publish report
+      if: inputs.emit-publish == 'true'
+      shell: bash
+      env:
+        HASSCHECK_OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+      run: |
+        ARGS=""
+        if [ "${{ inputs.no-config }}" = "true" ]; then
+          ARGS="--no-config"
+        fi
+        hasscheck publish \
+          --path "${{ inputs.path }}" \
+          --to "${{ inputs.publish-endpoint }}" \
+          $ARGS
 
     - name: Assert result
       shell: bash

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -39,3 +39,45 @@ def test_upload_badges_artifact_step_exists():
     )
     assert upload_step is not None
     assert upload_step["with"]["name"] == "hasscheck-badges"
+
+
+def test_emit_publish_input_exists_and_defaults_false():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert "emit-publish" in cfg["inputs"]
+    assert cfg["inputs"]["emit-publish"]["default"] == "false"
+
+
+def test_publish_endpoint_input_defaults_to_hasscheck_io():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    assert "publish-endpoint" in cfg["inputs"]
+    assert cfg["inputs"]["publish-endpoint"]["default"] == "https://hasscheck.io"
+
+
+def test_oidc_step_is_conditional_on_emit_publish():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    oidc_step = next(
+        (s for s in steps if s.get("name") == "Request GitHub OIDC token"), None
+    )
+    assert oidc_step is not None
+    assert "emit-publish" in oidc_step.get("if", "")
+
+
+def test_publish_step_is_conditional_on_emit_publish():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    publish_step = next((s for s in steps if s.get("name") == "Publish report"), None)
+    assert publish_step is not None
+    assert "emit-publish" in publish_step.get("if", "")
+    assert publish_step["env"]["HASSCHECK_OIDC_TOKEN"].startswith("${{ steps.oidc")
+
+
+def test_publish_step_calls_hasscheck_publish_with_endpoint():
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    publish_step = next((s for s in steps if s.get("name") == "Publish report"), None)
+    assert publish_step is not None
+    run_block = publish_step["run"]
+    assert "hasscheck publish" in run_block
+    assert "--to" in run_block
+    assert "publish-endpoint" in run_block


### PR DESCRIPTION
## Summary
- Two new action inputs: \`emit-publish\` (default \`false\`) and \`publish-endpoint\` (default \`https://hasscheck.io\`)
- OIDC step requests a workflow ID-token with audience \`hasscheck-web\`; fails fast without \`id-token: write\` permission
- Publish step runs \`hasscheck publish\` with the masked token
- README inputs table updated for v0.6 + v0.7 inputs
- 6 new tests (\`test_action_yml.py\`)

Closes #80

## Test plan
- [ ] CI passes (Python 3.12 + 3.13)
- [ ] All local tests pass