### PR TITLE
feat(v0.8): rule-depth PR 2/4 — manifest iot_class + integration_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ The exact category order may change as rules evolve. The JSON schema is the dura
 | `manifest.documentation.exists` | Manifest defines `documentation`. |
 | `manifest.issue_tracker.exists` | Manifest defines `issue_tracker`. |
 | `manifest.codeowners.exists` | Manifest defines non-empty `codeowners`. |
+| `manifest.iot_class.exists` | Manifest declares `iot_class`. |
+| `manifest.iot_class.valid` | Manifest `iot_class` is a recognized value. |
+| `manifest.integration_type.exists` | Manifest declares `integration_type`. |
+| `manifest.integration_type.valid` | Manifest `integration_type` is a recognized value. |
 
 ### Modern Home Assistant patterns
 

--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -18,6 +18,47 @@ from hasscheck.rules.base import ProjectContext, RuleDefinition
 HACS_INTEGRATION_SOURCE = "https://www.hacs.xyz/docs/publish/integration/"
 CATEGORY = "manifest_metadata"
 
+# ---------------------------------------------------------------------------
+# PR2 (#52) — iot_class + integration_type enum constants
+# Source: https://developers.home-assistant.io/docs/creating_integration_manifest
+# Source-checked-at: 2026-05-01
+# ---------------------------------------------------------------------------
+
+_HA_DEV_DOCS_URL = (
+    "https://developers.home-assistant.io/docs/creating_integration_manifest"
+)
+_SOURCE_CHECKED_AT = "2026-05-01"
+
+# Canonical iot_class values — anchor #iot-class
+# Source: https://developers.home-assistant.io/docs/creating_integration_manifest#iot-class
+# Verified: 2026-05-01
+_VALID_IOT_CLASSES: frozenset[str] = frozenset(
+    {
+        "assumed_state",
+        "calculated",
+        "cloud_polling",
+        "cloud_push",
+        "local_polling",
+        "local_push",
+    }
+)
+
+# Canonical integration_type values — anchor #integration-type
+# Source: https://developers.home-assistant.io/docs/creating_integration_manifest#integration-type
+# Verified: 2026-05-01
+_VALID_INTEGRATION_TYPES: frozenset[str] = frozenset(
+    {
+        "device",
+        "entity",
+        "hardware",
+        "helper",
+        "hub",
+        "service",
+        "system",
+        "virtual",
+    }
+)
+
 
 def _manifest_path(context: ProjectContext):
     if context.integration_path is None:
@@ -349,6 +390,292 @@ def manifest_domain_matches_directory(context: ProjectContext) -> Finding:
     )
 
 
+# ---------------------------------------------------------------------------
+# PR2 (#52) — _required_enum_field_rule factory
+# Generates both the *.exists and *.valid variants for a manifest field
+# that must belong to a known frozenset of string values.
+# ---------------------------------------------------------------------------
+
+
+def _required_enum_field_rule(
+    *,
+    exists_rule_id: str,
+    valid_rule_id: str,
+    field_name: str,
+    exists_title: str,
+    valid_title: str,
+    exists_warn_message: str,
+    valid_values: frozenset[str],
+    valid_sorted_display: str,
+    fix_exists_summary: str,
+    fix_valid_summary: str,
+    # why_exists and why_valid are used in RuleDefinition directly — not inside checks
+    why_exists: str = "",
+    why_valid: str = "",
+) -> tuple[Callable[[ProjectContext], Finding], Callable[[ProjectContext], Finding]]:
+    """Return (exists_check, valid_check) for a manifest enum field.
+
+    exists semantics:
+      - NOT_APPLICABLE if no manifest (missing or no integration path)
+      - FAIL if manifest JSON is broken
+      - PASS if field is present (any non-empty string)
+      - WARN if field is absent
+
+    valid semantics:
+      - NOT_APPLICABLE if no manifest OR field is absent
+      - PASS if field value is in valid_values
+      - FAIL if field value is present but not in valid_values
+    """
+
+    def exists_check(context: ProjectContext) -> Finding:
+        path = _manifest_path(context)
+        display = _manifest_display_path(context)
+
+        if path is None or not path.is_file():
+            return Finding(
+                rule_id=exists_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.NOT_APPLICABLE,
+                severity=RuleSeverity.RECOMMENDED,
+                title=exists_title,
+                message=f"manifest.json is missing, so the {field_name} field cannot be inspected yet.",
+                applicability=Applicability(
+                    status=ApplicabilityStatus.NOT_APPLICABLE,
+                    reason=f"manifest.json must exist before HassCheck can inspect manifest.{field_name}.",
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=FixSuggestion(summary=fix_exists_summary),
+                path="custom_components/<domain>/manifest.json",
+            )
+
+        payload, error = _read_manifest(context)
+        if error is not None:
+            return Finding(
+                rule_id=exists_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.FAIL,
+                severity=RuleSeverity.RECOMMENDED,
+                title=exists_title,
+                message=f"manifest.json is not valid JSON: {error}.",
+                applicability=Applicability(
+                    reason="manifest.json exists but cannot be parsed."
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=FixSuggestion(
+                    summary="Fix manifest.json syntax, then rerun HassCheck."
+                ),
+                path=display,
+            )
+
+        value = payload.get(field_name) if payload else None
+        is_present = isinstance(value, str) and bool(value.strip())
+
+        if is_present:
+            return Finding(
+                rule_id=exists_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.PASS,
+                severity=RuleSeverity.RECOMMENDED,
+                title=exists_title,
+                message=f"manifest.json declares {field_name}.",
+                applicability=Applicability(
+                    reason=f"Declaring {field_name} classifies the integration for Home Assistant discovery."
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=None,
+                path=display,
+            )
+
+        return Finding(
+            rule_id=exists_rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title=exists_title,
+            message=exists_warn_message,
+            applicability=Applicability(
+                reason=f"Declaring {field_name} is recommended for Home Assistant integrations."
+            ),
+            source=RuleSource(url=_HA_DEV_DOCS_URL),
+            fix=FixSuggestion(summary=fix_exists_summary),
+            path=display,
+        )
+
+    def valid_check(context: ProjectContext) -> Finding:
+        path = _manifest_path(context)
+        display = _manifest_display_path(context)
+
+        if path is None or not path.is_file():
+            return Finding(
+                rule_id=valid_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.NOT_APPLICABLE,
+                severity=RuleSeverity.RECOMMENDED,
+                title=valid_title,
+                message=f"manifest.json is missing, so the {field_name} field cannot be validated.",
+                applicability=Applicability(
+                    status=ApplicabilityStatus.NOT_APPLICABLE,
+                    reason=f"manifest.json must exist before HassCheck can validate manifest.{field_name}.",
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=FixSuggestion(summary=fix_exists_summary),
+                path="custom_components/<domain>/manifest.json",
+            )
+
+        payload, error = _read_manifest(context)
+        if error is not None:
+            # Broken manifest: exists rule FAILs, valid rule is NOT_APPLICABLE
+            return Finding(
+                rule_id=valid_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.NOT_APPLICABLE,
+                severity=RuleSeverity.RECOMMENDED,
+                title=valid_title,
+                message=f"manifest.json could not be parsed; {field_name} validation is skipped.",
+                applicability=Applicability(
+                    status=ApplicabilityStatus.NOT_APPLICABLE,
+                    reason="manifest.json must be valid JSON before field values can be validated.",
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=FixSuggestion(
+                    summary="Fix manifest.json syntax, then rerun HassCheck."
+                ),
+                path=display,
+            )
+
+        value = payload.get(field_name) if payload else None
+
+        if not isinstance(value, str) or not value.strip():
+            # Field absent → not applicable for the valid rule
+            return Finding(
+                rule_id=valid_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.NOT_APPLICABLE,
+                severity=RuleSeverity.RECOMMENDED,
+                title=valid_title,
+                message=f"manifest.json does not declare {field_name}; value validation is skipped.",
+                applicability=Applicability(
+                    status=ApplicabilityStatus.NOT_APPLICABLE,
+                    reason=f"manifest.{field_name} must be present before its value can be validated.",
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=FixSuggestion(summary=fix_exists_summary),
+                path=display,
+            )
+
+        if value in valid_values:
+            return Finding(
+                rule_id=valid_rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.PASS,
+                severity=RuleSeverity.RECOMMENDED,
+                title=valid_title,
+                message=f'manifest.json {field_name} "{value}" is a recognized value.',
+                applicability=Applicability(
+                    reason=f"manifest.{field_name} must be one of the values defined in the HA integration manifest docs."
+                ),
+                source=RuleSource(url=_HA_DEV_DOCS_URL),
+                fix=None,
+                path=display,
+            )
+
+        return Finding(
+            rule_id=valid_rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.FAIL,
+            severity=RuleSeverity.RECOMMENDED,
+            title=valid_title,
+            message=(
+                f'manifest.json {field_name} "{value}" is not a recognized value '
+                f"(expected one of: {valid_sorted_display})."
+            ),
+            applicability=Applicability(
+                reason=f"manifest.{field_name} must be one of the values defined in the HA integration manifest docs."
+            ),
+            source=RuleSource(url=_HA_DEV_DOCS_URL),
+            fix=FixSuggestion(summary=fix_valid_summary),
+            path=display,
+        )
+
+    return exists_check, valid_check
+
+
+_IOT_CLASS_EXISTS_WHY = (
+    "iot_class describes how the integration fetches data (polling vs. push, "
+    "cloud vs. local). Home Assistant uses this value to set user expectations "
+    "about connectivity and latency. "
+    f"Source: {_HA_DEV_DOCS_URL} (verified {_SOURCE_CHECKED_AT})."
+)
+_IOT_CLASS_VALID_WHY = (
+    "iot_class must be one of the canonical values defined in the Home Assistant "
+    "integration manifest docs. An unrecognised value may cause HA to silently "
+    "ignore the field or display incorrect information. "
+    f"Source: {_HA_DEV_DOCS_URL} (verified {_SOURCE_CHECKED_AT})."
+)
+_INTEGRATION_TYPE_EXISTS_WHY = (
+    "integration_type classifies how the integration fits into the Home Assistant "
+    "architecture (hub, device, helper, etc.). Required for integrations with a "
+    "config flow; custom integrations default to 'hub' when omitted. "
+    f"Source: {_HA_DEV_DOCS_URL} (verified {_SOURCE_CHECKED_AT})."
+)
+_INTEGRATION_TYPE_VALID_WHY = (
+    "integration_type must be one of the canonical values defined in the Home Assistant "
+    "integration manifest docs. An unrecognised value is rejected by the core manifest "
+    "loader in newer HA versions. "
+    f"Source: {_HA_DEV_DOCS_URL} (verified {_SOURCE_CHECKED_AT})."
+)
+
+_iot_class_exists_check, _iot_class_valid_check = _required_enum_field_rule(
+    exists_rule_id="manifest.iot_class.exists",
+    valid_rule_id="manifest.iot_class.valid",
+    field_name="iot_class",
+    exists_title="manifest.json declares iot_class",
+    valid_title="manifest.json iot_class is a recognized value",
+    exists_warn_message=(
+        "manifest.json does not declare iot_class; recommended for Home Assistant integrations."
+    ),
+    valid_values=_VALID_IOT_CLASSES,
+    valid_sorted_display="assumed_state, calculated, cloud_polling, cloud_push, local_polling, local_push",
+    fix_exists_summary="Add an iot_class field to manifest.json.",
+    fix_valid_summary=(
+        "Set iot_class to one of: assumed_state, calculated, cloud_polling, "
+        "cloud_push, local_polling, local_push."
+    ),
+    why_exists=_IOT_CLASS_EXISTS_WHY,
+    why_valid=_IOT_CLASS_VALID_WHY,
+)
+
+_integration_type_exists_check, _integration_type_valid_check = (
+    _required_enum_field_rule(
+        exists_rule_id="manifest.integration_type.exists",
+        valid_rule_id="manifest.integration_type.valid",
+        field_name="integration_type",
+        exists_title="manifest.json declares integration_type",
+        valid_title="manifest.json integration_type is a recognized value",
+        exists_warn_message=(
+            "manifest.json does not declare integration_type; recommended for Home Assistant integrations."
+        ),
+        valid_values=_VALID_INTEGRATION_TYPES,
+        valid_sorted_display="device, entity, hardware, helper, hub, service, system, virtual",
+        fix_exists_summary="Add an integration_type field to manifest.json.",
+        fix_valid_summary=(
+            "Set integration_type to one of: device, entity, hardware, helper, hub, service, system, virtual."
+        ),
+        why_exists=_INTEGRATION_TYPE_EXISTS_WHY,
+        why_valid=_INTEGRATION_TYPE_VALID_WHY,
+    )
+)
+
+
 def manifest_exists(context: ProjectContext) -> Finding:
     path = _manifest_path(context)
     exists = path is not None and path.is_file()
@@ -471,5 +798,50 @@ RULES = [
         source_url=HA_MANIFEST_DOCS_URL,
         check=manifest_domain_matches_directory,
         overridable=False,
+    ),
+    # PR2 (#52) — iot_class and integration_type validation
+    RuleDefinition(
+        id="manifest.iot_class.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json declares iot_class",
+        why=_IOT_CLASS_EXISTS_WHY,
+        source_url=_HA_DEV_DOCS_URL,
+        check=_iot_class_exists_check,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="manifest.iot_class.valid",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json iot_class is a recognized value",
+        why=_IOT_CLASS_VALID_WHY,
+        source_url=_HA_DEV_DOCS_URL,
+        check=_iot_class_valid_check,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="manifest.integration_type.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json declares integration_type",
+        why=_INTEGRATION_TYPE_EXISTS_WHY,
+        source_url=_HA_DEV_DOCS_URL,
+        check=_integration_type_exists_check,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="manifest.integration_type.valid",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json integration_type is a recognized value",
+        why=_INTEGRATION_TYPE_VALID_WHY,
+        source_url=_HA_DEV_DOCS_URL,
+        check=_integration_type_valid_check,
+        overridable=True,
     ),
 ]

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -30,3 +30,23 @@ def test_domain_mismatch_rule_fails_on_bad_integration_fixture() -> None:
     """Fixture declares domain 'wrong_domain' but directory is 'demo_bad' — must FAIL."""
     findings = _findings_by_id()
     assert findings["manifest.domain.matches_directory"].status is RuleStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# PR2: iot_class.valid must FAIL (fixture has iot_class: "not_a_valid_class")
+#       integration_type.exists must WARN (fixture has no integration_type)
+# ---------------------------------------------------------------------------
+
+
+def test_iot_class_valid_fails_on_bad_integration_fixture() -> None:
+    """Fixture has iot_class='not_a_valid_class' — must FAIL."""
+    findings = _findings_by_id()
+    f = findings["manifest.iot_class.valid"]
+    assert f.status is RuleStatus.FAIL
+    assert "not_a_valid_class" in f.message
+
+
+def test_integration_type_exists_warns_on_bad_integration_fixture() -> None:
+    """Fixture has no integration_type field — must WARN."""
+    findings = _findings_by_id()
+    assert findings["manifest.integration_type.exists"].status is RuleStatus.WARN

--- a/tests/test_rules_manifest_metadata.py
+++ b/tests/test_rules_manifest_metadata.py
@@ -1,0 +1,249 @@
+"""Tests for manifest.iot_class.{exists,valid} and manifest.integration_type.{exists,valid} (PR2, #52).
+
+TDD cycle:
+  - RED: written first, references production code that does not yet exist
+  - GREEN: confirmed after implementation
+
+Spec: sdd/v0-8-rule-depth/spec — Domain: manifest-rules (#52)
+Design: D5 (frozensets), D7 (exact message strings)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    root, manifest: dict | None, *, raw_json: str | None = None
+) -> None:
+    """Create custom_components/test_integration/manifest.json."""
+    integration = root / "custom_components" / "test_integration"
+    integration.mkdir(parents=True)
+    if raw_json is not None:
+        (integration / "manifest.json").write_text(raw_json, encoding="utf-8")
+    elif manifest is not None:
+        (integration / "manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+
+def _base_manifest(**extra) -> dict:
+    """Minimal valid manifest with overridable fields."""
+    return {
+        "domain": "test_integration",
+        "name": "Test Integration",
+        "documentation": "https://example.com",
+        "issue_tracker": "https://example.com/issues",
+        "codeowners": ["@test"],
+        "version": "0.1.0",
+        **extra,
+    }
+
+
+def _findings_for(root):
+    return {finding.rule_id: finding for finding in run_check(root).findings}
+
+
+# ---------------------------------------------------------------------------
+# Rule registration: all four rules must be present in the registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "manifest.iot_class.exists",
+        "manifest.iot_class.valid",
+        "manifest.integration_type.exists",
+        "manifest.integration_type.valid",
+    ],
+)
+def test_rule_is_registered(rule_id: str) -> None:
+    rule = RULES_BY_ID[rule_id]
+    assert rule.id == rule_id
+    assert rule.version == "1.0.0"
+    assert rule.category == "manifest_metadata"
+    assert str(rule.severity) == "recommended"
+    assert rule.overridable is True
+    assert rule.why, f"{rule_id}.why must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# manifest.iot_class.exists
+# ---------------------------------------------------------------------------
+
+IOT_CLASS_EXISTS_ID = "manifest.iot_class.exists"
+
+
+def test_iot_class_exists_pass_when_field_present(tmp_path) -> None:
+    """PASS when iot_class is present (any non-empty value)."""
+    _write_manifest(tmp_path, _base_manifest(iot_class="local_polling"))
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_EXISTS_ID].status is RuleStatus.PASS
+
+
+def test_iot_class_exists_warn_when_field_missing(tmp_path) -> None:
+    """WARN when iot_class is absent."""
+    _write_manifest(tmp_path, _base_manifest())
+    findings = _findings_for(tmp_path)
+    f = findings[IOT_CLASS_EXISTS_ID]
+    assert f.status is RuleStatus.WARN
+    assert "iot_class" in f.message
+
+
+def test_iot_class_exists_not_applicable_when_no_manifest(tmp_path) -> None:
+    """NOT_APPLICABLE when there is no manifest.json."""
+    # No custom_components directory at all
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_EXISTS_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_iot_class_exists_fail_when_manifest_is_invalid_json(tmp_path) -> None:
+    """FAIL when manifest.json exists but cannot be parsed."""
+    _write_manifest(tmp_path, None, raw_json="{invalid json here")
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_EXISTS_ID].status is RuleStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# manifest.iot_class.valid
+# ---------------------------------------------------------------------------
+
+IOT_CLASS_VALID_ID = "manifest.iot_class.valid"
+
+VALID_IOT_CLASSES = [
+    "assumed_state",
+    "calculated",
+    "cloud_polling",
+    "cloud_push",
+    "local_polling",
+    "local_push",
+]
+
+
+@pytest.mark.parametrize("value", VALID_IOT_CLASSES)
+def test_iot_class_valid_pass_for_valid_value(tmp_path, value: str) -> None:
+    """PASS for every value in the canonical frozenset."""
+    _write_manifest(tmp_path, _base_manifest(iot_class=value))
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_VALID_ID].status is RuleStatus.PASS
+
+
+def test_iot_class_valid_fail_for_invalid_value(tmp_path) -> None:
+    """FAIL when iot_class is present but not in the allowed set."""
+    _write_manifest(tmp_path, _base_manifest(iot_class="made_up_class"))
+    findings = _findings_for(tmp_path)
+    f = findings[IOT_CLASS_VALID_ID]
+    assert f.status is RuleStatus.FAIL
+    assert "made_up_class" in f.message
+    # D7 exact substring: "is not a recognized value"
+    assert "is not a recognized value" in f.message
+
+
+def test_iot_class_valid_not_applicable_when_field_absent(tmp_path) -> None:
+    """NOT_APPLICABLE when iot_class is absent (field not in manifest)."""
+    _write_manifest(tmp_path, _base_manifest())
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_VALID_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_iot_class_valid_not_applicable_when_no_manifest(tmp_path) -> None:
+    """NOT_APPLICABLE when there is no manifest.json."""
+    findings = _findings_for(tmp_path)
+    assert findings[IOT_CLASS_VALID_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# manifest.integration_type.exists
+# ---------------------------------------------------------------------------
+
+INTEGRATION_TYPE_EXISTS_ID = "manifest.integration_type.exists"
+
+
+def test_integration_type_exists_pass_when_field_present(tmp_path) -> None:
+    """PASS when integration_type is present (any non-empty value)."""
+    _write_manifest(tmp_path, _base_manifest(integration_type="hub"))
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_EXISTS_ID].status is RuleStatus.PASS
+
+
+def test_integration_type_exists_warn_when_field_missing(tmp_path) -> None:
+    """WARN when integration_type is absent."""
+    _write_manifest(tmp_path, _base_manifest())
+    findings = _findings_for(tmp_path)
+    f = findings[INTEGRATION_TYPE_EXISTS_ID]
+    assert f.status is RuleStatus.WARN
+    assert "integration_type" in f.message
+
+
+def test_integration_type_exists_not_applicable_when_no_manifest(tmp_path) -> None:
+    """NOT_APPLICABLE when there is no manifest.json."""
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_EXISTS_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_integration_type_exists_fail_when_manifest_is_invalid_json(tmp_path) -> None:
+    """FAIL when manifest.json exists but cannot be parsed."""
+    _write_manifest(tmp_path, None, raw_json="{invalid json here")
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_EXISTS_ID].status is RuleStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# manifest.integration_type.valid
+# ---------------------------------------------------------------------------
+
+INTEGRATION_TYPE_VALID_ID = "manifest.integration_type.valid"
+
+VALID_INTEGRATION_TYPES = [
+    "device",
+    "entity",
+    "hardware",
+    "helper",
+    "hub",
+    "service",
+    "system",
+    "virtual",
+]
+
+
+@pytest.mark.parametrize("value", VALID_INTEGRATION_TYPES)
+def test_integration_type_valid_pass_for_valid_value(tmp_path, value: str) -> None:
+    """PASS for every value in the canonical frozenset."""
+    _write_manifest(tmp_path, _base_manifest(integration_type=value))
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_VALID_ID].status is RuleStatus.PASS
+
+
+def test_integration_type_valid_fail_for_invalid_value(tmp_path) -> None:
+    """FAIL when integration_type is present but not in the allowed set."""
+    _write_manifest(tmp_path, _base_manifest(integration_type="fake_type"))
+    findings = _findings_for(tmp_path)
+    f = findings[INTEGRATION_TYPE_VALID_ID]
+    assert f.status is RuleStatus.FAIL
+    assert "fake_type" in f.message
+    # D7 exact substring: "is not a recognized value"
+    assert "is not a recognized value" in f.message
+
+
+def test_integration_type_valid_not_applicable_when_field_absent(tmp_path) -> None:
+    """NOT_APPLICABLE when integration_type is absent."""
+    _write_manifest(tmp_path, _base_manifest())
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_VALID_ID].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_integration_type_valid_not_applicable_when_no_manifest(tmp_path) -> None:
+    """NOT_APPLICABLE when there is no manifest.json."""
+    findings = _findings_for(tmp_path)
+    assert findings[INTEGRATION_TYPE_VALID_ID].status is RuleStatus.NOT_APPLICABLE

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 19 rules total (v0.8 adds manifest.domain.matches_directory),
-# 11 locked overridable=False, 8 overridable=True.
+# 23 rules total (v0.8 PR2 adds 4 manifest metadata rules):
+#   - manifest.iot_class.exists (overridable=True, RECOMMENDED)
+#   - manifest.iot_class.valid (overridable=True, RECOMMENDED)
+#   - manifest.integration_type.exists (overridable=True, RECOMMENDED)
+#   - manifest.integration_type.valid (overridable=True, RECOMMENDED)
+# 11 locked overridable=False, 12 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -38,11 +42,16 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "repo.license.exists",
     "tests.folder.exists",
     "ci.github_actions.exists",
+    # v0.8 PR2 — manifest metadata validation (RECOMMENDED, overridable=True)
+    "manifest.iot_class.exists",
+    "manifest.iot_class.valid",
+    "manifest.integration_type.exists",
+    "manifest.integration_type.valid",
 }
 
 
-def test_total_rule_count_is_nineteen() -> None:
-    assert len(RULES) == 19, f"expected 19 rules, got {len(RULES)}"
+def test_total_rule_count_is_twenty_three() -> None:
+    assert len(RULES) == 23, f"expected 23 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

PR 2 of 4 for **Theme A — rule depth** (v0.8.0). Adds four manifest metadata rules that validate \`iot_class\` and \`integration_type\` per the canonical Home Assistant developer docs.

> #86 (PR 1/4) merged just before this PR opened — base is now \`main\`. The diff below should show only PR2's contribution.

Closes #52.

## Rules added

| ID | Semantics |
|----|-----------|
| \`manifest.iot_class.exists\` | NOT_APPLICABLE (no manifest) · PASS (present) · WARN (missing) · FAIL (parse error) |
| \`manifest.iot_class.valid\` | NOT_APPLICABLE (no manifest / field absent) · PASS (in allowed set) · FAIL (not in allowed set) |
| \`manifest.integration_type.exists\` | same shape as iot_class.exists |
| \`manifest.integration_type.valid\` | same shape as iot_class.valid |

All four: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=manifest_metadata\`.

## Allowed values (verified against HA dev docs)

Source: https://developers.home-assistant.io/docs/creating_integration_manifest (\`source_checked_at = "2026-05-01"\`)

- **\`iot_class\`** (6): \`assumed_state, calculated, cloud_polling, cloud_push, local_polling, local_push\`
- **\`integration_type\`** (8): \`device, entity, hardware, helper, hub, service, system, virtual\`

Stored as module-level frozenset constants (\`_VALID_IOT_CLASSES\`, \`_VALID_INTEGRATION_TYPES\`) with \`_SOURCE_CHECKED_AT\` next to them. Per ADR 0009 this is additive — no schema change.

## Test plan

- [x] \`uv run pytest --ignore=tests/test_check_version.py\` — **400 passing** (32 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: RED → GREEN per rule
- [x] \`uv run hasscheck explain manifest.{iot_class,integration_type}.{exists,valid}\` — all four exit 0, prints rule + source URL + verified date
- [x] \`uv run hasscheck check --path examples/bad_integration\` — \`manifest.iot_class.valid\` FAIL (\`"not_a_valid_class"\`) + \`manifest.integration_type.exists\` WARN — deterministic
- [x] Whitelist test (\`tests/test_examples_bad_integration.py\`) extended with 2 new assertions

## Notes

- Rule count audit (\`tests/test_rules_meta.py\`): 19 → 23. Locked count unchanged (all 4 new rules are overridable).
- README "Current rule set" updated with 4 new rows.
- Single-commit batch — a shared \`_required_enum_field_rule()\` factory keeps both field pairs DRY; splitting commits would have been artificial.
- Pre-existing pylance type-narrowing warnings on \`_read_manifest\` and \`manifest.codeowners.exists\` are unchanged. Not introduced here.

## Sequencing

| PR | Issue(s) | Status |
|----|----------|--------|
| 1 | #50, #51 | #86 merged |
| **2 (this)** | **#52** | **this PR** |
| 3 | #54 — config_flow.user_step.exists | queued (introduces inline AST helper) |
| 4 | #53 — diagnostics.redaction.used | queued |

## SDD artifacts

- explore: 394 → proposal: 396 → spec: 397 → design: 398 → tasks: 399
- enums research: 420 (verified canonical URL + values)
- apply / verify: 421 / 418 (PR2 section appended to existing report)