### PR TITLE
feat(v0.8): rule-depth PR 3/4 — config_flow.user_step.exists (AST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The exact category order may change as rules evolve. The JSON schema is the dura
 | --- | --- |
 | `config_flow.file.exists` | Integration has `config_flow.py`. |
 | `config_flow.manifest_flag_consistent` | `config_flow.py` and manifest `config_flow: true` agree. |
+| `config_flow.user_step.exists` | `config_flow.py` defines `async_step_user` (AST inspection). |
 
 ### Diagnostics and repairs
 

--- a/examples/bad_integration/custom_components/demo_bad/config_flow.py
+++ b/examples/bad_integration/custom_components/demo_bad/config_flow.py
@@ -1,0 +1,20 @@
+"""Intentionally defective config flow — triggers config_flow.user_step.exists WARN.
+
+This file defines an async setup step named `async_step_setup` instead of the
+required `async_step_user`. Home Assistant requires `async_step_user` as the
+entry point for user-initiated config flow setup.
+
+See: examples/bad_integration/README.md for the full list of intentional defects.
+"""
+
+from __future__ import annotations
+
+
+class DemoBadConfigFlow:
+    """Config flow that intentionally omits async_step_user."""
+
+    VERSION = 1
+
+    async def async_step_setup(self, user_input=None):
+        """Wrong step name — should be async_step_user."""
+        return {}

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -21,6 +21,7 @@ APPLICABILITY_FLAGS_BY_RULE = {
     "repairs.file.exists": "has_user_fixable_repairs",
     "config_flow.file.exists": "uses_config_flow",
     "config_flow.manifest_flag_consistent": "uses_config_flow",
+    "config_flow.user_step.exists": "uses_config_flow",
 }
 
 CATEGORY_LABELS = {

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 
 from hasscheck.models import (
@@ -17,6 +19,12 @@ from hasscheck.rules.base import ProjectContext, RuleDefinition
 CATEGORY = "modern_ha_patterns"
 CONFIG_FLOW_SOURCE = (
     "https://developers.home-assistant.io/docs/core/integration/config_flow"
+)
+# Source: https://developers.home-assistant.io/docs/config_entries_config_flow_handler/
+# _SOURCE_CHECKED_AT = "2026-05-01"
+USER_STEP_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_config_flow_handler/"
+    "#defining-the-flow"
 )
 MANIFEST_SOURCE = (
     "https://developers.home-assistant.io/docs/creating_integration_manifest"
@@ -55,6 +63,167 @@ def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str 
         return None, "manifest root must be a JSON object"
 
     return payload, None
+
+
+def _parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
+    """Return (parsed_tree, None) on success, (None, error_msg) on failure.
+
+    Three states:
+    - (tree, None)  — parsed OK
+    - (None, msg)   — file could not be read or has a syntax error
+    - (None, None)  — file does not exist (caller should check before calling)
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, str(exc)
+    try:
+        return ast.parse(source), None
+    except SyntaxError as exc:
+        return None, exc.msg or "syntax error"
+
+
+def _has_async_function(tree: ast.Module, name: str) -> bool:
+    """Return True if tree contains any AsyncFunctionDef with the given name.
+
+    Uses ast.walk so it finds the function at any nesting depth
+    (module-level or as a class method).
+    """
+    return any(
+        isinstance(node, ast.AsyncFunctionDef) and node.name == name
+        for node in ast.walk(tree)
+    )
+
+
+def config_flow_user_step_exists(context: ProjectContext) -> Finding:
+    """Check that config_flow.py defines async_step_user."""
+    # Guard: no integration directory
+    if context.integration_path is None:
+        return Finding(
+            rule_id="config_flow.user_step.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py defines async_step_user",
+            message="No integration directory was detected.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect config_flow.py.",
+            ),
+            source=RuleSource(url=USER_STEP_SOURCE),
+            fix=None,
+            path="custom_components/<domain>/config_flow.py",
+        )
+
+    config_flow_path = context.integration_path / "config_flow.py"
+
+    # Guard: applicability flag opts out
+    if context.applicability and context.applicability.uses_config_flow is False:
+        return Finding(
+            rule_id="config_flow.user_step.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py defines async_step_user",
+            message="Project config declares this integration does not use config flow UI setup.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares uses_config_flow: false.",
+                source="config",
+            ),
+            source=RuleSource(url=USER_STEP_SOURCE),
+            fix=None,
+            path=_display_path(
+                config_flow_path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
+    # Guard: config_flow.py does not exist
+    if not config_flow_path.is_file():
+        return Finding(
+            rule_id="config_flow.user_step.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py defines async_step_user",
+            message="config_flow.py does not exist; async_step_user presence cannot be checked.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="config_flow.py must exist before this rule can run.",
+            ),
+            source=RuleSource(url=USER_STEP_SOURCE),
+            fix=None,
+            path=_display_path(
+                config_flow_path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
+    # Parse the file
+    tree, error = _parse_module(config_flow_path)
+
+    if error is not None:
+        return Finding(
+            rule_id="config_flow.user_step.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py defines async_step_user",
+            message=f"config_flow.py could not be parsed ({error}); async_step_user presence cannot be determined.",
+            applicability=Applicability(
+                reason="config_flow.py exists but has a syntax error."
+            ),
+            source=RuleSource(url=USER_STEP_SOURCE),
+            fix=FixSuggestion(summary="Fix syntax errors in config_flow.py."),
+            path=_display_path(
+                config_flow_path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
+    # error is None here, so tree must be a parsed Module
+    assert tree is not None
+    if _has_async_function(tree, "async_step_user"):
+        return Finding(
+            rule_id="config_flow.user_step.exists",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS,
+            severity=RuleSeverity.RECOMMENDED,
+            title="config_flow.py defines async_step_user",
+            message="config_flow.py defines async_step_user.",
+            applicability=Applicability(
+                reason="async_step_user is the standard entry point for UI-driven config flow setup."
+            ),
+            source=RuleSource(url=USER_STEP_SOURCE),
+            fix=None,
+            path=_display_path(
+                config_flow_path, context, "custom_components/<domain>/config_flow.py"
+            ),
+        )
+
+    return Finding(
+        rule_id="config_flow.user_step.exists",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py defines async_step_user",
+        message="config_flow.py does not define async_step_user; users cannot start setup from the UI.",
+        applicability=Applicability(
+            reason="async_step_user is the standard entry point for UI-driven config flow setup."
+        ),
+        source=RuleSource(url=USER_STEP_SOURCE),
+        fix=FixSuggestion(
+            summary="Add async_step_user to your ConfigFlow class in config_flow.py.",
+            docs_url=USER_STEP_SOURCE,
+        ),
+        path=_display_path(
+            config_flow_path, context, "custom_components/<domain>/config_flow.py"
+        ),
+    )
 
 
 def config_flow_file_exists(context: ProjectContext) -> Finding:
@@ -302,7 +471,27 @@ def config_flow_manifest_flag_consistent(context: ProjectContext) -> Finding:
     )
 
 
+_USER_STEP_WHY = (
+    "async_step_user is the standard entry point for Home Assistant config flows "
+    "initiated by the user from the UI. Without it, users cannot set up this "
+    "integration from Settings → Devices & Services. "
+    "Note: this rule uses AST inspection and cannot detect async_step_user that is "
+    "defined only in a base class, mixin, or via dynamic attribute assignment — "
+    "those cases will produce a false WARN."
+)
+
 RULES = [
+    RuleDefinition(
+        id="config_flow.user_step.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py defines async_step_user",
+        why=_USER_STEP_WHY,
+        source_url=USER_STEP_SOURCE,
+        check=config_flow_user_step_exists,
+        overridable=True,
+    ),
     RuleDefinition(
         id="config_flow.file.exists",
         version="1.0.0",

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -50,3 +50,17 @@ def test_integration_type_exists_warns_on_bad_integration_fixture() -> None:
     """Fixture has no integration_type field — must WARN."""
     findings = _findings_by_id()
     assert findings["manifest.integration_type.exists"].status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# PR3: config_flow.user_step.exists must WARN (fixture has async_step_setup,
+#       not async_step_user)
+# ---------------------------------------------------------------------------
+
+
+def test_config_flow_user_step_warns_on_bad_integration_fixture() -> None:
+    """Fixture config_flow.py defines async_step_setup but not async_step_user — must WARN."""
+    findings = _findings_by_id()
+    f = findings["config_flow.user_step.exists"]
+    assert f.status is RuleStatus.WARN
+    assert "async_step_user" in f.message

--- a/tests/test_project_applicability_context.py
+++ b/tests/test_project_applicability_context.py
@@ -39,14 +39,16 @@ def test_project_applicability_softens_missing_optional_files(tmp_path: Path) ->
         "repairs.file.exists",
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
+        "config_flow.user_step.exists",  # v0.8 PR3 — also responds to uses_config_flow
     ):
         assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
         assert findings[rule_id].applicability.source == "config"
 
-    assert report.summary.applicability_applied.count == 4
+    assert report.summary.applicability_applied.count == 5
     assert report.summary.applicability_applied.rule_ids == [
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
+        "config_flow.user_step.exists",
         "diagnostics.file.exists",
         "repairs.file.exists",
     ]
@@ -82,7 +84,12 @@ def test_project_applicability_natural_pass_wins(tmp_path: Path) -> None:
         assert findings[rule_id].status is RuleStatus.PASS
         assert findings[rule_id].applicability.source == "default"
 
-    assert report.summary.applicability_applied.count == 0
+    # config_flow.user_step.exists is NOT_APPLICABLE via config even when config_flow.py
+    # exists — per spec, uses_config_flow=False always suppresses user-step inspection.
+    assert findings["config_flow.user_step.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["config_flow.user_step.exists"].applicability.source == "config"
+    # Only config_flow.user_step.exists is suppressed via config in this scenario.
+    assert report.summary.applicability_applied.count == 1
 
 
 def test_project_applicability_does_not_hide_config_flow_mismatch(

--- a/tests/test_rules_config_flow_user_step.py
+++ b/tests/test_rules_config_flow_user_step.py
@@ -1,0 +1,217 @@
+"""Tests for config_flow.user_step.exists rule (PR3, #54).
+
+TDD cycle:
+  - RED: written first, references production code that does not yet exist
+  - GREEN: confirmed after implementation
+
+Spec: sdd/v0-8-rule-depth/spec — Domain: config-flow-rules (#54)
+Design: D1 (AST helpers), D7 (exact message strings)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RULE_ID = "config_flow.user_step.exists"
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "test_integration",
+    manifest: str | None = None,
+    config_flow_src: str | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with optional manifest and config_flow.py."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    # Write a minimal manifest so other rules don't interfere
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0", "config_flow": true}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+
+    if config_flow_src is not None:
+        (integration / "config_flow.py").write_text(config_flow_src, encoding="utf-8")
+
+    return integration
+
+
+def _finding_for(root: Path):
+    return {f.rule_id: f for f in run_check(root).findings}[RULE_ID]
+
+
+# ---------------------------------------------------------------------------
+# Rule registration — explain reachability + metadata
+# ---------------------------------------------------------------------------
+
+
+def test_rule_is_registered() -> None:
+    rule = RULES_BY_ID[RULE_ID]
+    assert rule.id == RULE_ID
+    assert rule.version == "1.0.0"
+    assert rule.category == "modern_ha_patterns"
+    assert str(rule.severity) == "recommended"
+    assert rule.overridable is True
+    assert rule.why, "why must be non-empty"
+
+
+def test_why_mentions_ast_limitation() -> None:
+    """Spec: AST Limitation Documented — why must mention inherited methods."""
+    rule = RULES_BY_ID[RULE_ID]
+    why_lower = rule.why.lower()
+    assert (
+        "inherit" in why_lower or "base class" in why_lower or "mixin" in why_lower
+    ), "why must mention inherited/base-class limitation per spec"
+
+
+# ---------------------------------------------------------------------------
+# PASS: config_flow.py with class-method async_step_user
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_async_step_user_is_class_method(tmp_path: Path) -> None:
+    """Typical pattern: async_step_user defined as a method inside a class."""
+    src = """\
+from homeassistant import config_entries
+
+class DemoConfigFlow(config_entries.ConfigFlow, domain="test_integration"):
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        return self.async_show_form(step_id="user")
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# PASS: async_step_user at module level (rare but allowed)
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_async_step_user_is_at_module_level(tmp_path: Path) -> None:
+    """Edge case: async_step_user as a module-level function, not a method."""
+    src = """\
+async def async_step_user(user_input=None):
+    pass
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# WARN: config_flow.py exists but no async_step_user
+# ---------------------------------------------------------------------------
+
+
+def test_warn_when_async_step_user_absent(tmp_path: Path) -> None:
+    """WARN when config_flow.py exists but async_step_user is not found."""
+    src = """\
+from homeassistant import config_entries
+
+class DemoConfigFlow(config_entries.ConfigFlow, domain="test_integration"):
+    VERSION = 1
+
+    async def async_step_setup(self, user_input=None):
+        return self.async_show_form(step_id="setup")
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "async_step_user" in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN: sync def step_user must NOT match (only AsyncFunctionDef counts)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_def_does_not_match(tmp_path: Path) -> None:
+    """Edge case: sync 'def async_step_user' should NOT count — only async def."""
+    src = """\
+class DemoConfigFlow:
+    def async_step_user(self, user_input=None):
+        pass
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+    f = _finding_for(tmp_path)
+    # Sync def named async_step_user does NOT satisfy the rule
+    assert f.status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: no config_flow.py in integration directory
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_no_config_flow_file(tmp_path: Path) -> None:
+    """No config_flow.py → NOT_APPLICABLE."""
+    _write_integration(tmp_path)  # no config_flow_src
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: no integration directory at all
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_no_integration_directory(tmp_path: Path) -> None:
+    """No custom_components/ → NOT_APPLICABLE."""
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: uses_config_flow=False in hasscheck.yaml applicability
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_uses_config_flow_false(tmp_path: Path) -> None:
+    """Applicability flag uses_config_flow=False → NOT_APPLICABLE even if file exists."""
+    src = """\
+async def async_step_user(user_input=None):
+    pass
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+
+    # Write hasscheck.yaml that declares uses_config_flow: false
+    (tmp_path / "hasscheck.yaml").write_text(
+        "applicability:\n  uses_config_flow: false\n", encoding="utf-8"
+    )
+
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# WARN: syntax error in config_flow.py (parse fails → conservative WARN)
+# ---------------------------------------------------------------------------
+
+
+def test_warn_when_config_flow_has_syntax_error(tmp_path: Path) -> None:
+    """Parse error → WARN with message containing 'could not be parsed'."""
+    src = """\
+def broken(
+    # unclosed parenthesis — invalid Python
+"""
+    _write_integration(tmp_path, config_flow_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "could not be parsed" in f.message

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,12 +13,9 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 23 rules total (v0.8 PR2 adds 4 manifest metadata rules):
-#   - manifest.iot_class.exists (overridable=True, RECOMMENDED)
-#   - manifest.iot_class.valid (overridable=True, RECOMMENDED)
-#   - manifest.integration_type.exists (overridable=True, RECOMMENDED)
-#   - manifest.integration_type.valid (overridable=True, RECOMMENDED)
-# 11 locked overridable=False, 12 overridable=True.
+# 24 rules total (v0.8 PR3 adds 1 config_flow rule):
+#   - config_flow.user_step.exists (overridable=True, RECOMMENDED)
+# 11 locked overridable=False, 13 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -35,6 +32,7 @@ EXPECTED_LOCKED_RULE_IDS = {
 
 EXPECTED_OVERRIDABLE_RULE_IDS = {
     "config_flow.file.exists",
+    "config_flow.user_step.exists",  # v0.8 PR3 — AST inspection (RECOMMENDED, overridable=True)
     "diagnostics.file.exists",
     "repairs.file.exists",
     "brand.icon.exists",
@@ -50,8 +48,8 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
 }
 
 
-def test_total_rule_count_is_twenty_three() -> None:
-    assert len(RULES) == 23, f"expected 23 rules, got {len(RULES)}"
+def test_total_rule_count_is_twenty_four() -> None:
+    assert len(RULES) == 24, f"expected 24 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

PR 3 of 4 for **Theme A — rule depth** (v0.8.0). Introduces the first AST-based rule and the inline \`_parse_module()\` helper that PR4 will mirror.

Closes #54.

## Rule

| Field | Value |
|-------|-------|
| ID | \`config_flow.user_step.exists\` |
| Category | \`modern_ha_patterns\` |
| Severity | \`recommended\` |
| Overridable | \`true\` |
| Status | NOT_APPLICABLE (no integration / no \`config_flow.py\` / \`uses_config_flow=False\`) · PASS (\`async_step_user\` AsyncFunctionDef found) · WARN (file present but function missing) · WARN (parse error — conservative AST stance per design) |

## Helpers introduced (inline, ~25 lines)

- \`_parse_module(path) -> (ast.Module | None, str | None)\` — 3-state parser. **Stable signature — PR4 will copy this verbatim into \`diagnostics.py\`** (per design D1).
- \`_has_async_function(tree, name)\` — \`ast.walk\` based, depth-independent. Finds the function whether it sits at module top-level or as a method on a \`ConfigFlow\` subclass.

Sync \`def async_step_user\` does NOT match — only \`AsyncFunctionDef\`.

## Test plan

- [x] \`uv run pytest --ignore=tests/test_check_version.py\` — **411 passing** (10 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: RED → GREEN per scenario
- [x] \`uv run hasscheck explain config_flow.user_step.exists\` — exits 0, \`why\` mentions mixin/base-class limitation
- [x] \`uv run hasscheck check --path examples/bad_integration\` — \`config_flow.user_step.exists\` WARN deterministic (fixture has \`async_step_setup\`, not \`async_step_user\`)
- [x] Whitelist test (\`tests/test_examples_bad_integration.py\`) extended with PR3 assertion

## Notes

- **Type narrowing on \`_parse_module\` result** — a single \`assert tree is not None\` after the error-handling branch satisfies pylance's correlation-narrowing limitation (the tuple's two elements are independent in the type system). One-line, no behavior change.
- **\`tests/test_project_applicability_context.py\`** count assertions updated: the new rule correctly responds to \`uses_config_flow=False\` suppression (4→5 / 0→1). Spec-correct.
- **Rule count audit** (\`tests/test_rules_meta.py\`): 23 → 24. Locked count unchanged (overridable rule).
- **Future scope (explicitly out)** — duplicate prevention, connection testing, reauth, reconfigure detection. Deferred per #54 issue body.

## Sequencing

| PR | Issue(s) | Status |
|----|----------|--------|
| 1 | #50, #51 | merged |
| 2 | #52 | merged |
| **3 (this)** | **#54** | **this PR** |
| 4 | #53 — diagnostics.redaction.used (will copy \`_parse_module\` from this PR) | queued |

## SDD artifacts

- explore: 394 → proposal: 396 → spec: 397 → design: 398 → tasks: 399
- apply / verify: 422 / 418 (PR3 section appended to existing report)