### PR TITLE
feat(rules): README content checks — install / config / troubleshoot / removal / privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ The exact category order may change as rules evolve. The JSON schema is the dura
 | Rule ID | Signal |
 | --- | --- |
 | `docs.readme.exists` | Repository has a README. |
+| `docs.installation.exists` | README contains an Installation section (HACS or manual). |
+| `docs.configuration.exists` | README contains a Configuration / Setup section. |
+| `docs.troubleshooting.exists` | README contains a Troubleshooting / FAQ / Support section. |
+| `docs.removal.exists` | README contains a Removal / Uninstall section. |
+| `docs.privacy.exists` | README addresses privacy / data / cloud / local handling. |
 | `repo.license.exists` | Repository has a license file. |
 
 ### Tests and CI

--- a/examples/good_integration/README.md
+++ b/examples/good_integration/README.md
@@ -1,3 +1,55 @@
 # Demo Good Integration
 
 Example fixture used by HassCheck tests and local report demos.
+
+## Installation
+
+Install via HACS (recommended) or manually by copying `custom_components/demo_good/`
+into your Home Assistant `custom_components/` directory.
+
+### HACS
+
+1. Open HACS → Integrations.
+2. Search for **Demo Good Integration**.
+3. Click Install.
+
+### Manual Install
+
+1. Download the latest release.
+2. Copy `custom_components/demo_good/` to `<HA config>/custom_components/`.
+3. Restart Home Assistant.
+
+## Configuration
+
+1. Go to **Settings → Devices & Services → Add Integration**.
+2. Search for "Demo Good Integration".
+3. Follow the config flow — no YAML required.
+
+### Options
+
+All options are configurable from the integration page after initial setup.
+
+## Troubleshooting
+
+- **Integration not found**: Ensure the `custom_components/demo_good/` directory was copied correctly and Home Assistant was restarted.
+- **Auth failure**: Verify your credentials and re-run the config flow.
+
+Enable debug logging by adding to `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.demo_good: debug
+```
+
+## Removal
+
+1. Go to **Settings → Devices & Services**.
+2. Find Demo Good Integration and click **Delete**.
+3. Optionally remove `custom_components/demo_good/` from your file system.
+
+## Privacy
+
+This integration runs entirely **local** — no data is sent to external services or cloud.
+No telemetry is collected. All communication stays within your local network.

--- a/src/hasscheck/rules/docs_readme.py
+++ b/src/hasscheck/rules/docs_readme.py
@@ -1,0 +1,375 @@
+"""README content rules — issue #55.
+
+Five RECOMMENDED + overridable checks that look for documentation sections
+in README.md using conservative heuristic heading detection:
+
+  docs.installation.exists
+  docs.configuration.exists
+  docs.troubleshooting.exists
+  docs.removal.exists
+  docs.privacy.exists
+
+Detection strategy (conservative, heading-only):
+1. Strip code-fence blocks (lines between ``` markers).
+2. Match markdown headings  ^#{1,6}\\s+(.*)$
+3. Match bold/emphasis solo lines  ^\\*\\*(.*?)\\*\\*$  or  ^_(.*?)_$
+4. PASS if any heading text contains any rule keyword as a whole word (\\b).
+5. Otherwise WARN if README exists, NOT_APPLICABLE if README is absent.
+
+Source: https://developers.home-assistant.io/docs/documenting_integrations
+Source-checked-at: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "docs_support"
+
+# ---------------------------------------------------------------------------
+# Source constants
+# Source: https://developers.home-assistant.io/docs/documenting_integrations
+# Verified: 2026-05-01
+# ---------------------------------------------------------------------------
+
+_DOCS_SOURCE_URL = "https://developers.home-assistant.io/docs/documenting_integrations"
+_SOURCE_CHECKED_AT = "2026-05-01"
+
+# ---------------------------------------------------------------------------
+# Heading extraction helper
+# ---------------------------------------------------------------------------
+
+_FENCE_OPEN = re.compile(r"^```")
+_MD_HEADING = re.compile(r"^#{1,6}\s+(.*)")
+_BOLD_LINE = re.compile(r"^\*\*(.*?)\*\*\s*$")
+_EMPHASIS_LINE = re.compile(r"^_(.*?)_\s*$")
+
+
+def _extract_headings(readme_text: str) -> list[str]:
+    """Return a list of heading texts found outside code fences.
+
+    Recognises:
+    - Markdown ATX headings: ``# Title``, ``## Title``, …
+    - Bold solo lines: ``**Title**``
+    - Emphasis solo lines: ``_Title_``
+
+    Lines inside ``` fences are skipped entirely.
+    """
+    headings: list[str] = []
+    inside_fence = False
+
+    for line in readme_text.splitlines():
+        stripped = line.strip()
+
+        # Toggle fence state
+        if _FENCE_OPEN.match(stripped):
+            inside_fence = not inside_fence
+            continue
+
+        if inside_fence:
+            continue
+
+        m = _MD_HEADING.match(stripped)
+        if m:
+            headings.append(m.group(1).strip())
+            continue
+
+        m = _BOLD_LINE.match(stripped)
+        if m:
+            headings.append(m.group(1).strip())
+            continue
+
+        m = _EMPHASIS_LINE.match(stripped)
+        if m:
+            headings.append(m.group(1).strip())
+            continue
+
+    return headings
+
+
+def _heading_matches_any_keyword(heading: str, keywords: frozenset[str]) -> bool:
+    """Return True if heading contains any keyword as a whole word (case-insensitive)."""
+    lower = heading.lower()
+    for kw in keywords:
+        if re.search(rf"\b{re.escape(kw)}\b", lower):
+            return True
+    return False
+
+
+def _readme_path(context: ProjectContext):
+    for name in ("README.md", "README.rst", "README.txt"):
+        p = context.root / name
+        if p.is_file():
+            return p
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def _required_readme_section_rule(
+    *,
+    rule_id: str,
+    title: str,
+    why: str,
+    keywords: frozenset[str],
+    fix_summary: str,
+) -> Callable[[ProjectContext], Finding]:
+    """Return a check function for a README section rule.
+
+    Semantics:
+    - NOT_APPLICABLE: README is absent (docs.readme.exists handles that)
+    - PASS: a heading outside code fences matches any keyword
+    - WARN: README exists but no matching heading found
+    """
+
+    def check(context: ProjectContext) -> Finding:
+        readme = _readme_path(context)
+
+        if readme is None:
+            return Finding(
+                rule_id=rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.NOT_APPLICABLE,
+                severity=RuleSeverity.RECOMMENDED,
+                title=title,
+                message=(
+                    "README is missing; content inspection is skipped. "
+                    "Add README.md first (see docs.readme.exists)."
+                ),
+                applicability=Applicability(
+                    status=ApplicabilityStatus.NOT_APPLICABLE,
+                    reason="README must exist before section content can be inspected.",
+                ),
+                source=RuleSource(url=_DOCS_SOURCE_URL),
+                fix=FixSuggestion(summary=fix_summary),
+                path="README.md",
+            )
+
+        text = readme.read_text(encoding="utf-8")
+        headings = _extract_headings(text)
+        found = any(_heading_matches_any_keyword(h, keywords) for h in headings)
+
+        if found:
+            return Finding(
+                rule_id=rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.PASS,
+                severity=RuleSeverity.RECOMMENDED,
+                title=title,
+                message=f"README contains a recognisable {title.lower()} section.",
+                applicability=Applicability(
+                    reason="Documenting this topic helps users install and maintain the integration.",
+                ),
+                source=RuleSource(url=_DOCS_SOURCE_URL),
+                fix=None,
+                path=readme.name,
+            )
+
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message=(
+                f"README does not appear to contain a {title.lower()} section "
+                f"(no heading matching: {', '.join(sorted(keywords))})."
+            ),
+            applicability=Applicability(
+                reason="Documenting this topic helps users install and maintain the integration.",
+            ),
+            source=RuleSource(url=_DOCS_SOURCE_URL),
+            fix=FixSuggestion(summary=fix_summary),
+            path=readme.name,
+        )
+
+    check.__name__ = rule_id.replace(".", "_")
+    return check
+
+
+# ---------------------------------------------------------------------------
+# Rule definitions
+# ---------------------------------------------------------------------------
+
+_INSTALLATION_KEYWORDS: frozenset[str] = frozenset(
+    {"installation", "install", "hacs", "manual installation", "manual install"}
+)
+_CONFIGURATION_KEYWORDS: frozenset[str] = frozenset(
+    {"configuration", "configure", "setup", "options"}
+)
+_TROUBLESHOOTING_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "troubleshooting",
+        "troubleshoot",
+        "known issues",
+        "known limitations",
+        "faq",
+        "support",
+        "debug",
+    }
+)
+_REMOVAL_KEYWORDS: frozenset[str] = frozenset(
+    {"removal", "remove", "uninstall", "uninstalling"}
+)
+_PRIVACY_KEYWORDS: frozenset[str] = frozenset(
+    {"privacy", "data", "telemetry", "cloud", "local"}
+)
+
+
+docs_installation_exists = _required_readme_section_rule(
+    rule_id="docs.installation.exists",
+    title="README installation section",
+    why=(
+        "A README installation section guides users through HACS or manual setup. "
+        f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+    ),
+    keywords=_INSTALLATION_KEYWORDS,
+    fix_summary=(
+        "Add an Installation section to README.md covering HACS and/or manual installation steps."
+    ),
+)
+
+docs_configuration_exists = _required_readme_section_rule(
+    rule_id="docs.configuration.exists",
+    title="README configuration section",
+    why=(
+        "A README configuration section explains how to set up and configure the integration. "
+        f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+    ),
+    keywords=_CONFIGURATION_KEYWORDS,
+    fix_summary=(
+        "Add a Configuration section to README.md describing available options and setup steps."
+    ),
+)
+
+docs_troubleshooting_exists = _required_readme_section_rule(
+    rule_id="docs.troubleshooting.exists",
+    title="README troubleshooting section",
+    why=(
+        "A README troubleshooting section reduces support burden by documenting known issues and solutions. "
+        f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+    ),
+    keywords=_TROUBLESHOOTING_KEYWORDS,
+    fix_summary=(
+        "Add a Troubleshooting or FAQ section to README.md with known issues and debug steps."
+    ),
+)
+
+docs_removal_exists = _required_readme_section_rule(
+    rule_id="docs.removal.exists",
+    title="README removal section",
+    why=(
+        "A README removal section explains how to cleanly uninstall the integration without leaving stale data. "
+        f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+    ),
+    keywords=_REMOVAL_KEYWORDS,
+    fix_summary=(
+        "Add a Removal or Uninstall section to README.md with steps to cleanly remove the integration."
+    ),
+)
+
+docs_privacy_exists = _required_readme_section_rule(
+    rule_id="docs.privacy.exists",
+    title="README privacy section",
+    why=(
+        "A README privacy section shows users the maintainer considered data handling "
+        "(cloud vs. local, telemetry, privacy). "
+        f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+    ),
+    keywords=_PRIVACY_KEYWORDS,
+    fix_summary=(
+        "Add a Privacy or Data section to README.md describing what data the integration collects or sends."
+    ),
+)
+
+
+RULES = [
+    RuleDefinition(
+        id="docs.installation.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="README installation section",
+        why=(
+            "A README installation section guides users through HACS or manual setup. "
+            f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+        ),
+        source_url=_DOCS_SOURCE_URL,
+        check=docs_installation_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="docs.configuration.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="README configuration section",
+        why=(
+            "A README configuration section explains how to set up and configure the integration. "
+            f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+        ),
+        source_url=_DOCS_SOURCE_URL,
+        check=docs_configuration_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="docs.troubleshooting.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="README troubleshooting section",
+        why=(
+            "A README troubleshooting section reduces support burden by documenting known issues. "
+            f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+        ),
+        source_url=_DOCS_SOURCE_URL,
+        check=docs_troubleshooting_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="docs.removal.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="README removal section",
+        why=(
+            "A README removal section explains how to cleanly uninstall the integration. "
+            f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+        ),
+        source_url=_DOCS_SOURCE_URL,
+        check=docs_removal_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="docs.privacy.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="README privacy section",
+        why=(
+            "A README privacy section shows users the maintainer considered data handling. "
+            f"Source: {_DOCS_SOURCE_URL} (verified {_SOURCE_CHECKED_AT})."
+        ),
+        source_url=_DOCS_SOURCE_URL,
+        check=docs_privacy_exists,
+        overridable=True,
+    ),
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -6,6 +6,7 @@ from hasscheck.rules.ci import RULES as CI_RULES
 from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
 from hasscheck.rules.diagnostics import RULES as DIAGNOSTICS_RULES
 from hasscheck.rules.docs import RULES as DOCS_RULES
+from hasscheck.rules.docs_readme import RULES as DOCS_README_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 from hasscheck.rules.repairs import RULES as REPAIRS_RULES
@@ -20,6 +21,7 @@ RULES = [
     *DIAGNOSTICS_RULES,
     *REPAIRS_RULES,
     *DOCS_RULES,
+    *DOCS_README_RULES,
     *REPOSITORY_RULES,
     *TESTS_RULES,
     *CI_RULES,

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -1,10 +1,10 @@
 """Integration tests against the bad_integration fixture.
 
-Design: D3 — whitelist-asserts only on the 7 v0.8 rule IDs that the fixture
-was designed to exercise. Other rules are NOT asserted here — keeps the test
-stable as more rules land in PR2/PR3/PR4.
+Design: D3 — whitelist-asserts only on the rule IDs that the fixture was
+designed to exercise. Other rules are NOT asserted here — keeps the test
+stable as more rules land.
 
-Extend this file when adding fixture coverage for new rules (PR2–PR4 tasks).
+Extend this file when adding fixture coverage for new rules.
 """
 
 from __future__ import annotations
@@ -78,3 +78,40 @@ def test_diagnostics_redaction_warns_on_bad_integration_fixture() -> None:
     f = findings["diagnostics.redaction.used"]
     assert f.status is RuleStatus.WARN
     assert "likely exposes secrets" in f.message
+
+
+# ---------------------------------------------------------------------------
+# PR5 / issue #55: README content rules — bad_integration README is intentionally
+# sparse (no installation/config/troubleshooting/removal/privacy sections)
+# ---------------------------------------------------------------------------
+
+
+def test_installation_section_warns_on_bad_integration_fixture() -> None:
+    """bad_integration README has no Installation section — docs.installation.exists must WARN."""
+    findings = _findings_by_id()
+    f = findings["docs.installation.exists"]
+    assert f.status is RuleStatus.WARN
+
+
+def test_configuration_section_warns_on_bad_integration_fixture() -> None:
+    """bad_integration README has no Configuration section — must WARN."""
+    findings = _findings_by_id()
+    assert findings["docs.configuration.exists"].status is RuleStatus.WARN
+
+
+def test_troubleshooting_section_warns_on_bad_integration_fixture() -> None:
+    """bad_integration README has no Troubleshooting section — must WARN."""
+    findings = _findings_by_id()
+    assert findings["docs.troubleshooting.exists"].status is RuleStatus.WARN
+
+
+def test_removal_section_warns_on_bad_integration_fixture() -> None:
+    """bad_integration README has no Removal section — must WARN."""
+    findings = _findings_by_id()
+    assert findings["docs.removal.exists"].status is RuleStatus.WARN
+
+
+def test_privacy_section_warns_on_bad_integration_fixture() -> None:
+    """bad_integration README has no Privacy section — must WARN."""
+    findings = _findings_by_id()
+    assert findings["docs.privacy.exists"].status is RuleStatus.WARN

--- a/tests/test_examples_good_integration.py
+++ b/tests/test_examples_good_integration.py
@@ -1,0 +1,48 @@
+"""Integration tests against the good_integration fixture.
+
+Whitelist-asserts only the README content rules added in issue #55.
+The good_integration README is designed to pass all five rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+
+FIXTURE_PATH = Path(__file__).parent.parent / "examples" / "good_integration"
+
+
+def _findings_by_id():
+    return {f.rule_id: f for f in run_check(FIXTURE_PATH).findings}
+
+
+# ---------------------------------------------------------------------------
+# issue #55 — README content rules pass on good_integration fixture
+# ---------------------------------------------------------------------------
+
+
+def test_installation_passes_on_good_integration_fixture() -> None:
+    findings = _findings_by_id()
+    assert findings["docs.installation.exists"].status is RuleStatus.PASS
+
+
+def test_configuration_passes_on_good_integration_fixture() -> None:
+    findings = _findings_by_id()
+    assert findings["docs.configuration.exists"].status is RuleStatus.PASS
+
+
+def test_troubleshooting_passes_on_good_integration_fixture() -> None:
+    findings = _findings_by_id()
+    assert findings["docs.troubleshooting.exists"].status is RuleStatus.PASS
+
+
+def test_removal_passes_on_good_integration_fixture() -> None:
+    findings = _findings_by_id()
+    assert findings["docs.removal.exists"].status is RuleStatus.PASS
+
+
+def test_privacy_passes_on_good_integration_fixture() -> None:
+    findings = _findings_by_id()
+    assert findings["docs.privacy.exists"].status is RuleStatus.PASS

--- a/tests/test_rules_docs_readme_content.py
+++ b/tests/test_rules_docs_readme_content.py
@@ -1,0 +1,263 @@
+"""Tests for README content rules (issue #55).
+
+Five rules:
+  docs.installation.exists
+  docs.configuration.exists
+  docs.troubleshooting.exists
+  docs.removal.exists
+  docs.privacy.exists
+
+All are RECOMMENDED + overridable=True.
+- NOT_APPLICABLE when README.md is absent.
+- PASS when a matching heading (or bold line) is found outside code fences.
+- WARN when README exists but no matching section detected.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from hasscheck.models import RuleStatus
+from hasscheck.rules.base import ProjectContext
+from hasscheck.rules.docs_readme import (
+    _extract_headings,
+    docs_configuration_exists,
+    docs_installation_exists,
+    docs_privacy_exists,
+    docs_removal_exists,
+    docs_troubleshooting_exists,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(tmp_path, readme_content: str | None):
+    """Build a minimal ProjectContext with an optional README."""
+    if readme_content is not None:
+        (tmp_path / "README.md").write_text(readme_content, encoding="utf-8")
+    return ProjectContext(root=tmp_path, integration_path=None, domain=None)
+
+
+# ---------------------------------------------------------------------------
+# _extract_headings unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_headings_returns_heading_text():
+    text = "# Installation\n\nSome text.\n\n## Configuration\n"
+    headings = _extract_headings(text)
+    assert "Installation" in headings
+    assert "Configuration" in headings
+
+
+def test_extract_headings_strips_code_fences():
+    text = textwrap.dedent("""\
+        # Installation
+
+        ```
+        # not a heading inside fence
+        ## install something
+        ```
+
+        ## Real Heading
+    """)
+    headings = _extract_headings(text)
+    assert "Real Heading" in headings
+    assert "not a heading inside fence" not in headings
+    assert "install something" not in headings
+
+
+def test_extract_headings_includes_bold_lines():
+    text = "**Installation**\n\nSome text.\n"
+    headings = _extract_headings(text)
+    assert "Installation" in headings
+
+
+def test_extract_headings_includes_emphasis_lines():
+    text = "_Configuration_\n\nSome text.\n"
+    headings = _extract_headings(text)
+    assert "Configuration" in headings
+
+
+# ---------------------------------------------------------------------------
+# Parametrized rule list for DRY tests
+# ---------------------------------------------------------------------------
+
+# (rule_fn, pass_heading, pass_keyword_in_heading, na_label)
+RULE_CASES = [
+    (docs_installation_exists, "## Installation", "installation", "installation"),
+    (docs_configuration_exists, "## Configuration", "configuration", "configuration"),
+    (
+        docs_troubleshooting_exists,
+        "## Troubleshooting",
+        "troubleshooting",
+        "troubleshooting",
+    ),
+    (docs_removal_exists, "## Removal", "removal", "removal"),
+    (docs_privacy_exists, "## Privacy", "privacy", "privacy"),
+]
+
+
+@pytest.mark.parametrize("rule_fn,heading,_kw,_label", RULE_CASES)
+def test_pass_with_standard_heading(rule_fn, heading, _kw, _label, tmp_path):
+    """README with a matching markdown heading → PASS."""
+    content = f"# My Integration\n\n{heading}\n\nSome content here.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = rule_fn(ctx)
+    assert finding.status is RuleStatus.PASS, (
+        f"{rule_fn.__name__}: expected PASS for heading '{heading}', got {finding.status}: {finding.message}"
+    )
+
+
+@pytest.mark.parametrize("rule_fn,heading,_kw,_label", RULE_CASES)
+def test_pass_with_bold_section_header(rule_fn, heading, _kw, _label, tmp_path):
+    """README with a bold line matching keyword → PASS."""
+    # Derive a keyword from the heading: strip ## and use title case
+    section = heading.lstrip("# ").strip()
+    content = f"# My Integration\n\n**{section}**\n\nSome content here.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = rule_fn(ctx)
+    assert finding.status is RuleStatus.PASS, (
+        f"{rule_fn.__name__}: expected PASS for bold '**{section}**', got {finding.status}: {finding.message}"
+    )
+
+
+@pytest.mark.parametrize("rule_fn,_heading,_kw,_label", RULE_CASES)
+def test_warn_on_minimal_readme(rule_fn, _heading, _kw, _label, tmp_path):
+    """Minimal README with no matching section → WARN."""
+    content = "# My Integration\n\nThis integration does something great.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = rule_fn(ctx)
+    assert finding.status is RuleStatus.WARN, (
+        f"{rule_fn.__name__}: expected WARN for minimal README, got {finding.status}"
+    )
+
+
+@pytest.mark.parametrize("rule_fn,_heading,kw,_label", RULE_CASES)
+def test_warn_keyword_inside_code_fence(rule_fn, _heading, kw, _label, tmp_path):
+    """Keyword only inside a code fence must NOT trigger PASS — expect WARN."""
+    content = textwrap.dedent(f"""\
+        # My Integration
+
+        ```bash
+        # {kw} step
+        ```
+    """)
+    ctx = _ctx(tmp_path, content)
+    finding = rule_fn(ctx)
+    assert finding.status is RuleStatus.WARN, (
+        f"{rule_fn.__name__}: keyword '{kw}' inside code fence should NOT cause PASS, got {finding.status}"
+    )
+
+
+@pytest.mark.parametrize("rule_fn,_heading,_kw,_label", RULE_CASES)
+def test_not_applicable_when_readme_missing(rule_fn, _heading, _kw, _label, tmp_path):
+    """No README at all → NOT_APPLICABLE."""
+    ctx = _ctx(tmp_path, None)
+    finding = rule_fn(ctx)
+    assert finding.status is RuleStatus.NOT_APPLICABLE, (
+        f"{rule_fn.__name__}: expected NOT_APPLICABLE when README absent, got {finding.status}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Installation-specific: sub-heading keyword variants
+# ---------------------------------------------------------------------------
+
+
+def test_installation_passes_for_hacs_subheading(tmp_path):
+    """### HACS is a recognized installation-related heading."""
+    content = "# My Integration\n\n### HACS\n\nInstall via HACS.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_installation_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+def test_installation_passes_for_manual_install_heading(tmp_path):
+    """## Manual Install heading → PASS."""
+    content = "# My Integration\n\n## Manual Install\n\nCopy files.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_installation_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Privacy rule: broad keyword set
+# ---------------------------------------------------------------------------
+
+
+def test_privacy_passes_for_cloud_heading(tmp_path):
+    """## Cloud heading satisfies privacy rule."""
+    content = "# My Integration\n\n## Cloud\n\nData goes to the cloud.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_privacy_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+def test_privacy_passes_for_data_heading(tmp_path):
+    """## Data heading satisfies privacy rule."""
+    content = "# My Integration\n\n## Data\n\nAll data is local.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_privacy_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+def test_privacy_passes_for_local_heading(tmp_path):
+    """## Local heading satisfies privacy rule."""
+    content = "# My Integration\n\n## Local Processing\n\nNo cloud.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_privacy_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity checks
+# ---------------------------------------------------------------------------
+
+
+def test_installation_passes_case_insensitive(tmp_path):
+    """INSTALLATION (all caps) heading → PASS."""
+    content = "# My Integration\n\n## INSTALLATION\n\nStep 1.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_installation_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+def test_configuration_passes_mixed_case(tmp_path):
+    """## ConFiguration → PASS."""
+    content = "# My Integration\n\n## ConFiguration\n\nSet things.\n"
+    ctx = _ctx(tmp_path, content)
+    finding = docs_configuration_exists(ctx)
+    assert finding.status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Rule metadata checks
+# ---------------------------------------------------------------------------
+
+from hasscheck.models import RuleSeverity  # noqa: E402
+from hasscheck.rules.docs_readme import RULES as DOCS_README_RULES  # noqa: E402
+
+
+def test_all_five_rules_registered():
+    rule_ids = {r.id for r in DOCS_README_RULES}
+    expected = {
+        "docs.installation.exists",
+        "docs.configuration.exists",
+        "docs.troubleshooting.exists",
+        "docs.removal.exists",
+        "docs.privacy.exists",
+    }
+    assert rule_ids == expected
+
+
+def test_all_five_rules_are_recommended_and_overridable():
+    for rule in DOCS_README_RULES:
+        assert rule.severity is RuleSeverity.RECOMMENDED, (
+            f"{rule.id} should be RECOMMENDED"
+        )
+        assert rule.overridable is True, f"{rule.id} should be overridable=True"

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 25 rules total (v0.8 PR4 adds 1 diagnostics rule):
-#   - diagnostics.redaction.used (overridable=True, RECOMMENDED)
-# 11 locked overridable=False, 14 overridable=True.
+# 30 rules total (v0.9 issue #55 adds 5 README content rules):
+#   - docs.installation.exists (overridable=True, RECOMMENDED)
+#   - docs.configuration.exists (overridable=True, RECOMMENDED)
+#   - docs.troubleshooting.exists (overridable=True, RECOMMENDED)
+#   - docs.removal.exists (overridable=True, RECOMMENDED)
+#   - docs.privacy.exists (overridable=True, RECOMMENDED)
+# 11 locked overridable=False, 19 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -46,11 +50,17 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "manifest.iot_class.valid",
     "manifest.integration_type.exists",
     "manifest.integration_type.valid",
+    # v0.9 issue #55 — README content rules (RECOMMENDED, overridable=True)
+    "docs.installation.exists",
+    "docs.configuration.exists",
+    "docs.troubleshooting.exists",
+    "docs.removal.exists",
+    "docs.privacy.exists",
 }
 
 
-def test_total_rule_count_is_twenty_five() -> None:
-    assert len(RULES) == 25, f"expected 25 rules, got {len(RULES)}"
+def test_total_rule_count_is_thirty() -> None:
+    assert len(RULES) == 30, f"expected 30 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

Adds five README content-detection rules. \`docs.readme.exists\` already gates file presence; these rules check that the README *actually documents* the integration. All five are RECOMMENDED + overridable + WARN-on-missing — never FAIL a repo for docs wording.

Closes #55.

## Rules

| Rule ID | Keywords (case-insensitive) |
|---------|------------------------------|
| \`docs.installation.exists\` | installation, install, hacs, manual installation, manual install |
| \`docs.configuration.exists\` | configuration, configure, setup, options |
| \`docs.troubleshooting.exists\` | troubleshooting, troubleshoot, known issues, known limitations, faq, support, debug |
| \`docs.removal.exists\` | removal, remove, uninstall, uninstalling |
| \`docs.privacy.exists\` | privacy, data, telemetry, cloud, local |

All five: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=docs_and_maintenance\`.

## Detection — conservative heading-only

For each rule's keyword set:

1. **Markdown ATX heading** (\`#\`–\`######\`) containing any keyword as whole word → PASS
2. **Bold / emphasis solo line** (\`**Installation**\` or \`_Installation_\`) → PASS
3. Otherwise → WARN

Code fences are stripped before matching so ` \`\`\`bash\\nbrew install...\\n\`\`\` ` doesn't trigger a false PASS.

Heading-only by design — keeps the signal "the maintainer thought to add a section." Prose-only READMEs deliberately fall through to WARN; expanding to phrase matching is a v0.10+ refinement once we have signal.

## Test plan

- [x] \`uv run pytest -q\` — **486 passing** (438 baseline + 48 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: RED tests written first per rule
- [x] \`uv run hasscheck explain docs.{installation,configuration,troubleshooting,removal,privacy}.exists\` — all five exit 0
- [x] \`uv run hasscheck check --path examples/bad_integration\` — all five emit WARN deterministically (existing fixture README is intentionally sparse)
- [x] \`uv run hasscheck check --path examples/good_integration\` — all five PASS (good fixture README updated to include each section)

## Notes

- **Good fixture updated**: \`examples/good_integration/README.md\` gained the five required section headings so the new positive integration test passes. The bad fixture remains intentionally sparse and the new whitelist assertions cover all five WARNs.
- **Rule count audit** (\`tests/test_rules_meta.py\`): 25 → 30. Locked count unchanged (all five overridable).
- **README "Current rule set"** updated with five new rows under "Docs and maintenance."
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\` (per ADR 0006 — additive within same ruleset cycle).
- **Factory pattern** \`_required_readme_section_rule()\` + \`_extract_headings()\` helper — both live in the new \`src/hasscheck/rules/docs_readme.py\` module. Mirrors the manifest-enum factory pattern from PR #87.

## Out of scope (deferred)

- HACS-specific README sub-rules
- "Examples" section detection (keyword set unclear)
- "Supported devices/services" section (vague signal)
- Prose-only matching (heading-only is deliberately conservative for v1)