### PR TITLE
feat(v0.8): rule-depth PR 1/4 — bad fixture + manifest.domain.matches_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The exact category order may change as rules evolve. The JSON schema is the dura
 | --- | --- |
 | `manifest.exists` | Integration has `manifest.json`. |
 | `manifest.domain.exists` | Manifest defines `domain`. |
+| `manifest.domain.matches_directory` | Manifest `domain` matches the integration directory name. |
 | `manifest.name.exists` | Manifest defines `name`. |
 | `manifest.version.exists` | Manifest defines `version`. |
 | `manifest.documentation.exists` | Manifest defines `documentation`. |

--- a/examples/bad_integration/README.md
+++ b/examples/bad_integration/README.md
@@ -1,0 +1,15 @@
+# bad_integration fixture
+
+This directory is an **intentionally broken** Home Assistant integration used by hasscheck's own test suite to demonstrate failing rules.
+
+It is NOT a real integration. Every defect is deliberate. Run `hasscheck check examples/bad_integration` to see the full findings list.
+
+## Intentional defects (v0.8)
+
+- `manifest.json` declares `"domain": "wrong_domain"` but the directory is `demo_bad` — triggers **manifest.domain.matches_directory** FAIL.
+- `manifest.json` declares `"iot_class": "not_a_valid_class"` — triggers **manifest.iot_class.valid** FAIL (PR2).
+- `manifest.json` omits `integration_type` — triggers **manifest.integration_type.exists** WARN (PR2).
+- `config_flow.py` defines `async_step_setup` instead of `async_step_user` — triggers **config_flow.user_step.exists** WARN (PR3).
+- `diagnostics.py` returns `entry.data` without redaction — triggers **diagnostics.redaction.used** WARN (PR4).
+
+Additional defects will be added as new rules land in subsequent PRs.

--- a/examples/bad_integration/custom_components/demo_bad/manifest.json
+++ b/examples/bad_integration/custom_components/demo_bad/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "wrong_domain",
+  "name": "Demo Bad",
+  "documentation": "https://example.com/demo_bad",
+  "issue_tracker": "https://example.com/demo_bad/issues",
+  "codeowners": ["@demo"],
+  "version": "0.1.0",
+  "config_flow": true,
+  "iot_class": "not_a_valid_class"
+}

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -10,7 +10,7 @@ from hasscheck import __version__
 
 SCHEMA_VERSION = "0.3.0"
 # See docs/decisions/0006-ruleset-versioning.md for bump policy.
-DEFAULT_RULESET_ID = "hasscheck-ha-2026.4"
+DEFAULT_RULESET_ID = "hasscheck-ha-2026.5"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
 
 

--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -224,6 +224,130 @@ manifest_issue_tracker_exists = _required_string_field_rule(
 )
 manifest_codeowners_exists = _codeowners_rule
 
+# ---------------------------------------------------------------------------
+# manifest.domain.matches_directory — PR1 (#51)
+# Source: https://developers.home-assistant.io/docs/creating_integration_manifest
+# ---------------------------------------------------------------------------
+
+HA_MANIFEST_DOCS_URL = (
+    "https://developers.home-assistant.io/docs/creating_integration_manifest"
+)
+
+
+def manifest_domain_matches_directory(context: ProjectContext) -> Finding:
+    rule_id = "manifest.domain.matches_directory"
+    title = "manifest.json domain matches integration directory"
+
+    if context.integration_path is None:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message="No integration directory was detected, so domain consistency cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect domain consistency.",
+            ),
+            source=RuleSource(url=HA_MANIFEST_DOCS_URL),
+            fix=FixSuggestion(
+                summary="Create custom_components/<domain>/ and manifest.json first."
+            ),
+            path="custom_components/<domain>/manifest.json",
+        )
+
+    manifest_path = context.integration_path / "manifest.json"
+    display = str(manifest_path.relative_to(context.root))
+
+    if not manifest_path.is_file():
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message="manifest.json is missing, so the domain field cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.json must exist before HassCheck can inspect manifest.domain.",
+            ),
+            source=RuleSource(url=HA_MANIFEST_DOCS_URL),
+            fix=FixSuggestion(
+                summary="Add manifest.json with a domain field that matches the integration directory name."
+            ),
+            path=display,
+        )
+
+    payload, error = _read_manifest(context)
+    if error is not None:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.FAIL,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message=f"manifest.json is not valid JSON: {error}.",
+            applicability=Applicability(
+                reason="manifest.json exists but cannot be parsed."
+            ),
+            source=RuleSource(url=HA_MANIFEST_DOCS_URL),
+            fix=FixSuggestion(
+                summary="Fix manifest.json syntax, then rerun HassCheck."
+            ),
+            path=display,
+        )
+
+    dir_name = context.integration_path.name
+    manifest_domain = payload.get("domain") if payload else None
+
+    if isinstance(manifest_domain, str) and manifest_domain == dir_name:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message=f'manifest.json domain matches integration directory "{dir_name}".',
+            applicability=Applicability(
+                reason="The manifest domain must match the integration directory name."
+            ),
+            source=RuleSource(url=HA_MANIFEST_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    manifest_domain_display = (
+        manifest_domain if isinstance(manifest_domain, str) else "(missing)"
+    )
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title=title,
+        message=(
+            f'manifest.json domain "{manifest_domain_display}" does not match '
+            f'integration directory "{dir_name}".'
+        ),
+        applicability=Applicability(
+            reason="The manifest domain must match the integration directory name."
+        ),
+        source=RuleSource(url=HA_MANIFEST_DOCS_URL),
+        fix=FixSuggestion(
+            summary=(
+                "Rename the integration directory or update manifest.domain so both "
+                "use the same stable domain."
+            )
+        ),
+        path=display,
+    )
+
 
 def manifest_exists(context: ProjectContext) -> Finding:
     path = _manifest_path(context)
@@ -330,6 +454,22 @@ RULES = [
         why="Code owners make maintainership explicit and are expected by HACS integration metadata.",
         source_url=HACS_INTEGRATION_SOURCE,
         check=manifest_codeowners_exists,
+        overridable=False,
+    ),
+    RuleDefinition(
+        id="manifest.domain.matches_directory",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json domain matches integration directory",
+        why=(
+            "The manifest domain must match the name of the integration directory under "
+            "custom_components/. A mismatch causes Home Assistant to silently misidentify "
+            "the integration, breaking HACS discovery and core platform loading. "
+            "Note: this rule cannot be overridden via hasscheck.yaml."
+        ),
+        source_url=HA_MANIFEST_DOCS_URL,
+        check=manifest_domain_matches_directory,
         overridable=False,
     ),
 ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -97,3 +97,12 @@ def test_run_check_no_yaml_overrides_applied_is_empty(tmp_path) -> None:
 def test_run_check_schema_version_is_0_3_0(tmp_path) -> None:
     report = run_check(tmp_path)
     assert report.schema_version == "0.3.0"
+
+
+# ---------- v0.8: Ruleset ID bump ----------
+
+
+def test_default_ruleset_id_is_hasscheck_ha_2026_5() -> None:
+    from hasscheck.models import DEFAULT_RULESET_ID
+
+    assert DEFAULT_RULESET_ID == "hasscheck-ha-2026.5"

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -1,0 +1,32 @@
+"""Integration tests against the bad_integration fixture.
+
+Design: D3 — whitelist-asserts only on the 7 v0.8 rule IDs that the fixture
+was designed to exercise. Other rules are NOT asserted here — keeps the test
+stable as more rules land in PR2/PR3/PR4.
+
+Extend this file when adding fixture coverage for new rules (PR2–PR4 tasks).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+FIXTURE_PATH = Path(__file__).parent.parent / "examples" / "bad_integration"
+
+
+def _findings_by_id():
+    return {f.rule_id: f for f in run_check(FIXTURE_PATH).findings}
+
+
+# ---------------------------------------------------------------------------
+# PR1: manifest.domain.matches_directory must FAIL on the bad_integration fixture
+# ---------------------------------------------------------------------------
+
+
+def test_domain_mismatch_rule_fails_on_bad_integration_fixture() -> None:
+    """Fixture declares domain 'wrong_domain' but directory is 'demo_bad' — must FAIL."""
+    findings = _findings_by_id()
+    assert findings["manifest.domain.matches_directory"].status is RuleStatus.FAIL

--- a/tests/test_rules_manifest_domain_match.py
+++ b/tests/test_rules_manifest_domain_match.py
@@ -1,0 +1,148 @@
+"""Tests for manifest.domain.matches_directory rule (PR1, #51).
+
+TDD cycle:
+  - RED: written first, references production code that does not yet exist
+  - GREEN: confirmed after implementation
+"""
+
+from __future__ import annotations
+
+import json
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RULE_ID = "manifest.domain.matches_directory"
+
+
+def _write_integration(
+    root, *, dir_name: str, manifest: dict | None, raw_json: str | None = None
+) -> None:
+    """Create custom_components/<dir_name>/ with an optional manifest.json."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+    if raw_json is not None:
+        (integration / "manifest.json").write_text(raw_json, encoding="utf-8")
+    elif manifest is not None:
+        (integration / "manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+
+def _findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+# ---------------------------------------------------------------------------
+# Subtask 1.11: Explain reachability — rule is registered with non-empty why
+# ---------------------------------------------------------------------------
+
+
+def test_rule_is_registered_with_non_empty_why() -> None:
+    rule = RULES_BY_ID[RULE_ID]
+    assert rule.id == RULE_ID
+    assert rule.overridable is False
+    assert str(rule.severity) == "required"
+    assert rule.version == "1.0.0"
+    assert rule.why, "why field must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# Subtask 1.4 / 1.6: PASS when domain matches directory name
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_domain_matches_directory(tmp_path) -> None:
+    _write_integration(
+        tmp_path,
+        dir_name="my_light",
+        manifest={
+            "domain": "my_light",
+            "name": "My Light",
+            "documentation": "https://example.com",
+            "issue_tracker": "https://example.com/issues",
+            "codeowners": ["@demo"],
+            "version": "0.1.0",
+        },
+    )
+
+    findings = _findings_for(tmp_path)
+
+    assert findings[RULE_ID].status is RuleStatus.PASS
+    assert "my_light" in findings[RULE_ID].message
+
+
+# ---------------------------------------------------------------------------
+# FAIL when domain differs from directory name
+# ---------------------------------------------------------------------------
+
+
+def test_fail_when_domain_does_not_match_directory(tmp_path) -> None:
+    _write_integration(
+        tmp_path,
+        dir_name="my_light",
+        manifest={
+            "domain": "wrong_light",
+            "name": "Wrong Light",
+            "documentation": "https://example.com",
+            "issue_tracker": "https://example.com/issues",
+            "codeowners": ["@demo"],
+            "version": "0.1.0",
+        },
+    )
+
+    findings = _findings_for(tmp_path)
+
+    assert findings[RULE_ID].status is RuleStatus.FAIL
+    assert "wrong_light" in findings[RULE_ID].message
+    assert "my_light" in findings[RULE_ID].message
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE when no integration directory
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_no_integration_path(tmp_path) -> None:
+    # No custom_components/ directory at all
+    findings = _findings_for(tmp_path)
+
+    assert findings[RULE_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE when manifest is absent
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_manifest_missing(tmp_path) -> None:
+    # Integration directory exists but no manifest.json
+    integration = tmp_path / "custom_components" / "my_light"
+    integration.mkdir(parents=True)
+
+    findings = _findings_for(tmp_path)
+
+    assert findings[RULE_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# FAIL when manifest exists but cannot be parsed
+# ---------------------------------------------------------------------------
+
+
+def test_fail_when_manifest_is_invalid_json(tmp_path) -> None:
+    _write_integration(
+        tmp_path,
+        dir_name="my_light",
+        manifest=None,
+        raw_json="{invalid json here",
+    )
+
+    findings = _findings_for(tmp_path)
+
+    assert findings[RULE_ID].status is RuleStatus.FAIL

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 18 rules total, 10 locked overridable=False, 8 overridable=True.
+# 19 rules total (v0.8 adds manifest.domain.matches_directory),
+# 11 locked overridable=False, 8 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -24,6 +25,7 @@ EXPECTED_LOCKED_RULE_IDS = {
     "manifest.documentation.exists",
     "manifest.issue_tracker.exists",
     "manifest.codeowners.exists",
+    "manifest.domain.matches_directory",  # v0.8 PR1 — non-overridable REQUIRED
     "config_flow.manifest_flag_consistent",
 }
 
@@ -39,8 +41,8 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
 }
 
 
-def test_total_rule_count_is_eighteen() -> None:
-    assert len(RULES) == 18, f"expected 18 rules, got {len(RULES)}"
+def test_total_rule_count_is_nineteen() -> None:
+    assert len(RULES) == 19, f"expected 19 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

PR 1 of 4 for **Theme A — rule depth** (v0.8.0). Closes the foundation that subsequent rule-expansion PRs build on.

- **`chore(rules)`** — bumps `DEFAULT_RULESET_ID` from `hasscheck-ha-2026.4` → `hasscheck-ha-2026.5` per ADR 0006 (new rules added in this batch and follow-ups).
- **`test(fixtures)`** — adds the tracked `examples/bad_integration/` fixture promised by the README. Sparse, deterministic, demonstrates failing rules without being noisy.
- **`feat(rules)`** — implements `manifest.domain.matches_directory`: required-severity, non-overridable rule that catches the most common identity drift in HA integrations.

Closes #50, #51.

## Rule details

| Field | Value |
|-------|-------|
| ID | \`manifest.domain.matches_directory\` |
| Category | \`manifest_metadata\` |
| Severity | \`required\` |
| Overridable | \`false\` (identity correctness, not preference) |
| Status | PASS on match · FAIL on mismatch · NOT_APPLICABLE without manifest/integration · FAIL on parse error |

## Test plan

- [x] \`uv run pytest --ignore=tests/test_check_version.py\` — 366 passing (8 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD across all 3 commits (RED → GREEN per commit)
- [x] \`uv run hasscheck explain manifest.domain.matches_directory\` — exits 0, prints rule
- [x] \`uv run hasscheck check --path examples/bad_integration\` — deterministic FAIL on \`manifest.domain.matches_directory\`
- [x] Whitelist test asserts only the new rule's FAIL on the fixture (per design — keeps the fixture stable as more rules land in PRs 2-4)

## Notes

- The fixture also triggers \`config_flow.manifest_flag_consistent\` FAIL because \`manifest.json\` has \`config_flow: true\` with no \`config_flow.py\` present. This is intentional fixture behavior — it IS a bad integration. The whitelist test only asserts \`manifest.domain.matches_directory\`, so future rules can ride on the same fixture without test churn.
- Pre-existing pylance warnings on \`_read_manifest\` and \`manifest.codeowners.exists\` are confirmed identical on \`origin/main\`. Not introduced by this PR. Track separately as type-narrowing cleanup.
- README "Current rule set" updated; the rule is reachable via \`hasscheck explain\`.

## Sequencing

| PR | Issue(s) | Branch |
|----|----------|--------|
| 1 (this) | #50, #51 | \`feat/v0-8-rule-depth-pr1\` |
| 2 (next) | #52 — manifest.iot_class.{exists,valid} + manifest.integration_type.{exists,valid} | TBD — gate: research canonical HA docs URL |
| 3 | #54 — config_flow.user_step.exists (introduces inline AST helper) | TBD |
| 4 | #53 — diagnostics.redaction.used (AST + suspicious-return + local-helper regex) | TBD |

## SDD artifacts

Planned via SDD with engram persistence:
- explore: 394 → proposal: 396 → spec: 397 → design: 398 → tasks: 399 → apply / verify: 417/418