### PR TITLE
fix(v0.8.1): collect test_check_version + narrow manifest types for pylance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from hasscheck.models import (
     Applicability,
@@ -88,7 +88,7 @@ def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str 
     if not isinstance(payload, dict):
         return None, "manifest root must be a JSON object"
 
-    return payload, None
+    return cast(dict[str, Any], payload), None
 
 
 def _not_applicable_for_missing_manifest(
@@ -193,7 +193,7 @@ def _codeowners_rule(context: ProjectContext) -> Finding:
 
     value = payload.get("codeowners") if payload else None
     is_present = isinstance(value, list) and any(
-        isinstance(item, str) and item.strip() for item in value
+        isinstance(item, str) and item.strip() for item in cast(list[Any], value)
     )
     return Finding(
         rule_id="manifest.codeowners.exists",


### PR DESCRIPTION
## Summary

Two pre-existing tech-debt fixes that surfaced repeatedly during the v0.8.0 SDD cycle. Both were deferred each time because rule work shouldn't carry tooling fixes. Now they ship together as a small patch.

Closes #91
Closes #92.

## Fix 1 — \`tests/test_check_version.py\` collects again (#91)

The test imports \`from scripts.check_version import ...\`. Without \`scripts/\` on \`sys.path\` AND without \`scripts/__init__.py\`, pytest collection fails with:

\`\`\`
ModuleNotFoundError: No module named 'scripts'
\`\`\`

**Fix**: \`pythonpath = ["src", "."]\` in \`[tool.pytest.ini_options]\` plus an empty \`scripts/__init__.py\` to make \`scripts\` a proper package.

> Issue #91 suggested \`pythonpath = ["scripts"]\` as option 2. That path would expose \`check_version\` as a top-level module — but the test uses the qualified form \`from scripts.check_version import ...\`, so we need the **package form** instead. Decision documented in apply notes; reversal cost low.

## Fix 2 — pylance type narrowing in \`src/hasscheck/rules/manifest.py\` (#92)

\`json.loads()\` returns \`Any\`, so pylance can't preserve \`dict[str, Any]\` typing through \`isinstance(payload, dict)\` narrowing. Two warnings cleared with explicit \`cast()\`:

- Line 50 in \`_read_manifest\`: \`return cast(dict[str, Any], payload), None\`
- Line 155 in \`_codeowners_rule\`: \`for item in cast(list[Any], value)\`

No behavior change; type annotations only.

## Test plan

- [x] \`uv run pytest tests/test_check_version.py -v\` — **5 passed** (was: collection error)
- [x] \`uv run pytest -q\` (NO \`--ignore=\`) — **435 passing** (was 430 with the workaround)
- [x] \`uv run ruff check\` — clean
- [x] Pre-commit hooks (including \`hasscheck version consistency\`) all green
- [x] Pylance warnings on \`manifest.py:50\` and \`:155\` resolve

## Notes

- After this lands, the \`--ignore=tests/test_check_version.py\` workaround in local SDD apply commands is no longer needed.
- This is a v0.8.1 patch — no rule changes, no schema changes, no breaking-changes. \`SCHEMA_VERSION\` still 0.3.0; \`DEFAULT_RULESET_ID\` still \`hasscheck-ha-2026.5\`.

After merge: bump to v0.8.1 + tag.