### PR TITLE
refactor(rules): extract _parse_module to ast_utils for shared AST inspection

### DIFF
--- a/src/hasscheck/ast_utils.py
+++ b/src/hasscheck/ast_utils.py
@@ -1,0 +1,22 @@
+"""AST helpers shared across rule modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
+    """Parse a Python file with the standard library AST module.
+
+    Returns (parsed_tree, None) on success, (None, error_msg) on failure.
+    Failure modes covered: file unreadable (OSError) and syntax errors.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, str(exc)
+    try:
+        return ast.parse(source), None
+    except SyntaxError as exc:
+        return None, exc.msg or "syntax error"

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import ast
 import json
-from pathlib import Path
 from typing import Any
 
+from hasscheck.ast_utils import parse_module
 from hasscheck.models import (
     Applicability,
     ApplicabilityStatus,
@@ -63,24 +63,6 @@ def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str 
         return None, "manifest root must be a JSON object"
 
     return payload, None
-
-
-def _parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
-    """Return (parsed_tree, None) on success, (None, error_msg) on failure.
-
-    Three states:
-    - (tree, None)  — parsed OK
-    - (None, msg)   — file could not be read or has a syntax error
-    - (None, None)  — file does not exist (caller should check before calling)
-    """
-    try:
-        source = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return None, str(exc)
-    try:
-        return ast.parse(source), None
-    except SyntaxError as exc:
-        return None, exc.msg or "syntax error"
 
 
 def _has_async_function(tree: ast.Module, name: str) -> bool:
@@ -162,7 +144,7 @@ def config_flow_user_step_exists(context: ProjectContext) -> Finding:
         )
 
     # Parse the file
-    tree, error = _parse_module(config_flow_path)
+    tree, error = parse_module(config_flow_path)
 
     if error is not None:
         return Finding(

--- a/src/hasscheck/rules/diagnostics.py
+++ b/src/hasscheck/rules/diagnostics.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import ast
 import re
 from dataclasses import dataclass
-from pathlib import Path
 
+from hasscheck.ast_utils import parse_module
 from hasscheck.models import (
     Applicability,
     ApplicabilityStatus,
@@ -27,24 +27,6 @@ _DIAGNOSTICS_FUNC_NAMES = frozenset(
     {"async_get_config_entry_diagnostics", "async_get_device_diagnostics"}
 )
 _LOCAL_REDACT_RE = re.compile(r"^_?redact(_.*)?$")
-
-
-def _parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
-    """Return (parsed_tree, None) on success, (None, error_msg) on failure.
-
-    Three states:
-    - (tree, None)  — parsed OK
-    - (None, msg)   — file could not be read or has a syntax error
-    - (None, None)  — file does not exist (caller should check before calling)
-    """
-    try:
-        source = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return None, str(exc)
-    try:
-        return ast.parse(source), None
-    except SyntaxError as exc:
-        return None, exc.msg or "syntax error"
 
 
 @dataclass(frozen=True)
@@ -287,7 +269,7 @@ def diagnostics_redaction_used(context: ProjectContext) -> Finding:
     rel_path = str(diagnostics_path.relative_to(context.root))
 
     # Parse the file
-    tree, error = _parse_module(diagnostics_path)
+    tree, error = parse_module(diagnostics_path)
 
     if error is not None:
         return Finding(

--- a/tests/test_ast_utils.py
+++ b/tests/test_ast_utils.py
@@ -1,0 +1,42 @@
+"""Unit tests for hasscheck.ast_utils.parse_module."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from hasscheck.ast_utils import parse_module
+
+
+def test_parse_module_success(tmp_path: Path) -> None:
+    """Valid Python file returns (tree, None)."""
+    py_file = tmp_path / "good.py"
+    py_file.write_text("x = 1\n", encoding="utf-8")
+
+    tree, error = parse_module(py_file)
+
+    assert tree is not None
+    assert isinstance(tree, ast.Module)
+    assert error is None
+
+
+def test_parse_module_oserror_nonexistent(tmp_path: Path) -> None:
+    """Non-existent path returns (None, error) where error mentions the path."""
+    missing = tmp_path / "does_not_exist.py"
+
+    tree, error = parse_module(missing)
+
+    assert tree is None
+    assert error is not None
+    assert "does_not_exist.py" in error or "No such file" in error
+
+
+def test_parse_module_syntax_error(tmp_path: Path) -> None:
+    """File with invalid Python syntax returns (None, error)."""
+    bad_file = tmp_path / "bad.py"
+    bad_file.write_text("def broken(\n", encoding="utf-8")
+
+    tree, error = parse_module(bad_file)
+
+    assert tree is None
+    assert error is not None


### PR DESCRIPTION
## Summary

Extracts the duplicated \`_parse_module(path) -> (ast.Module | None, str | None)\` helper from \`config_flow.py\` and \`diagnostics.py\` into a new shared \`src/hasscheck/ast_utils.py\` as public \`parse_module()\`.

Closes #93.

## Why now

v0.8 deliberately kept the helper inline-per-module (design D1) — only two callers, copy-verbatim was cheaper than premature abstraction. Now the seam is proven and the next AST-based rule (v0.9 candidates: reauth detection, \`async_setup_entry\` shape, \`runtime_data\`, \`has_entity_name\`, \`device_info\`) should ride on shared code, not a third copy.

## What changed

- **New**: \`src/hasscheck/ast_utils.py\` — public \`parse_module()\`, dropped underscore (no longer module-private)
- **Updated**: \`config_flow.py\` and \`diagnostics.py\` import from the shared module; local copies removed
- **Removed**: unused \`from pathlib import Path\` from both rule modules (only the local helper needed it)
- **Preserved**: \`assert tree is not None\` after error early-return in both callers (pylance correlation narrowing)

## Test plan

- [x] \`uv run pytest -q\` — **438 passing** (435 baseline + 3 new tests in \`tests/test_ast_utils.py\` covering success, OSError, SyntaxError)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck check --path examples/bad_integration\` — \`config_flow.user_step.exists\` WARN + \`diagnostics.redaction.used\` WARN both still emit (behavior unchanged)
- [x] \`uv run hasscheck explain config_flow.user_step.exists\` — exit 0
- [x] \`uv run hasscheck explain diagnostics.redaction.used\` — exit 0

## Notes

Mechanical extraction. Zero behavior change. \`SCHEMA_VERSION\` unchanged at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\`.