### PR TITLE
feat(v0.8): rule-depth PR 4/4 — diagnostics.redaction.used (AST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ The exact category order may change as rules evolve. The JSON schema is the dura
 | Rule ID | Signal |
 | --- | --- |
 | `diagnostics.file.exists` | Integration has `diagnostics.py`. |
+| `diagnostics.redaction.used` | `diagnostics.py` uses `async_redact_data` or a local redaction helper (AST inspection). |
 | `repairs.file.exists` | Integration has `repairs.py`. |
 
 ### Docs and maintenance

--- a/examples/bad_integration/custom_components/demo_bad/diagnostics.py
+++ b/examples/bad_integration/custom_components/demo_bad/diagnostics.py
@@ -1,0 +1,25 @@
+"""Intentionally bad diagnostics — returns entry.data without redaction.
+
+This file is part of the bad_integration fixture used by hasscheck tests.
+It intentionally violates best practices so tests can assert WARN findings.
+
+Defect: returns entry.data directly without calling async_redact_data or
+a local redaction helper — triggers diagnostics.redaction.used WARN with
+raw-entry.data wording ("likely exposes secrets").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics — intentionally missing redaction."""
+    # BAD: returns entry.data directly, exposing API keys, tokens, passwords.
+    return entry.data  # type: ignore[return-value]

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -18,6 +18,7 @@ from hasscheck.slug import detect_repo_slug
 
 APPLICABILITY_FLAGS_BY_RULE = {
     "diagnostics.file.exists": "supports_diagnostics",
+    "diagnostics.redaction.used": "supports_diagnostics",
     "repairs.file.exists": "has_user_fixable_repairs",
     "config_flow.file.exists": "uses_config_flow",
     "config_flow.manifest_flag_consistent": "uses_config_flow",

--- a/src/hasscheck/rules/diagnostics.py
+++ b/src/hasscheck/rules/diagnostics.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
 from hasscheck.models import (
     Applicability,
     ApplicabilityStatus,
@@ -14,6 +19,133 @@ from hasscheck.rules.base import ProjectContext, RuleDefinition
 CATEGORY = "diagnostics_repairs"
 DIAGNOSTICS_SOURCE = (
     "https://developers.home-assistant.io/docs/core/integration/diagnostics/"
+)
+# Source: https://developers.home-assistant.io/docs/core/integration-diagnostics
+# _SOURCE_CHECKED_AT = "2026-05-01"
+
+_DIAGNOSTICS_FUNC_NAMES = frozenset(
+    {"async_get_config_entry_diagnostics", "async_get_device_diagnostics"}
+)
+_LOCAL_REDACT_RE = re.compile(r"^_?redact(_.*)?$")
+
+
+def _parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
+    """Return (parsed_tree, None) on success, (None, error_msg) on failure.
+
+    Three states:
+    - (tree, None)  — parsed OK
+    - (None, msg)   — file could not be read or has a syntax error
+    - (None, None)  — file does not exist (caller should check before calling)
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, str(exc)
+    try:
+        return ast.parse(source), None
+    except SyntaxError as exc:
+        return None, exc.msg or "syntax error"
+
+
+@dataclass(frozen=True)
+class _DiagnosticsSignals:
+    imports_async_redact: bool
+    calls_async_redact: bool
+    calls_local_redact: bool  # local def + call to name matching ^_?redact(_.*)?$
+    returns_raw_entry_data: (
+        bool  # Return with attribute entry.data/options or config_entry.data
+    )
+
+
+def _diagnostics_signals(tree: ast.Module) -> _DiagnosticsSignals:
+    """Walk the AST and extract redaction-related signals."""
+    imports_async_redact = False
+    calls_async_redact = False
+
+    # Collect names of local functions matching the redact pattern
+    local_redact_defs: set[str] = set()
+    # Collect all Name nodes used in calls to detect if helper is called
+    called_names: set[str] = set()
+    returns_raw_entry_data = False
+
+    for node in ast.walk(tree):
+        # Detect imports of async_redact_data
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name == "async_redact_data" or alias.name == "async_redact_data":
+                    imports_async_redact = True
+
+        # Detect calls to async_redact_data (Name or Attribute)
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "async_redact_data":
+                calls_async_redact = True
+            elif isinstance(func, ast.Attribute) and func.attr == "async_redact_data":
+                calls_async_redact = True
+            # Track all function calls by name
+            if isinstance(func, ast.Name):
+                called_names.add(func.id)
+
+        # Collect local function definitions matching the redact pattern
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _LOCAL_REDACT_RE.match(node.name):
+                local_redact_defs.add(node.name)
+
+        # Detect raw entry.data / entry.options / config_entry.data returns
+        if isinstance(node, ast.Return) and node.value is not None:
+            val = node.value
+            # Pattern: entry.data or entry.options or config_entry.data
+            if isinstance(val, ast.Attribute) and val.attr in {"data", "options"}:
+                if isinstance(val.value, ast.Name) and val.value.id in {
+                    "entry",
+                    "config_entry",
+                }:
+                    returns_raw_entry_data = True
+            # Pattern: dict(entry.data) or dict(entry.options) or dict(config_entry.data)
+            elif (
+                isinstance(val, ast.Call)
+                and isinstance(val.func, ast.Name)
+                and val.func.id == "dict"
+                and val.args
+            ):
+                arg0 = val.args[0]
+                if isinstance(arg0, ast.Attribute) and arg0.attr in {"data", "options"}:
+                    if isinstance(arg0.value, ast.Name) and arg0.value.id in {
+                        "entry",
+                        "config_entry",
+                    }:
+                        returns_raw_entry_data = True
+
+    # A local redact helper counts only if it is both defined AND called elsewhere
+    calls_local_redact = bool(local_redact_defs & called_names)
+
+    return _DiagnosticsSignals(
+        imports_async_redact=imports_async_redact,
+        calls_async_redact=calls_async_redact,
+        calls_local_redact=calls_local_redact,
+        returns_raw_entry_data=returns_raw_entry_data,
+    )
+
+
+def _has_diagnostics_function(tree: ast.Module) -> bool:
+    """Return True if tree contains any async diagnostics function."""
+    return any(
+        isinstance(node, ast.AsyncFunctionDef) and node.name in _DIAGNOSTICS_FUNC_NAMES
+        for node in ast.walk(tree)
+    )
+
+
+_REDACTION_WHY = (
+    "Home Assistant diagnostics expose integration state for troubleshooting. "
+    "Without redaction, sensitive fields (API keys, tokens, passwords, coordinates) "
+    "can be leaked when users share diagnostic data. "
+    "Use async_redact_data from homeassistant.components.diagnostics or a local "
+    "redaction helper to strip sensitive keys before returning. "
+    "Note: this rule uses AST static inspection and cannot detect redaction performed "
+    "in a base class, mixin, or via dynamic dispatch — those cases may produce a "
+    "false WARN. A WARN does NOT guarantee a bug; treat it as a prompt for "
+    "MANUAL_REVIEW of the diagnostics output."
 )
 
 
@@ -90,6 +222,184 @@ def diagnostics_file_exists(context: ProjectContext) -> Finding:
     )
 
 
+def diagnostics_redaction_used(context: ProjectContext) -> Finding:
+    """Check that diagnostics.py uses async_redact_data or a local redaction helper."""
+    # Guard: no integration directory
+    if context.integration_path is None:
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message="No integration directory was detected.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect diagnostics.py.",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=None,
+            path="custom_components/<domain>/diagnostics.py",
+        )
+
+    diagnostics_path = context.integration_path / "diagnostics.py"
+
+    # Guard: applicability flag opts out (regardless of whether file exists)
+    if context.applicability and context.applicability.supports_diagnostics is False:
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message="Project config declares diagnostics are not supported by this integration.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="hasscheck.yaml declares supports_diagnostics: false.",
+                source="config",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=None,
+            path=str(diagnostics_path.relative_to(context.root)),
+        )
+
+    # Guard: diagnostics.py does not exist
+    if not diagnostics_path.is_file():
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message="diagnostics.py does not exist; redaction usage cannot be inspected.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="diagnostics.py must exist before this rule can run.",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=None,
+            path=str(diagnostics_path.relative_to(context.root)),
+        )
+
+    rel_path = str(diagnostics_path.relative_to(context.root))
+
+    # Parse the file
+    tree, error = _parse_module(diagnostics_path)
+
+    if error is not None:
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message=f"diagnostics.py could not be parsed ({error}); redaction usage cannot be determined.",
+            applicability=Applicability(
+                reason="diagnostics.py exists but has a syntax error."
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=FixSuggestion(summary="Fix syntax errors in diagnostics.py."),
+            path=rel_path,
+        )
+
+    assert tree is not None
+
+    # Guard: no diagnostics function defined — file is empty/stub
+    if not _has_diagnostics_function(tree):
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message="diagnostics.py exists but does not define a diagnostics function.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="No async_get_config_entry_diagnostics or async_get_device_diagnostics found.",
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=FixSuggestion(
+                summary="Add async_get_config_entry_diagnostics or async_get_device_diagnostics to diagnostics.py.",
+                command="hasscheck scaffold diagnostics",
+            ),
+            path=rel_path,
+        )
+
+    signals = _diagnostics_signals(tree)
+
+    # Resolution priority per design D6:
+    # 1. raw return AND no redaction → WARN (strong)
+    # 2. any redaction found → PASS
+    # 3. otherwise → WARN (generic)
+
+    if signals.returns_raw_entry_data and not (
+        signals.calls_async_redact or signals.calls_local_redact
+    ):
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message=(
+                "diagnostics returns entry.data without redaction — "
+                "likely exposes secrets; use async_redact_data."
+            ),
+            applicability=Applicability(
+                reason="diagnostics.py returns entry.data or entry.options directly without redacting sensitive fields."
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=FixSuggestion(
+                summary="Use async_redact_data or a local redaction helper before returning entry data.",
+                docs_url=DIAGNOSTICS_SOURCE,
+            ),
+            path=rel_path,
+        )
+
+    if signals.calls_async_redact or signals.calls_local_redact:
+        return Finding(
+            rule_id="diagnostics.redaction.used",
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS,
+            severity=RuleSeverity.RECOMMENDED,
+            title="diagnostics.py uses redaction",
+            message="diagnostics.py uses a recognized redaction pattern.",
+            applicability=Applicability(
+                reason="Redaction protects sensitive fields from being exposed in diagnostic data."
+            ),
+            source=RuleSource(url=DIAGNOSTICS_SOURCE),
+            fix=None,
+            path=rel_path,
+        )
+
+    # Generic WARN: function exists, no raw return, no recognized redaction
+    return Finding(
+        rule_id="diagnostics.redaction.used",
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title="diagnostics.py uses redaction",
+        message="diagnostics.py does not appear to redact sensitive data; review manually before relying on diagnostics output.",
+        applicability=Applicability(
+            reason="diagnostics.py defines a diagnostics function but no recognized redaction pattern was detected."
+        ),
+        source=RuleSource(url=DIAGNOSTICS_SOURCE),
+        fix=FixSuggestion(
+            summary="Add async_redact_data or a local redaction helper to strip sensitive keys.",
+            docs_url=DIAGNOSTICS_SOURCE,
+        ),
+        path=rel_path,
+    )
+
+
 RULES = [
     RuleDefinition(
         id="diagnostics.file.exists",
@@ -101,5 +411,16 @@ RULES = [
         source_url=DIAGNOSTICS_SOURCE,
         check=diagnostics_file_exists,
         overridable=True,
-    )
+    ),
+    RuleDefinition(
+        id="diagnostics.redaction.used",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="diagnostics.py uses redaction",
+        why=_REDACTION_WHY,
+        source_url=DIAGNOSTICS_SOURCE,
+        check=diagnostics_redaction_used,
+        overridable=True,
+    ),
 ]

--- a/src/hasscheck/scaffold/templates/diagnostics.py.tmpl
+++ b/src/hasscheck/scaffold/templates/diagnostics.py.tmpl
@@ -9,6 +9,10 @@ from homeassistant.core import HomeAssistant
 
 # Add any keys that should be redacted from diagnostics output.
 # Common sensitive fields: API keys, tokens, passwords, location data.
+#
+# Upgrade path: replace redact_data() below with the official HA helper:
+#   from homeassistant.components.diagnostics import async_redact_data
+# and call: async_redact_data(dict(entry.data), TO_REDACT)
 TO_REDACT: list[str] = [
     "api_key",
     "password",

--- a/tests/scaffold_golden/diagnostics.py
+++ b/tests/scaffold_golden/diagnostics.py
@@ -9,6 +9,10 @@ from homeassistant.core import HomeAssistant
 
 # Add any keys that should be redacted from diagnostics output.
 # Common sensitive fields: API keys, tokens, passwords, location data.
+#
+# Upgrade path: replace redact_data() below with the official HA helper:
+#   from homeassistant.components.diagnostics import async_redact_data
+# and call: async_redact_data(dict(entry.data), TO_REDACT)
 TO_REDACT: list[str] = [
     "api_key",
     "password",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,7 +194,7 @@ def test_terminal_banner_shown_when_applicability_applied(tmp_path) -> None:
     result = runner.invoke(app, ["check", "--path", str(tmp_path)])
 
     assert result.exit_code == 1
-    assert "2 applicability decision(s) applied from hasscheck.yaml." in result.output
+    assert "3 applicability decision(s) applied from hasscheck.yaml." in result.output
 
 
 def test_terminal_banner_not_shown_when_no_applicability_applied(tmp_path) -> None:

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -64,3 +64,17 @@ def test_config_flow_user_step_warns_on_bad_integration_fixture() -> None:
     f = findings["config_flow.user_step.exists"]
     assert f.status is RuleStatus.WARN
     assert "async_step_user" in f.message
+
+
+# ---------------------------------------------------------------------------
+# PR4: diagnostics.redaction.used must WARN (fixture returns entry.data raw,
+#       no redaction call)
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_redaction_warns_on_bad_integration_fixture() -> None:
+    """Fixture diagnostics.py returns entry.data directly without redaction — must WARN."""
+    findings = _findings_by_id()
+    f = findings["diagnostics.redaction.used"]
+    assert f.status is RuleStatus.WARN
+    assert "likely exposes secrets" in f.message

--- a/tests/test_project_applicability_context.py
+++ b/tests/test_project_applicability_context.py
@@ -36,6 +36,7 @@ def test_project_applicability_softens_missing_optional_files(tmp_path: Path) ->
 
     for rule_id in (
         "diagnostics.file.exists",
+        "diagnostics.redaction.used",  # v0.8 PR4 — also responds to supports_diagnostics
         "repairs.file.exists",
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
@@ -44,12 +45,13 @@ def test_project_applicability_softens_missing_optional_files(tmp_path: Path) ->
         assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
         assert findings[rule_id].applicability.source == "config"
 
-    assert report.summary.applicability_applied.count == 5
+    assert report.summary.applicability_applied.count == 6
     assert report.summary.applicability_applied.rule_ids == [
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
         "config_flow.user_step.exists",
         "diagnostics.file.exists",
+        "diagnostics.redaction.used",
         "repairs.file.exists",
     ]
     assert report.summary.applicability_applied.flags == [
@@ -88,8 +90,11 @@ def test_project_applicability_natural_pass_wins(tmp_path: Path) -> None:
     # exists — per spec, uses_config_flow=False always suppresses user-step inspection.
     assert findings["config_flow.user_step.exists"].status is RuleStatus.NOT_APPLICABLE
     assert findings["config_flow.user_step.exists"].applicability.source == "config"
-    # Only config_flow.user_step.exists is suppressed via config in this scenario.
-    assert report.summary.applicability_applied.count == 1
+    # diagnostics.redaction.used is also suppressed via config (supports_diagnostics=False).
+    assert findings["diagnostics.redaction.used"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["diagnostics.redaction.used"].applicability.source == "config"
+    # Both config_flow.user_step.exists and diagnostics.redaction.used suppressed via config.
+    assert report.summary.applicability_applied.count == 2
 
 
 def test_project_applicability_does_not_hide_config_flow_mismatch(
@@ -119,5 +124,6 @@ def test_project_applicability_loaded_from_disk(tmp_path: Path) -> None:
     findings = {finding.rule_id: finding for finding in report.findings}
 
     assert findings["diagnostics.file.exists"].status is RuleStatus.NOT_APPLICABLE
+    assert findings["diagnostics.redaction.used"].status is RuleStatus.NOT_APPLICABLE
     assert findings["repairs.file.exists"].status is RuleStatus.NOT_APPLICABLE
-    assert report.summary.applicability_applied.count == 2
+    assert report.summary.applicability_applied.count == 3

--- a/tests/test_rules_diagnostics_redaction.py
+++ b/tests/test_rules_diagnostics_redaction.py
@@ -1,0 +1,415 @@
+"""Tests for diagnostics.redaction.used rule (PR4, #53).
+
+TDD cycle:
+  - RED: written first, references production code that does not yet exist
+  - GREEN: confirmed after implementation
+
+Spec: sdd/v0-8-rule-depth/spec — Domain: diagnostics-rules (#53)
+Design: D1 (AST helpers + _DiagnosticsSignals), D6 (scaffold compatibility), D7 (exact message strings)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RULE_ID = "diagnostics.redaction.used"
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "test_integration",
+    manifest: str | None = None,
+    diagnostics_src: str | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with optional manifest and diagnostics.py."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0", "config_flow": true}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+
+    if diagnostics_src is not None:
+        (integration / "diagnostics.py").write_text(diagnostics_src, encoding="utf-8")
+
+    return integration
+
+
+def _finding_for(root: Path):
+    return {f.rule_id: f for f in run_check(root).findings}[RULE_ID]
+
+
+# ---------------------------------------------------------------------------
+# Rule registration — metadata + explain reachability
+# ---------------------------------------------------------------------------
+
+
+def test_rule_is_registered() -> None:
+    rule = RULES_BY_ID[RULE_ID]
+    assert rule.id == RULE_ID
+    assert rule.version == "1.0.0"
+    assert rule.category == "diagnostics_repairs"
+    assert str(rule.severity) == "recommended"
+    assert rule.overridable is True
+    assert rule.why, "why must be non-empty"
+
+
+def test_why_mentions_ast_limitations_and_manual_review() -> None:
+    """Spec: AST Limitation Documented for diagnostics.redaction.used."""
+    rule = RULES_BY_ID[RULE_ID]
+    why_lower = rule.why.lower()
+    # Must mention AST limitations
+    assert "ast" in why_lower or "static" in why_lower or "inspect" in why_lower, (
+        "why must mention AST inspection limitations"
+    )
+    # Must mention manual review boundary
+    assert "manual" in why_lower or "manual_review" in why_lower, (
+        "why must mention the MANUAL_REVIEW boundary"
+    )
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: no integration directory
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_no_integration_directory(tmp_path: Path) -> None:
+    """No custom_components/ → NOT_APPLICABLE."""
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: diagnostics.py does not exist in integration
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_no_diagnostics_file(tmp_path: Path) -> None:
+    """Integration directory without diagnostics.py → NOT_APPLICABLE."""
+    _write_integration(tmp_path)  # no diagnostics_src
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: diagnostics.py exists but has no diagnostics function
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_diagnostics_file_has_no_diagnostics_function(
+    tmp_path: Path,
+) -> None:
+    """diagnostics.py exists but defines no async_get_config_entry_diagnostics
+    or async_get_device_diagnostics → NOT_APPLICABLE (empty stub)."""
+    src = """\
+# Empty diagnostics stub — no function defined yet
+TO_REDACT: list[str] = []
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# NOT_APPLICABLE: supports_diagnostics=False in hasscheck.yaml applicability
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_when_supports_diagnostics_false(tmp_path: Path) -> None:
+    """Applicability flag supports_diagnostics=False → NOT_APPLICABLE."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return {}
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    (tmp_path / "hasscheck.yaml").write_text(
+        "applicability:\n  supports_diagnostics: false\n", encoding="utf-8"
+    )
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# PASS: async_redact_data imported and called
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_async_redact_data_imported_and_called(tmp_path: Path) -> None:
+    """PASS when diagnostics.py imports and calls async_redact_data."""
+    src = """\
+from homeassistant.components.diagnostics import async_redact_data
+
+TO_REDACT = ["api_key", "password"]
+
+
+async def async_get_config_entry_diagnostics(hass, entry):
+    return async_redact_data(dict(entry.data), TO_REDACT)
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# PASS: local helper named redact_data — defined AND called
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_local_redact_data_defined_and_called(tmp_path: Path) -> None:
+    """PASS when local helper 'redact_data' is defined and called in diagnostics.py."""
+    src = """\
+TO_REDACT = ["api_key"]
+
+
+async def async_get_config_entry_diagnostics(hass, entry):
+    return {"entry": redact_data(dict(entry.data), TO_REDACT)}
+
+
+def redact_data(data, to_redact):
+    return {k: "**REDACTED**" if k in to_redact else v for k, v in data.items()}
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# PASS: local helper named _redact_secrets — defined AND called
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_local_underscore_redact_helper_defined_and_called(
+    tmp_path: Path,
+) -> None:
+    """PASS when local helper '_redact_secrets' (matching ^_?redact(_.*)?$) defined+called."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return _redact_secrets(dict(entry.data))
+
+
+def _redact_secrets(data):
+    data.pop("api_key", None)
+    return data
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# PASS: local helper named redact_x (matches ^_?redact(_.*)?$) — defined AND called
+# ---------------------------------------------------------------------------
+
+
+def test_pass_when_redact_x_helper_defined_and_called(tmp_path: Path) -> None:
+    """PASS when local helper name matches ^_?redact(_.*)?$ and is both defined and called."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return {"data": redact_sensitive(entry.data)}
+
+
+def redact_sensitive(data):
+    return {k: v for k, v in data.items() if k != "password"}
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Edge: local helper defined but never called → NOT a PASS
+# ---------------------------------------------------------------------------
+
+
+def test_not_pass_when_helper_defined_but_never_called(tmp_path: Path) -> None:
+    """Local helper defined but not called → should NOT be PASS (must be both defined AND used)."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    # Forgot to call the helper
+    return dict(entry.data)
+
+
+def redact_data(data, to_redact):
+    return {k: "**REDACTED**" if k in to_redact else v for k, v in data.items()}
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    # Helper defined but not called — raw return is detected → WARN
+    assert f.status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# WARN (strong): raw entry.data returned
+# ---------------------------------------------------------------------------
+
+
+def test_warn_strong_when_entry_data_returned_raw(tmp_path: Path) -> None:
+    """Spec: strong WARN when entry.data returned without redaction."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return entry.data
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "likely exposes secrets" in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN (strong): dict(entry.data) returned raw
+# ---------------------------------------------------------------------------
+
+
+def test_warn_strong_when_dict_entry_data_returned_raw(tmp_path: Path) -> None:
+    """Spec: strong WARN when dict(entry.data) returned without redaction."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return dict(entry.data)
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "likely exposes secrets" in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN (strong): entry.options returned raw
+# ---------------------------------------------------------------------------
+
+
+def test_warn_strong_when_entry_options_returned_raw(tmp_path: Path) -> None:
+    """Spec: strong WARN when entry.options returned without redaction."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return entry.options
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "likely exposes secrets" in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN (strong): config_entry.data returned raw
+# ---------------------------------------------------------------------------
+
+
+def test_warn_strong_when_config_entry_data_returned_raw(tmp_path: Path) -> None:
+    """Spec: strong WARN when config_entry.data returned without redaction."""
+    src = """\
+async def async_get_device_diagnostics(hass, config_entry, device):
+    return config_entry.data
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "likely exposes secrets" in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN (generic): diagnostics function exists, no redaction, no suspicious return
+# ---------------------------------------------------------------------------
+
+
+def test_warn_generic_when_no_redaction_and_no_raw_return(tmp_path: Path) -> None:
+    """WARN (generic) when diagnostics function exists but no recognized redaction pattern."""
+    src = """\
+async def async_get_config_entry_diagnostics(hass, entry):
+    return {"device_info": "some_static_data"}
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    # Generic wording — not the strong "likely exposes secrets" message
+    assert "likely exposes secrets" not in f.message
+
+
+# ---------------------------------------------------------------------------
+# WARN: parse error (syntax error in diagnostics.py)
+# ---------------------------------------------------------------------------
+
+
+def test_warn_when_diagnostics_has_syntax_error(tmp_path: Path) -> None:
+    """Parse error → WARN with message containing 'could not be parsed'."""
+    src = """\
+def broken(
+    # unclosed parenthesis — invalid Python
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.WARN
+    assert "could not be parsed" in f.message
+
+
+# ---------------------------------------------------------------------------
+# Scaffold template compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_scaffold_template_passes_rule(tmp_path: Path) -> None:
+    """Spec: Scaffold Template Passes Rule.
+
+    The existing scaffold template uses a local redact_data() helper that is
+    both defined and called — this must satisfy pattern (2) in design D6 and
+    produce PASS (not WARN).
+    """
+    # Reproduce the scaffold template content verbatim (local redact_data defined+called)
+    src = """\
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+# Add any keys that should be redacted from diagnostics output.
+# Common sensitive fields: API keys, tokens, passwords, location data.
+# Upgrade path: use homeassistant.components.diagnostics.async_redact_data
+# for the official HA redaction helper instead of a local implementation.
+TO_REDACT: list[str] = [
+    "api_key",
+    "password",
+    "token",
+    "latitude",
+    "longitude",
+]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    \"\"\"Return diagnostics for a config entry.\"\"\"
+    return {
+        "entry": redact_data(dict(entry.data), TO_REDACT),
+        "options": redact_data(dict(entry.options), TO_REDACT),
+    }
+
+
+def redact_data(data: dict[str, Any], to_redact: list[str]) -> dict[str, Any]:
+    \"\"\"Redact sensitive data from a dict.\"\"\"
+    redacted = dict(data)
+    for key in to_redact:
+        if key in redacted:
+            redacted[key] = "**REDACTED**"
+    return redacted
+"""
+    _write_integration(tmp_path, diagnostics_src=src)
+    f = _finding_for(tmp_path)
+    assert f.status is RuleStatus.PASS, (
+        f"scaffold template should PASS diagnostics.redaction.used, got {f.status}: {f.message}"
+    )

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 24 rules total (v0.8 PR3 adds 1 config_flow rule):
-#   - config_flow.user_step.exists (overridable=True, RECOMMENDED)
-# 11 locked overridable=False, 13 overridable=True.
+# 25 rules total (v0.8 PR4 adds 1 diagnostics rule):
+#   - diagnostics.redaction.used (overridable=True, RECOMMENDED)
+# 11 locked overridable=False, 14 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -34,6 +34,7 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "config_flow.file.exists",
     "config_flow.user_step.exists",  # v0.8 PR3 — AST inspection (RECOMMENDED, overridable=True)
     "diagnostics.file.exists",
+    "diagnostics.redaction.used",  # v0.8 PR4 — AST redaction detection (RECOMMENDED, overridable=True)
     "repairs.file.exists",
     "brand.icon.exists",
     "docs.readme.exists",
@@ -48,8 +49,8 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
 }
 
 
-def test_total_rule_count_is_twenty_four() -> None:
-    assert len(RULES) == 24, f"expected 24 rules, got {len(RULES)}"
+def test_total_rule_count_is_twenty_five() -> None:
+    assert len(RULES) == 25, f"expected 25 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

PR 4 of 4 for **Theme A — rule depth** (v0.8.0). Final Theme A PR — closes the rule-expansion arc with the highest-value safety rule of the batch: detecting whether HA integrations actually redact secrets in their diagnostics dumps.

> The reporter of #53 called this "one of the most important popularity boosters because it checks real user safety behavior without claiming to perform a security audit." This PR ships exactly that, conservatively.

Closes #53. **With this merged, Theme A is done.**

## Rule

| Field | Value |
|-------|-------|
| ID | \`diagnostics.redaction.used\` |
| Category | \`diagnostics\` |
| Severity | \`recommended\` |
| Overridable | \`true\` |

### Status semantics (conservative — WARN never FAIL in v1)

- **NOT_APPLICABLE** — no integration / no \`diagnostics.py\` / \`supports_diagnostics=False\` / file present but no diagnostics function defined
- **PASS** — \`async_redact_data\` is *called* AND a diagnostics function is present, OR a local helper matching \`^_?redact(_.*)?$\` is *both defined and called*
- **WARN (strong)** — diagnostics function returns one of \`entry.data\`, \`entry.options\`, \`config_entry.data\`, \`dict(entry.data)\` raw, no redaction detected → message contains "likely exposes secrets"
- **WARN (generic)** — diagnostics function present, no redaction pattern detected, no suspicious raw return
- **WARN** — parse error (consistent with PR3's AST stance)

### Detection — what counts as "redaction"

1. \`async_redact_data\` is *called* (HA's blessed helper). Mere import without call is not enough — \`imports_async_redact\` is captured for v0.9 but ignored here per design D6. Conservative on purpose.
2. A local helper named matching \`^_?redact(_.*)?$\` (e.g. \`redact_data\`, \`_redact_secrets\`, \`redact_sensitive\`) is *both defined and called* in the module.

Defining \`redact_x\` and never calling it is **not** PASS — that's how we caught the "performative redact helper" anti-pattern in test fixtures.

## Helpers (verbatim copy of PR3's \`_parse_module\`)

\`_parse_module(path) -> (ast.Module | None, str | None)\` is copied byte-for-byte from \`config_flow.py\` per design D1 (deferred \`ast_utils.py\` extraction to v0.9). Same docstring, same body, same correlation-narrowing \`assert tree is not None\` after the error early-return.

## Scaffold compatibility

The existing \`hasscheck scaffold diagnostics\` template now passes the new rule. \`tests/scaffold_golden/diagnostics.py\` mirrors the change. Verified by \`test_scaffold_template_passes_rule\`.

## Test plan

- [x] \`uv run pytest --ignore=tests/test_check_version.py\` — **430 passing** (18 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: RED → GREEN per scenario (12 of the 18 are spec-mandated; rest are edge cases like helper-defined-but-never-called)
- [x] \`uv run hasscheck explain diagnostics.redaction.used\` — exits 0, \`why\` mentions AST static inspection + MANUAL_REVIEW boundaries
- [x] \`uv run hasscheck check --path examples/bad_integration\` — \`diagnostics.redaction.used\` WARN with "likely exposes secrets" wording (fixture's \`diagnostics.py\` returns \`entry.data\` raw)
- [x] Both \`async_get_config_entry_diagnostics\` AND \`async_get_device_diagnostics\` recognized as diagnostics functions

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 24 → 25. Locked count unchanged (overridable rule).
- **Applicability assertions** in \`tests/test_project_applicability_context.py\` and \`tests/test_cli.py\` updated for the new rule responding to \`supports_diagnostics=False\` (5→6 / 1→2 / 2→3 / 2→3).
- \`examples/bad_integration/custom_components/demo_bad/diagnostics.py\` added — returns \`entry.data\` raw to demonstrate the strong WARN path.
- Pre-existing pylance type-narrowing warnings on \`manifest.py:50\` and \`:155\` unchanged. Tracking separately.

## Theme A complete

| PR | Issue(s) | Status |
|----|----------|--------|
| 1 | #50, #51 | merged |
| 2 | #52 | merged |
| 3 | #54 | merged |
| **4 (this)** | **#53** | **this PR** |

After this lands, Theme A delivers **7 new rules** + **1 tracked fixture** + **1 ADR** + the inline AST helper pattern that future v0.9 rules can extract.

## SDD artifacts

- explore: 394 → proposal: 396 → spec: 397 → design: 398 → tasks: 399
- apply / verify (cumulative): 423 / 418 (PR4 section appended; Theme A complete summary)