### PR TITLE
chore(release): bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-01
+
 ### Added
+- Seven new rules covering manifest correctness, config flow, and diagnostics safety:
+  - `manifest.domain.matches_directory` (REQUIRED, non-overridable) — catches manifest `domain` vs. `custom_components/<dir>` identity drift (#51)
+  - `manifest.iot_class.exists` / `manifest.iot_class.valid` (RECOMMENDED, overridable) — verified against HA dev docs allowed set (#52)
+  - `manifest.integration_type.exists` / `manifest.integration_type.valid` (RECOMMENDED, overridable) — verified against HA dev docs allowed set (#52)
+  - `config_flow.user_step.exists` (RECOMMENDED, overridable) — AST-walks `config_flow.py` for `async_step_user` AsyncFunctionDef at any depth (#54)
+  - `diagnostics.redaction.used` (RECOMMENDED, overridable) — AST detects `async_redact_data` calls or local `^_?redact(_.*)?$` helpers; flags raw `entry.data` / `entry.options` / `dict(entry.data)` returns with strong "likely exposes secrets" wording (#53)
+- Inline `_parse_module(path) -> (ast.Module | None, str | None)` 3-state parser pattern in `config_flow.py` and `diagnostics.py` (extract to `ast_utils.py` deferred to v0.9)
+- `examples/bad_integration/custom_components/demo_bad/` — tracked negative fixture demonstrating five representative failures (manifest domain mismatch, invalid `iot_class`, missing `integration_type`, missing `async_step_user`, raw `entry.data` diagnostics) (#50)
+- `publish.endpoint` block in `hasscheck.yaml` — new fourth precedence tier (CLI flag > env var > config > default) for `hasscheck publish`. `PublishConfig` Pydantic sub-model with `extra="forbid"`
+- `--force` flag on `hasscheck publish` — required for non-interactive callers; without it, withdraw branches prompt via `typer.confirm(abort=True)` with report ID + endpoint + irreversibility note
+- `--enable-publish` flag on `hasscheck init` — selects sibling workflow template (`github_action_publish.yml.tmpl`) with `id-token: write` permission and `emit-publish: 'true'` step
 - `LICENSE` — MIT License at repository root, "Copyright (c) 2026 Daily Nerd"
 - `pyproject.toml` PyPI-grade metadata: `license = "MIT"` (SPDX/PEP 639), `authors`, `keywords`, `classifiers`, and `[project.urls]` (Homepage, Repository, Issues, Documentation)
-- ADR 0009 — Schema versioning policy: documents `SCHEMA_VERSION` bump triggers, additive-only stance, lockstep with `hasscheck-web`, and distinction from ADR 0006's ruleset versioning (policy-only; no version bump)
+- ADR 0009 — Schema versioning policy: documents `SCHEMA_VERSION` bump triggers, additive-only stance, lockstep with `hasscheck-web`, and distinction from ADR 0006's ruleset versioning
 
 ### Changed
-- README "Current status" block reflects v0.7.0 as latest release and v0.8.0 as in-progress
-- README GitHub Action examples bumped from `@v0.6.0` to `@v0.7.0` (lines 69 and 109)
+- Bumped `version` and `__version__` to `0.8.0`
+- `DEFAULT_RULESET_ID` bumped from `hasscheck-ha-2026.4` to `hasscheck-ha-2026.5` (per ADR 0006 — new rules added)
+- `resolve_endpoint(cli_value, *, config: HassCheckConfig | None = None)` — keyword-only `config` param; existing call sites unchanged
+- `hasscheck publish` CLI handler now loads `hasscheck.yaml` via `discover_config()` before endpoint resolution; malformed YAML surfaces as `ConfigError` rather than opaque `PublishError`
+- Diagnostics scaffold template (`src/hasscheck/scaffold/templates/diagnostics.py.tmpl`) and golden updated to pass `diagnostics.redaction.used`
+- `cross-reference` header comments added to both `github_action.yml.tmpl` and `github_action_publish.yml.tmpl` to mitigate two-template drift
+- README "Current status" block reflects v0.7.0 as latest release and v0.8.0 as in-progress at the time of writing
+- README GitHub Action examples bumped from `@v0.6.0` to `@v0.7.0`
+- README "Current rule set" tables extended with the seven new rules
+
+### Notes
+- **Breaking for non-interactive `hasscheck publish --withdraw` callers**: pipelines must add `--force` to bypass the confirmation prompt (deliberate; `typer.confirm(abort=True)` is the gate)
+- `SCHEMA_VERSION` unchanged at `0.3.0` — v0.8 adds no new finding fields (additive only per ADR 0009)
+- Test count: ~330 → 430 (+100 across the four rule-depth PRs and the publish-polish PR)
+
+[Compare v0.7.0...v0.8.0](https://github.com/Daily-Nerd/hasscheck/compare/v0.7.0...v0.8.0)
 
 ## [0.7.0] — 2026-05-01
 
@@ -144,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Initial release](https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.1.0)
 
-[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.8.0
 [0.7.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.7.0
 [0.6.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.6.0
 [0.5.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.7.0"
+version = "0.8.0"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

v0.8.0 ships three themes implemented across PRs #84, #85, #86, #87, #88, #89.

### Theme A — rule depth
Seven new rules across manifest correctness, config flow, and diagnostics safety:

| ID | Severity | Issue |
|----|----------|-------|
| \`manifest.domain.matches_directory\` | required (non-overridable) | #51 |
| \`manifest.iot_class.exists\` | recommended | #52 |
| \`manifest.iot_class.valid\` | recommended | #52 |
| \`manifest.integration_type.exists\` | recommended | #52 |
| \`manifest.integration_type.valid\` | recommended | #52 |
| \`config_flow.user_step.exists\` | recommended | #54 |
| \`diagnostics.redaction.used\` | recommended | #53 |

Plus the tracked \`examples/bad_integration/\` negative fixture (#50) and the inline \`_parse_module(path) -> (ast.Module \\| None, str \\| None)\` 3-state AST helper introduced in PR3 and copied verbatim into PR4 (extract to \`ast_utils.py\` deferred to v0.9).

\`DEFAULT_RULESET_ID\` bumped \`hasscheck-ha-2026.4\` → \`hasscheck-ha-2026.5\` per ADR 0006.

### Theme B — publish polish
Closes v0.7 doc/impl drift:
- \`publish.endpoint\` block in \`hasscheck.yaml\` — adds the fourth precedence tier (CLI flag > env var > config > default). \`PublishConfig\` Pydantic sub-model with \`extra="forbid"\`.
- \`--force\` flag on \`hasscheck publish\` — required for non-interactive callers; without it, withdraw branches prompt via \`typer.confirm(abort=True)\`. **BREAKING for CI pipelines that ran \`hasscheck publish --withdraw\` non-interactively.**
- \`--enable-publish\` flag on \`hasscheck init\` — selects sibling workflow template with \`id-token: write\` permission and \`emit-publish: 'true'\` step.

### Theme C — release hygiene
- \`LICENSE\` (MIT, © 2026 Daily Nerd)
- \`pyproject.toml\` PyPI-grade metadata via PEP 639 SPDX form, full classifiers + \`[project.urls]\`
- ADR 0009 — schema versioning policy (additive-only stance, lockstep with \`hasscheck-web\`)

## Test plan

- [x] \`uv sync\` succeeds (PEP 639 form accepted by hatchling)
- [x] \`uv run pytest --ignore=tests/test_check_version.py\` — **430 passing**, zero regressions
- [x] \`uv run ruff check\` — clean
- [x] \`uv run python -c "from hasscheck import __version__; print(__version__)"\` → \`0.8.0\`
- [x] \`uv run hasscheck --version\` → \`hasscheck 0.8.0\`
- [x] Pre-commit \`hasscheck version consistency\` hook passes (pyproject + __version__ aligned)

## Schema

\`SCHEMA_VERSION\` unchanged at \`0.3.0\` — v0.8 adds no new finding fields. ADR 0009 governs future bumps.

## Test count progression

~330 → **430** (+100 across the four rule-depth PRs and the publish-polish PR)

## After merge

Tag \`v0.8.0\` on the merge commit to trigger the release workflow and create the GitHub Release.

## SDD artifacts

- Theme A: explore 394 → proposal 396 → spec 397 → design 398 → tasks 399 → apply 423 → verify 418
- Theme B: explore 401 → proposal 404 → spec 406 → design 408 → tasks 410 → apply 415 → verify 416
- Theme C: explore 402 → proposal 405 → spec 407 → design 409 → tasks 411 → apply 413 → verify 414