### PR TITLE
chore(repo): pre-public-flip cleanup — README, CONTRIBUTING, CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at alangil505@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to HassCheck
+
+Thanks for considering a contribution. HassCheck is a small, focused tool — a few patterns keep it that way.
+
+## Before you start
+
+- **File an issue first.** Every change goes through maintainer review BEFORE implementation. The issue is where scope, severity, and rule semantics get pinned down. PRs without an approved issue may be closed.
+- **Read the closest existing rule.** Pattern-match instead of inventing. Rules follow a uniform shape (`RuleDefinition` + check function + `RULES` list).
+- **Read the relevant ADR.** Rules: `docs/decisions/0006-ruleset-versioning.md`. Schema: `docs/decisions/0009-schema-versioning.md`. Publish contract: `docs/decisions/0008-hosted-reports-publish-contract.md`.
+
+## Setting up
+
+```bash
+git clone https://github.com/Daily-Nerd/hasscheck.git
+cd hasscheck
+uv sync
+uv run pytest
+```
+
+Requires Python 3.12+. Tests must pass before any commit (pre-commit hook enforces the version-consistency check; please run `uv run pytest` yourself before pushing).
+
+## Adding a rule
+
+1. **Get the issue approved** — `status:approved` label, rule semantics confirmed.
+2. **Pick the right module** in `src/hasscheck/rules/`. New category → new module + add to `registry.py`.
+3. **Write the test first** (`tests/test_rules_<module>.py`). RED → GREEN. Cover PASS, FAIL/WARN, NOT_APPLICABLE, and parse-error scenarios where applicable.
+4. **Implement the rule.** `RuleDefinition(id, version="1.0.0", category, severity, ...)`.
+5. **Update the rule audit** (`tests/test_rules_meta.py`) — total count + the appropriate set (overridable / locked).
+6. **Update README** "Current rule set" table.
+7. **Add a `docs/rules/<rule_id>.md` page** matching the template of existing pages.
+
+## Rule philosophy
+
+- **Sourced**: every finding cites an HA dev docs URL with a `source_checked_at` date.
+- **Conservative**: AST and heuristic rules WARN, never FAIL. False positives are worse than false negatives for a maintainer-facing tool.
+- **Overridable by default** unless the rule is a correctness check (identity, validity).
+- **No certification language.** Forbidden tokens: `certify`, `approved`, `safe`, `ready`, `quality tier`. A property test enforces this at runtime.
+
+## Commits
+
+- Conventional commits required: `feat(rules): ...`, `fix(cli): ...`, `docs(readme): ...`, `chore(release): ...`.
+- No AI attribution / `Co-Authored-By` trailers.
+- One concern per commit. Squash-merge by default; keep history readable on the main branch.
+
+## What we won't accept
+
+- Rules that fail repos for stylistic preferences (formatting, line length).
+- Rules that require running tests, linters, or builds in the user's project — HassCheck is static analysis only.
+- Server-side dependencies in OSS rules (the hosted service is opt-in; OSS works offline).
+- "Quality tier" or certification framings of any kind.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+## Questions
+
+Open a `question`-labeled issue. We don't have a Discussions tab yet; issues are the channel.

--- a/README.md
+++ b/README.md
@@ -48,27 +48,9 @@ HassCheck is intentionally not a replacement for hassfest and does not assign Ho
 
 ## Current status
 
-- **Latest release:** v0.7.0 — opt-in hosted reports via GitHub OIDC
-- **Current development target:** v0.8.0 — license, packaging metadata, and schema-versioning policy (in progress)
+**Latest release**: v0.9.0 — rule depth, AST-based config flow + diagnostics inspection, README content rules, and adoption-focused docs.
 
-v0.6.0 includes:
-
-- GitHub Action (`uses: Daily-Nerd/hasscheck@v0.6.0`) with PR comment, JSON artifact upload, and opt-in badge artifact
-- Typer CLI with `check`, `explain`, `schema`, `scaffold`, and `badge` commands
-- Rich terminal output with per-finding fix suggestions
-- `scaffold github-action` — generate a GitHub Actions CI workflow
-- `scaffold diagnostics` — generate a `diagnostics.py` starter with redaction helpers
-- `scaffold repairs` — generate a `repairs.py` starter with `ConfirmRepairFlow` skeleton
-- Applicability-aware scaffold refusal (respects `hasscheck.yaml` flags)
-- `hasscheck badge` — opt-in shields.io endpoint JSON for per-category quality signals
-- Pydantic JSON report schema (stable, additive-only versioning)
-- Rule IDs and rule versions
-- Source links and source timestamps
-- Applicability-aware statuses
-- Per-rule config overrides via `hasscheck.yaml`
-- Project applicability context via `hasscheck.yaml`
-- Example good and partial integration fixtures
-- Pytest coverage for the current rule set
+**In progress**: v0.10 — rule expansion (modern HA pattern checks, manifest.requirements sanity, advanced config flow signals). See open issues for the working backlog.
 
 ## GitHub Action
 
@@ -87,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Daily-Nerd/hasscheck@v0.7.0
+      - uses: Daily-Nerd/hasscheck@v0.9.0
         with:
           comment-pr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,6 +87,8 @@ jobs:
 | `badges-out-dir` | `badges` | Directory for badge JSON when `emit-badges: 'true'` |
 | `emit-publish` | `false` | Publish the report to a hosted HassCheck service. Requires workflow `permissions: id-token: write` |
 | `publish-endpoint` | `https://hasscheck.io` | Publish endpoint URL when `emit-publish: 'true'` |
+
+> The hosted reports endpoint (`hasscheck.io`) launches alongside the public release. Until then, `emit-publish: 'true'` works against a self-hosted endpoint via the `publish-endpoint` input or `HASSCHECK_PUBLISH_ENDPOINT` env var. The local CLI (without `--emit-publish`) is fully functional and is the recommended starting point.
 
 **Outputs:** `exit-code` — `0` when no FAIL findings, `1` when one or more FAIL findings.
 
@@ -127,7 +111,7 @@ This writes per-category JSON files and a `manifest.json` to `badges/`. Commit t
 Add `emit-badges: 'true'` to your HassCheck action step:
 
 ```yaml
-- uses: Daily-Nerd/hasscheck@v0.7.0
+- uses: Daily-Nerd/hasscheck@v0.9.0
   with:
     emit-badges: 'true'
     badges-out-dir: 'badges'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: 'badges'
   emit-publish:
-    description: 'Publish the report to a hosted HassCheck service (opt-in). Set to "true" to enable. Requires `permissions: id-token: write` on the workflow.'
+    description: 'Publish the report to a hosted HassCheck service (opt-in). Set to "true" to enable. Requires `permissions: id-token: write` on the workflow. The hosted endpoint launches alongside the public release; until then, set `publish-endpoint` to a self-hosted URL or omit `emit-publish` entirely.'
     required: false
     default: 'false'
   publish-endpoint:


### PR DESCRIPTION
## Summary

Pre-public-flip cleanup. Closes the three credibility gates surfaced by the v0.9 strategic survey before the repo goes public.

## Commits

| Commit | What |
|--------|------|
| \`923e03f\` | \`docs(readme)\`: refresh \"Current status\" block to v0.9.0 + softer framing for the \`emit-publish\` flow noting that the hosted endpoint launches alongside the public release. \`action.yml\` input description matches. |
| \`3865b6b\` | \`docs(contributing)\`: add CONTRIBUTING.md — issue-first workflow, rule-add checklist, rule philosophy (sourced + conservative + overridable + no-certification language), conventional commits. |
| \`96eaa97\` | \`docs(coc)\`: add CODE_OF_CONDUCT.md — Contributor Covenant 2.1 with maintainer contact filled in. Sourced from EthicalSource canonical repo. |

## Why

Strategic survey (post-v0.9.0) flagged three credibility gates a first-time visitor would hit on the public flip:

1. README \"Current status\" was stale (showed v0.7.0 latest, v0.8.0 in-progress while repo was at v0.9.0 — already corrected during the v0.9 docs sweep, refreshed once more here for clarity)
2. CONTRIBUTING.md absent → GitHub warns first-time contributors and signals \"not ready for external participation\"
3. CODE_OF_CONDUCT.md absent → same GitHub warning + missing the social contract a public OSS project is expected to publish

The \`hasscheck.io\` endpoint is not live yet (sibling \`hasscheck-web\` agent is building it; domain purchased). Code defaults stay at \`https://hasscheck.io\`. README + action.yml input docs add a one-line callout that the hosted endpoint launches alongside the public release — local CLI works fully without it.

## Test plan

- [x] \`uv run pytest -q\` — **486 passing**, zero changes (docs-only PR)
- [x] \`uv run ruff check\` — clean
- [x] CONTRIBUTING.md present at repo root
- [x] CODE_OF_CONDUCT.md present at repo root with maintainer email substituted
- [x] README \"Current status\" reflects v0.9.0
- [x] No \"certify / approved / ready / safe\" language introduced anywhere

## After merge

Repo can be flipped public. Then queue:

1. PyPI publishing (#15) — was gated on repo public; now unblocked
2. v0.10 rule expansion — #100 (manifest.requirements), #101 (config_flow advanced), #107 (modern HA patterns)
3. Eventually v1.0 hub work once \`hasscheck.io\` is online and the publish handshake has live signal