### PR TITLE
chore(release): bump to v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-05-01
+
+### Fixed
+- `tests/test_check_version.py` no longer fails pytest collection. Added `pythonpath = ["src", "."]` to `[tool.pytest.ini_options]` and an empty `scripts/__init__.py` so `from scripts.check_version import ...` resolves. The previous `--ignore=tests/test_check_version.py` workaround used during the v0.8.0 SDD cycle is no longer needed (#91)
+- Pylance type narrowing on `src/hasscheck/rules/manifest.py:50` and `:155`. `json.loads()` returns `Any`, so explicit `cast(dict[str, Any], payload)` and `cast(list[Any], value)` calls preserve the typed shape across `isinstance` narrowing. No behavior change (#92)
+
+### Changed
+- Bumped `version` and `__version__` to `0.8.1`
+
+[Compare v0.8.0...v0.8.1](https://github.com/Daily-Nerd/hasscheck/compare/v0.8.0...v0.8.1)
+
 ## [0.8.0] — 2026-05-01
 
 ### Added
@@ -171,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Initial release](https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.1.0)
 
-[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.8.1
 [0.8.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.8.0
 [0.7.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.7.0
 [0.6.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.8.0"
+version = "0.8.1"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Patch release closing two pre-existing tech-debt items that surfaced during v0.8.0 SDD work.

- **#91** — \`tests/test_check_version.py\` collects again (\`pythonpath = ["src", "."]\` + empty \`scripts/__init__.py\`). The \`--ignore=tests/test_check_version.py\` workaround used during v0.8.0 apply is no longer needed. Shipped in #94.
- **#92** — pylance type-narrowing on \`src/hasscheck/rules/manifest.py:50\` and \`:155\` (explicit \`cast()\` calls preserve typed shape across \`json.loads\` Any). Behavior unchanged. Shipped in #94.

## Test plan

- [x] \`uv sync\` — clean
- [x] \`uv run pytest -q\` (NO \`--ignore=\`) — **435 passing** (was 430; 5 newly-collected from test_check_version)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck --version\` → \`hasscheck 0.8.1\`
- [x] Pre-commit \`hasscheck version consistency\` hook passes

## Scope

Patch only. No rule changes, no schema changes, no breaking changes.

- \`SCHEMA_VERSION\` unchanged at \`0.3.0\`
- \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\`
- 25 rules, 11 locked — same as v0.8.0

## After merge

Tag \`v0.8.1\` on the merge commit.