### PR TITLE
docs(v0.9): adoption sweep — comparison + per-rule pages + demo walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ HassCheck turns scattered Home Assistant and HACS expectations into local checks
 
 HassCheck starts as a local CLI. Public badges, hosted reports, and any future hub should be opt-in only.
 
+## See it in action
+
+HassCheck is designed to produce concrete next steps, not a vague score.
+
+```bash
+uv run hasscheck check --path examples/bad_integration
+uv run hasscheck scaffold diagnostics --path examples/bad_integration --dry-run
+```
+
+See [`docs/demo.md`](docs/demo.md) for the full workflow.
+
 ## How HassCheck relates to other tools
 
 | Tool | Purpose | HassCheck relationship |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ HassCheck turns scattered Home Assistant and HACS expectations into local checks
 
 HassCheck starts as a local CLI. Public badges, hosted reports, and any future hub should be opt-in only.
 
+## How HassCheck relates to other tools
+
+| Tool | Purpose | HassCheck relationship |
+|---|---|---|
+| [hassfest](https://github.com/home-assistant/core/tree/dev/script/hassfest) | Validates Home Assistant integration metadata and compatibility expectations. | Complementary. HassCheck does not replace hassfest. |
+| [HACS publishing docs](https://www.hacs.xyz/docs/publish/start/) | Define repository structure and metadata expectations for HACS custom integrations. | HassCheck turns selected expectations into sourced local checks. |
+| [Home Assistant Integration Quality Scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/) | Official framework for graded core integrations. | HassCheck reports unofficial quality signals only; it does not assign official tiers. |
+
+HassCheck is intentionally not a replacement for hassfest and does not assign Home Assistant quality tiers. It provides maintainer-facing, sourced findings that help custom integration authors improve their repositories.
+
 ## Current status
 
 - **Latest release:** v0.7.0 — opt-in hosted reports via GitHub OIDC

--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ HACS Acceptance: Not guaranteed
 
 The exact category order may change as rules evolve. The JSON schema is the durable contract.
 
+## Documentation
+
+Per-rule documentation pages with status behavior tables, fix instructions, and examples: [`docs/rules/`](docs/rules/README.md).
+
 ## Current rule set
 
 ### HACS structure

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,72 @@
+# HassCheck demo
+
+Run HassCheck against the tracked `bad_integration` fixture, see findings, run a scaffold, see improvement.
+
+## 1. Check the bad fixture
+
+```bash
+uv run hasscheck check --path examples/bad_integration
+```
+
+Expected output (abridged):
+
+```text
+HassCheck Summary
+
+Diagnostics/Repairs: 1 / 3
+Docs/Support: 1 / 6
+HACS Structure: 1 / 3
+Manifest Metadata: 8 / 11
+Modern HA Patterns: 2 / 3
+Tests/CI: 0 / 2
+
+Overall: Informational only
+Security Review: Not performed
+Official HA Tier: Not assigned
+HACS Acceptance: Not guaranteed
+
+...
+| FAIL | manifest.domain.matches_directory | manifest.json domain "wrong_domain" does not match integration directory "demo_bad". |
+| FAIL | manifest.iot_class.valid          | manifest.json iot_class "not_a_valid_class" is not a recognized value ...            |
+| WARN | diagnostics.redaction.used        | diagnostics returns entry.data without redaction — likely exposes secrets ...         |
+```
+
+The fixture intentionally triggers a range of findings across categories so you can see what actionable output looks like.
+
+## 2. Inspect a finding
+
+```bash
+uv run hasscheck explain manifest.domain.matches_directory
+```
+
+Output shows the rule ID, severity, whether it is overridable, the `why` text, and the source URL — the same sourced information that appears in the JSON report.
+
+## 3. Generate a fix scaffold
+
+```bash
+uv run hasscheck scaffold diagnostics --path examples/bad_integration --dry-run
+```
+
+The `--dry-run` flag prints the proposed file contents without writing. This lets you review the generated `diagnostics.py` starter before committing.
+
+## 4. Apply the fix
+
+Drop `--dry-run` to write files.
+
+```bash
+uv run hasscheck scaffold diagnostics --path examples/bad_integration
+```
+
+This writes `custom_components/demo_bad/diagnostics.py` with a local redaction helper pre-wired.
+
+## 5. Re-check
+
+```bash
+uv run hasscheck check --path examples/bad_integration
+```
+
+The `diagnostics.redaction.used` finding should improve from WARN to PASS after the scaffold is applied. Other findings (like `manifest.domain.matches_directory`) remain until you fix the underlying manifest mismatch.
+
+## 6. Wire into CI (optional)
+
+See [README "GitHub Action"](../README.md#github-action) for the composite action. The same fixture lives in `examples/`; you can point the action at any path.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,63 @@
+# HassCheck Rule Index
+
+All 30 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
+
+## HACS structure
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `hacs.custom_components.exists` | Repository has `custom_components/`. | (no docs page yet) |
+| `hacs.file.parseable` | Repository has parseable `hacs.json`. | (no docs page yet) |
+| `brand.icon.exists` | Integration has `custom_components/<domain>/brand/icon.png`. | (no docs page yet) |
+
+## Manifest metadata
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `manifest.exists` | Integration has `manifest.json`. | (no docs page yet) |
+| `manifest.domain.exists` | Manifest defines `domain`. | (no docs page yet) |
+| `manifest.domain.matches_directory` | Manifest `domain` matches the integration directory name. | [manifest.domain.matches_directory.md](manifest.domain.matches_directory.md) |
+| `manifest.name.exists` | Manifest defines `name`. | (no docs page yet) |
+| `manifest.version.exists` | Manifest defines `version`. | (no docs page yet) |
+| `manifest.documentation.exists` | Manifest defines `documentation`. | (no docs page yet) |
+| `manifest.issue_tracker.exists` | Manifest defines `issue_tracker`. | (no docs page yet) |
+| `manifest.codeowners.exists` | Manifest defines non-empty `codeowners`. | (no docs page yet) |
+| `manifest.iot_class.exists` | Manifest declares `iot_class`. | (no docs page yet) |
+| `manifest.iot_class.valid` | Manifest `iot_class` is a recognized value. | [manifest.iot_class.valid.md](manifest.iot_class.valid.md) |
+| `manifest.integration_type.exists` | Manifest declares `integration_type`. | (no docs page yet) |
+| `manifest.integration_type.valid` | Manifest `integration_type` is a recognized value. | [manifest.integration_type.valid.md](manifest.integration_type.valid.md) |
+
+## Modern Home Assistant patterns
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `config_flow.file.exists` | Integration has `config_flow.py`. | (no docs page yet) |
+| `config_flow.manifest_flag_consistent` | `config_flow.py` and manifest `config_flow: true` agree. | (no docs page yet) |
+| `config_flow.user_step.exists` | `config_flow.py` defines `async_step_user` (AST inspection). | [config_flow.user_step.exists.md](config_flow.user_step.exists.md) |
+
+## Diagnostics and repairs
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `diagnostics.file.exists` | Integration has `diagnostics.py`. | (no docs page yet) |
+| `diagnostics.redaction.used` | `diagnostics.py` uses `async_redact_data` or a local redaction helper (AST inspection). | [diagnostics.redaction.used.md](diagnostics.redaction.used.md) |
+| `repairs.file.exists` | Integration has `repairs.py`. | (no docs page yet) |
+
+## Docs and maintenance
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `docs.readme.exists` | Repository has a README. | (no docs page yet) |
+| `docs.installation.exists` | README contains an Installation section (HACS or manual). | [docs.installation.exists.md](docs.installation.exists.md) |
+| `docs.configuration.exists` | README contains a Configuration / Setup section. | (no docs page yet) |
+| `docs.troubleshooting.exists` | README contains a Troubleshooting / FAQ / Support section. | (no docs page yet) |
+| `docs.removal.exists` | README contains a Removal / Uninstall section. | (no docs page yet) |
+| `docs.privacy.exists` | README addresses privacy / data / cloud / local handling. | [docs.privacy.exists.md](docs.privacy.exists.md) |
+| `repo.license.exists` | Repository has a license file. | (no docs page yet) |
+
+## Tests and CI
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `tests.folder.exists` | Repository has `tests/`. | (no docs page yet) |
+| `ci.github_actions.exists` | Repository has `.github/workflows/*.yml` or `.yaml`. | (no docs page yet) |

--- a/docs/rules/config_flow.user_step.exists.md
+++ b/docs/rules/config_flow.user_step.exists.md
@@ -1,0 +1,74 @@
+# config_flow.user_step.exists
+
+## Summary
+
+Checks that `config_flow.py` defines an `async_step_user` method using AST inspection. Without it, users cannot start integration setup from the Home Assistant UI (Settings → Devices & Services).
+
+## Why this matters
+
+`async_step_user` is the standard entry point for Home Assistant config flows initiated by the user from the UI. If `config_flow.py` exists but does not define this method, the integration cannot be set up interactively — users must configure it manually via `configuration.yaml`, which is increasingly unsupported by HACS and the HA ecosystem. Note: this rule uses static AST inspection and cannot detect `async_step_user` defined only in a base class, mixin, or via dynamic attribute assignment — those cases produce a false WARN.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| No integration directory detected | NOT_APPLICABLE |
+| `hasscheck.yaml` declares `uses_config_flow: false` | NOT_APPLICABLE |
+| `config_flow.py` does not exist | NOT_APPLICABLE |
+| `config_flow.py` has a syntax error | WARN |
+| `config_flow.py` defines `async_step_user` | PASS |
+| `config_flow.py` does not define `async_step_user` | WARN |
+
+## How to fix
+
+Add `async_step_user` to your `ConfigFlow` class in `config_flow.py`:
+
+```python
+class MyIntegrationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="My Integration", data=user_input)
+        return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+```
+
+See the [HA config flow handler docs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#defining-the-flow) for the full pattern.
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED). If the integration intentionally uses only `configuration.yaml` setup:
+
+```yaml
+applicability:
+  uses_config_flow: false
+```
+
+This marks both `config_flow.file.exists` and `config_flow.user_step.exists` as NOT_APPLICABLE.
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#defining-the-flow
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```python
+# custom_components/my_sensor/config_flow.py
+from homeassistant import config_entries
+
+class MySensorConfigFlow(config_entries.ConfigFlow, domain="my_sensor"):
+    async def async_step_user(self, user_input=None):
+        ...
+```
+
+### Failing / warning
+
+```python
+# custom_components/my_sensor/config_flow.py
+from homeassistant import config_entries
+
+class MySensorConfigFlow(config_entries.ConfigFlow, domain="my_sensor"):
+    # async_step_user is missing — HassCheck reports WARN
+    pass
+```

--- a/docs/rules/diagnostics.redaction.used.md
+++ b/docs/rules/diagnostics.redaction.used.md
@@ -1,0 +1,83 @@
+# diagnostics.redaction.used
+
+## Summary
+
+Checks that `diagnostics.py` uses `async_redact_data` from `homeassistant.components.diagnostics` or a local redaction helper (matched by name pattern `^_?redact(_.*)?$`) before returning diagnostic data. Uses AST static inspection.
+
+## Why this matters
+
+Home Assistant diagnostics expose integration state for troubleshooting. Without redaction, sensitive fields (API keys, tokens, passwords, coordinates) can be leaked when users share diagnostic downloads with maintainers or support channels. This rule checks for the most common patterns; it cannot detect redaction performed in a base class, mixin, or via dynamic dispatch — those cases may produce a false WARN. A WARN does NOT guarantee a bug; treat it as a prompt for manual review of the diagnostics output.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| No integration directory detected | NOT_APPLICABLE |
+| `hasscheck.yaml` declares `supports_diagnostics: false` | NOT_APPLICABLE |
+| `diagnostics.py` does not exist | NOT_APPLICABLE |
+| `diagnostics.py` has a syntax error | WARN |
+| `diagnostics.py` exists but has no diagnostics function | NOT_APPLICABLE |
+| Diagnostics function returns `entry.data` / `entry.options` directly without redaction | WARN |
+| `async_redact_data` or a matching local redaction helper is called | PASS |
+| Diagnostics function exists, no raw return, no recognized redaction | WARN |
+
+## How to fix
+
+Use `async_redact_data` from `homeassistant.components.diagnostics` with a list of sensitive keys:
+
+```python
+from homeassistant.components.diagnostics import async_redact_data
+
+TO_REDACT = ["api_key", "password", "token", "latitude", "longitude"]
+
+async def async_get_config_entry_diagnostics(hass, entry):
+    return async_redact_data(dict(entry.data), TO_REDACT)
+```
+
+Alternatively, use `hasscheck scaffold diagnostics --path <your-integration-path>` to generate a starter file with a local redaction helper.
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED). To declare the integration does not expose diagnostics:
+
+```yaml
+applicability:
+  supports_diagnostics: false
+```
+
+Or to override just this rule:
+
+```yaml
+rules:
+  diagnostics.redaction.used:
+    status: manual_review
+    reason: Redaction is performed in the shared base class DiagnosticsMixin.
+```
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/core/integration/diagnostics/
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```python
+from homeassistant.components.diagnostics import async_redact_data
+
+TO_REDACT = ["api_key", "token"]
+
+async def async_get_config_entry_diagnostics(hass, entry):
+    return async_redact_data(dict(entry.data), TO_REDACT)
+```
+
+### Failing / warning
+
+```python
+async def async_get_config_entry_diagnostics(hass, entry):
+    # Returns raw entry data — likely exposes secrets
+    return dict(entry.data)
+```
+
+HassCheck reports WARN because `entry.data` is returned without redaction.

--- a/docs/rules/docs.installation.exists.md
+++ b/docs/rules/docs.installation.exists.md
@@ -1,0 +1,76 @@
+# docs.installation.exists
+
+## Summary
+
+Checks that the repository README contains a recognisable Installation section by scanning headings for installation-related keywords. A missing installation section means users have no in-repo guidance for adding the integration via HACS or manually.
+
+## Why this matters
+
+A README installation section guides users through HACS or manual setup. Without it, users must guess the setup path or find instructions elsewhere, increasing support requests and reducing adoption. This rule uses a conservative heading-only heuristic — it scans Markdown headings, bold solo lines, and emphasis solo lines outside code fences, and reports WARN only when no matching heading is found.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| README is missing | NOT_APPLICABLE |
+| README has a heading matching an installation keyword | PASS |
+| README exists but no matching heading found | WARN |
+
+**Installation keywords** (whole-word match, case-insensitive): `installation`, `install`, `hacs`, `manual installation`, `manual install`.
+
+## How to fix
+
+Add an Installation section to `README.md`. Minimal example:
+
+```markdown
+## Installation
+
+### Via HACS
+
+1. Open HACS in your Home Assistant instance.
+2. Search for "My Sensor".
+3. Click Install.
+
+### Manual
+
+1. Copy `custom_components/my_sensor/` to your `custom_components/` directory.
+2. Restart Home Assistant.
+```
+
+Any heading that contains one of the installation keywords will satisfy this rule.
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED):
+
+```yaml
+rules:
+  docs.installation.exists:
+    status: not_applicable
+    reason: Installation instructions live in an external wiki.
+```
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/documenting_integrations
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```markdown
+## Installation
+
+Install via HACS or manually by copying the integration folder.
+```
+
+### Failing / warning
+
+```markdown
+## My Sensor
+
+A great sensor integration.
+```
+
+No heading contains `install`, `hacs`, or related keywords — HassCheck reports WARN.

--- a/docs/rules/docs.privacy.exists.md
+++ b/docs/rules/docs.privacy.exists.md
@@ -1,0 +1,83 @@
+# docs.privacy.exists
+
+## Summary
+
+Checks that the repository README contains a recognisable privacy or data handling section by scanning headings for privacy-related keywords. Presence of this section signals that the maintainer considered what data the integration collects or transmits.
+
+## Why this matters
+
+A README privacy section shows users the maintainer considered data handling — whether the integration operates cloud vs. local, sends telemetry, or stores sensitive data. Integration Quality Scale guidelines expect maintainers to document this explicitly. Without it, users have no way to evaluate the integration's privacy posture before installing. This rule uses a conservative heading-only heuristic.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| README is missing | NOT_APPLICABLE |
+| README has a heading matching a privacy keyword | PASS |
+| README exists but no matching heading found | WARN |
+
+**Privacy keywords** (whole-word match, case-insensitive): `privacy`, `data`, `telemetry`, `cloud`, `local`.
+
+Note: `data` and `local` are broad — any heading containing these words (e.g. "Local data", "Data storage", "Cloud connectivity") satisfies the rule.
+
+## How to fix
+
+Add a Privacy or Data section to `README.md`. Minimal example:
+
+```markdown
+## Privacy
+
+This integration communicates only with the local device at the configured IP address.
+No data is sent to external servers or cloud services.
+```
+
+Or for a cloud-based integration:
+
+```markdown
+## Data
+
+This integration uses the Example Cloud API. Device state is synced via the
+vendor's cloud service. See the vendor's privacy policy for data retention details.
+```
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED):
+
+```yaml
+rules:
+  docs.privacy.exists:
+    status: not_applicable
+    reason: Privacy documentation lives in the integration's wiki.
+```
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/documenting_integrations
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```markdown
+## Local operation
+
+This integration operates entirely on your local network and does not contact any cloud services.
+```
+
+The heading contains `local` — HassCheck reports PASS.
+
+### Failing / warning
+
+```markdown
+## My Sensor
+
+A great sensor integration.
+
+## Installation
+
+Install via HACS.
+```
+
+No heading contains `privacy`, `data`, `telemetry`, `cloud`, or `local` — HassCheck reports WARN.

--- a/docs/rules/manifest.domain.matches_directory.md
+++ b/docs/rules/manifest.domain.matches_directory.md
@@ -1,0 +1,58 @@
+# manifest.domain.matches_directory
+
+## Summary
+
+Checks that the `domain` field in `manifest.json` matches the name of the integration directory under `custom_components/`. A mismatch causes Home Assistant to silently misidentify the integration, breaking HACS discovery and core platform loading.
+
+## Why this matters
+
+Home Assistant uses the integration directory name as the authoritative domain identifier. When `manifest.json` declares a different domain, the platform loader and HACS treat them as two separate entities. This mismatch is silent — no error is thrown at install time — so integrations can appear to load while being unreachable by domain-dependent features. This rule cannot be overridden via `hasscheck.yaml`.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| No integration directory (`custom_components/<domain>/`) detected | NOT_APPLICABLE |
+| `manifest.json` is missing | NOT_APPLICABLE |
+| `manifest.json` is invalid JSON | FAIL |
+| `manifest.domain` matches the directory name | PASS |
+| `manifest.domain` does not match the directory name | FAIL |
+
+## How to fix
+
+Rename the integration directory to match `manifest.domain`, or update `manifest.domain` to match the existing directory name. Both sides must agree on the same stable domain string.
+
+## Applicability / overrides
+
+This rule is **not overridable** via `hasscheck.yaml`. The domain-directory consistency is a structural requirement; no project-level flag changes its evaluation.
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/creating_integration_manifest
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```json
+// custom_components/my_sensor/manifest.json
+{
+  "domain": "my_sensor",
+  "name": "My Sensor"
+}
+```
+
+The directory is `my_sensor/` and the manifest domain is `"my_sensor"` — they agree.
+
+### Failing
+
+```json
+// custom_components/my_sensor/manifest.json
+{
+  "domain": "wrong_domain",
+  "name": "My Sensor"
+}
+```
+
+The directory is `my_sensor/` but the manifest domain is `"wrong_domain"` — HassCheck reports FAIL.

--- a/docs/rules/manifest.integration_type.valid.md
+++ b/docs/rules/manifest.integration_type.valid.md
@@ -1,0 +1,75 @@
+# manifest.integration_type.valid
+
+## Summary
+
+Checks that the `integration_type` field in `manifest.json` is one of the canonical values defined in the Home Assistant integration manifest docs. An unrecognised value is rejected by the core manifest loader in newer HA versions.
+
+## Why this matters
+
+`integration_type` classifies how the integration fits into the Home Assistant architecture — as a hub managing devices, a helper that processes data, a hardware-level driver, and so on. Newer HA versions actively reject unknown values at manifest load time, which can prevent the integration from loading. Custom integrations default to `"hub"` when the field is omitted, but a present-but-invalid value is worse than absent.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| No integration directory detected | NOT_APPLICABLE |
+| `manifest.json` is missing | NOT_APPLICABLE |
+| `manifest.json` is invalid JSON | NOT_APPLICABLE (exists rule handles FAIL) |
+| `integration_type` field is absent | NOT_APPLICABLE |
+| `integration_type` value is a recognized value | PASS |
+| `integration_type` value is not a recognized value | FAIL |
+
+## How to fix
+
+Set `integration_type` in `manifest.json` to one of the following recognized values:
+
+- `device`
+- `entity`
+- `hardware`
+- `helper`
+- `hub`
+- `service`
+- `system`
+- `virtual`
+
+Most custom integrations that talk to an external service or device should use `"hub"`.
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED). Add the following to opt out:
+
+```yaml
+rules:
+  manifest.integration_type.valid:
+    status: not_applicable
+    reason: <your reason>
+```
+
+This rule is only evaluated when `integration_type` is present. If the field is absent, `manifest.integration_type.exists` warns first.
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/creating_integration_manifest
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```json
+{
+  "domain": "my_sensor",
+  "integration_type": "hub"
+}
+```
+
+### Failing
+
+```json
+{
+  "domain": "my_sensor",
+  "integration_type": "appliance"
+}
+```
+
+HassCheck reports FAIL because `"appliance"` is not a recognized value.

--- a/docs/rules/manifest.iot_class.valid.md
+++ b/docs/rules/manifest.iot_class.valid.md
@@ -1,0 +1,73 @@
+# manifest.iot_class.valid
+
+## Summary
+
+Checks that the `iot_class` field in `manifest.json` is one of the canonical values defined in the Home Assistant integration manifest docs. An unrecognised value may cause HA to silently ignore the field or display incorrect information.
+
+## Why this matters
+
+`iot_class` tells Home Assistant and users how the integration fetches data — whether it polls or uses push, and whether the connection is to a cloud service or local device. HA may use this to set UI expectations around connectivity and latency. Supplying an unrecognised value means the field is effectively absent, and users see no connectivity classification.
+
+## Status behavior
+
+| Condition | Status |
+|---|---|
+| No integration directory detected | NOT_APPLICABLE |
+| `manifest.json` is missing | NOT_APPLICABLE |
+| `manifest.json` is invalid JSON | NOT_APPLICABLE (exists rule handles FAIL) |
+| `iot_class` field is absent | NOT_APPLICABLE |
+| `iot_class` value is a recognized value | PASS |
+| `iot_class` value is not a recognized value | FAIL |
+
+## How to fix
+
+Set `iot_class` in `manifest.json` to one of the following recognized values:
+
+- `assumed_state`
+- `calculated`
+- `cloud_polling`
+- `cloud_push`
+- `local_polling`
+- `local_push`
+
+Choose the value that most accurately describes how your integration retrieves state from the device or service.
+
+## Applicability / overrides
+
+Overridable via `hasscheck.yaml` (severity: RECOMMENDED). Add the following to opt out:
+
+```yaml
+rules:
+  manifest.iot_class.valid:
+    status: not_applicable
+    reason: <your reason>
+```
+
+This rule is only evaluated when `iot_class` is present. If the field is absent, `manifest.iot_class.exists` warns first.
+
+## Source
+
+- HA dev docs: https://developers.home-assistant.io/docs/creating_integration_manifest
+- `source_checked_at`: 2026-05-01
+
+## Examples
+
+### Passing
+
+```json
+{
+  "domain": "my_sensor",
+  "iot_class": "local_polling"
+}
+```
+
+### Failing
+
+```json
+{
+  "domain": "my_sensor",
+  "iot_class": "not_a_valid_class"
+}
+```
+
+HassCheck reports FAIL with the list of recognized values.


### PR DESCRIPTION
## Summary

Three-commit adoption-focused docs sweep ahead of the public OSS launch. Closes #57, #58, #59 in a single PR.

## Commits

| Commit | Issue | What |
|--------|-------|------|
| \`f3f8edf\` | #57 | README "How HassCheck relates to other tools" — comparison table positioning HassCheck against hassfest, HACS publishing docs, and the HA Integration Quality Scale. Explicit "complementary, not a replacement" framing. |
| \`2704954\` | #58 | \`docs/rules/README.md\` index covering all 30 rules grouped by category. Seven hand-written per-rule pages for the highest-leverage rules (manifest.domain.matches_directory, manifest.iot_class.valid, manifest.integration_type.valid, config_flow.user_step.exists, diagnostics.redaction.used, docs.installation.exists, docs.privacy.exists). README links to the index. |
| \`d33b764\` | #59 | \`docs/demo.md\` — copy-paste walkthrough using the tracked \`examples/bad_integration\` fixture: check → explain → scaffold dry-run → re-check loop. README "See it in action" section links to it. Real captured output snippets, no fabrication. |

## Test plan

- [x] \`uv run pytest -q\` — **486 passing**, zero changes (docs-only PR)
- [x] \`uv run ruff check\` — clean
- [x] \`docs/rules/README.md\` lists all 30 current rules
- [x] All 7 per-rule pages reference real \`why\` / \`fix.summary\` / \`source.url\` from \`src/hasscheck/rules/\` — no fabricated behavior
- [x] \`docs/demo.md\` commands all reference tracked fixtures (\`examples/bad_integration\`); output snippets captured from real local runs
- [x] hassfest, HACS, and HA IQS URLs verified live
- [x] No "certify" / "approved" / "ready" / "safe" language anywhere — unofficial stance preserved

## Notes

- **Auto-generation deferred**: per #58 issue ("may be overengineering for the first version"), the 7 per-rule pages are hand-written. The 23 remaining rules sit in the index with no docs page yet — when v0.10 expands rule coverage further, generating pages from \`RuleDefinition\` metadata becomes worth the cost.
- **No source changes**: this PR is documentation-only. \`SCHEMA_VERSION\`, \`DEFAULT_RULESET_ID\`, rule count, and test count are all unchanged.
- **README structure**: three new sections added near the top (See it in action / How HassCheck relates to other tools / Documentation link). Existing rule tables preserved verbatim.