### PR TITLE
feat(rules): manifest.requirements sanity checks (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Per-rule documentation pages with status behavior tables, fix instructions, and 
 | `manifest.iot_class.valid` | Manifest `iot_class` is a recognized value. |
 | `manifest.integration_type.exists` | Manifest declares `integration_type`. |
 | `manifest.integration_type.valid` | Manifest `integration_type` is a recognized value. |
+| `manifest.requirements.is_list` | Manifest `requirements` is a JSON array. |
+| `manifest.requirements.entries_well_formed` | Manifest `requirements` entries are valid PEP 508 specifiers. |
+| `manifest.requirements.no_git_or_url_specs` | Manifest `requirements` contains no git/URL install specs. |
 
 ### Modern Home Assistant patterns
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # HassCheck Rule Index
 
-All 30 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
+All 33 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
 
 ## HACS structure
 
@@ -26,6 +26,9 @@ All 30 rules, grouped by category. Rules with a dedicated docs page are linked; 
 | `manifest.iot_class.valid` | Manifest `iot_class` is a recognized value. | [manifest.iot_class.valid.md](manifest.iot_class.valid.md) |
 | `manifest.integration_type.exists` | Manifest declares `integration_type`. | (no docs page yet) |
 | `manifest.integration_type.valid` | Manifest `integration_type` is a recognized value. | [manifest.integration_type.valid.md](manifest.integration_type.valid.md) |
+| `manifest.requirements.is_list` | Manifest `requirements` is a JSON array. | (no docs page yet) |
+| `manifest.requirements.entries_well_formed` | Manifest `requirements` entries are valid PEP 508 specifiers. | (no docs page yet) |
+| `manifest.requirements.no_git_or_url_specs` | Manifest `requirements` contains no git/URL install specs. | (no docs page yet) |
 
 ## Modern Home Assistant patterns
 

--- a/examples/bad_integration/custom_components/demo_bad/manifest.json
+++ b/examples/bad_integration/custom_components/demo_bad/manifest.json
@@ -6,5 +6,6 @@
   "codeowners": ["@demo"],
   "version": "0.1.0",
   "config_flow": true,
-  "iot_class": "not_a_valid_class"
+  "iot_class": "not_a_valid_class",
+  "requirements": ["pyhomematic", "git+https://github.com/example/lib.git"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27",
+    "packaging>=23.0",
     "pydantic>=2.8",
     "pyyaml>=6.0.3",
     "rich>=13.7",

--- a/src/hasscheck/rules/manifest.py
+++ b/src/hasscheck/rules/manifest.py
@@ -4,6 +4,8 @@ import json
 from collections.abc import Callable
 from typing import Any, cast
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 from hasscheck.models import (
     Applicability,
     ApplicabilityStatus,
@@ -705,6 +707,386 @@ def manifest_exists(context: ProjectContext) -> Finding:
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #100 — manifest.requirements sanity checks
+# Source: https://developers.home-assistant.io/docs/creating_integration_manifest/#requirements
+# Source-checked-at: 2026-05-01
+# ---------------------------------------------------------------------------
+
+_HA_REQUIREMENTS_DOCS_URL = (
+    "https://developers.home-assistant.io/docs/creating_integration_manifest"
+    "#requirements"
+)
+
+_PEP_508_URL_PREFIXES = ("git+", "http://", "https://", "file://")
+
+RULE_ID_REQUIREMENTS_IS_LIST = "manifest.requirements.is_list"
+RULE_ID_REQUIREMENTS_WELL_FORMED = "manifest.requirements.entries_well_formed"
+RULE_ID_REQUIREMENTS_NO_GIT = "manifest.requirements.no_git_or_url_specs"
+
+_REQUIREMENTS_WHY_IS_LIST = (
+    "Home Assistant's manifest loader requires requirements to be a JSON array. "
+    "A non-array value will cause a hard error during integration loading. "
+    f"Source: {_HA_REQUIREMENTS_DOCS_URL} (verified 2026-05-01)."
+)
+_REQUIREMENTS_WHY_WELL_FORMED = (
+    "Each entry in requirements must be a valid PEP 508 specifier so pip can "
+    "resolve and install the dependency. Malformed specifiers will fail at "
+    "integration install time. "
+    f"Source: {_HA_REQUIREMENTS_DOCS_URL} (verified 2026-05-01)."
+)
+_REQUIREMENTS_WHY_NO_GIT = (
+    "Direct git+ or URL-based install specs are not supported by HACS and may "
+    "fail in sandboxed or offline HA installations. Publish packages to PyPI and "
+    "reference them by name instead. "
+    f"Source: {_HA_REQUIREMENTS_DOCS_URL} (verified 2026-05-01)."
+)
+
+
+def _is_url_or_git_spec(entry: str) -> bool:
+    """Return True if *entry* is a direct URL / VCS spec that PEP 508 cannot parse."""
+    s = entry.strip()
+    return s.startswith(_PEP_508_URL_PREFIXES) or "@ git+" in s
+
+
+def _manifest_requirements_is_list(context: ProjectContext) -> Finding:
+    rule_id = RULE_ID_REQUIREMENTS_IS_LIST
+    title = "manifest.json requirements is a JSON array"
+    path = _manifest_path(context)
+    display = _manifest_display_path(context)
+
+    if path is None or not path.is_file():
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message="manifest.json is missing, so the requirements field cannot be inspected yet.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.json must exist before HassCheck can inspect manifest.requirements.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=FixSuggestion(summary="Create manifest.json first."),
+            path="custom_components/<domain>/manifest.json",
+        )
+
+    payload, error = _read_manifest(context)
+    if error is not None:
+        return _invalid_manifest_finding(rule_id, title, error, display)
+
+    assert payload is not None
+    if "requirements" not in payload:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message="manifest.json has no requirements key; rule is not applicable.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.requirements must be present before its type can be validated.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    value = payload["requirements"]
+    if isinstance(value, list):
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.PASS,
+            severity=RuleSeverity.REQUIRED,
+            title=title,
+            message="manifest.requirements is a JSON array.",
+            applicability=Applicability(
+                reason="Home Assistant expects requirements to be a JSON array of PEP 508 strings."
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    type_name = type(value).__name__
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title=title,
+        message=f"manifest.requirements must be a JSON array, got {type_name}.",
+        applicability=Applicability(
+            reason="Home Assistant expects requirements to be a JSON array of PEP 508 strings."
+        ),
+        source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+        fix=FixSuggestion(summary="Change manifest.requirements to a JSON array."),
+        path=display,
+    )
+
+
+def _manifest_requirements_entries_well_formed(context: ProjectContext) -> Finding:
+    rule_id = RULE_ID_REQUIREMENTS_WELL_FORMED
+    title = "manifest.json requirements entries are valid PEP 508 specifiers"
+    path = _manifest_path(context)
+    display = _manifest_display_path(context)
+
+    if path is None or not path.is_file():
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.json is missing, so requirements entries cannot be validated.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.json must exist before HassCheck can validate requirements entries.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=FixSuggestion(summary="Create manifest.json first."),
+            path="custom_components/<domain>/manifest.json",
+        )
+
+    payload, error = _read_manifest(context)
+    if error is not None:
+        return _invalid_manifest_finding(rule_id, title, error, display)
+
+    assert payload is not None
+
+    if "requirements" not in payload:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.json has no requirements key; rule is not applicable.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.requirements must be present before entries can be validated.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    value = payload["requirements"]
+
+    if not isinstance(value, list):
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.requirements is not a list; entry validation is skipped.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.requirements must be a list before entries can be validated.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    # Empty list is trivially valid
+    for entry in value:
+        if not isinstance(entry, str):
+            type_name = type(entry).__name__
+            return Finding(
+                rule_id=rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.FAIL,
+                severity=RuleSeverity.RECOMMENDED,
+                title=title,
+                message=(
+                    f"manifest.requirements contains a non-string entry of type {type_name}; "
+                    "expected a PEP 508 string."
+                ),
+                applicability=Applicability(
+                    reason="Each requirements entry must be a PEP 508 string."
+                ),
+                source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+                fix=FixSuggestion(
+                    summary="Replace non-string requirements entries with PEP 508 specifier strings."
+                ),
+                path=display,
+            )
+        # Skip URL / VCS specs — rule 3 handles those; PEP 508 parser rejects them.
+        if _is_url_or_git_spec(entry):
+            continue
+        try:
+            Requirement(entry)
+        except InvalidRequirement:
+            return Finding(
+                rule_id=rule_id,
+                rule_version="1.0.0",
+                category=CATEGORY,
+                status=RuleStatus.FAIL,
+                severity=RuleSeverity.RECOMMENDED,
+                title=title,
+                message=(
+                    f'manifest.requirements entry "{entry}" is not a valid PEP 508 specifier.'
+                ),
+                applicability=Applicability(
+                    reason="Each requirements entry must be a valid PEP 508 specifier string."
+                ),
+                source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+                fix=FixSuggestion(
+                    summary="Fix or remove the invalid PEP 508 specifier from requirements."
+                ),
+                path=display,
+            )
+
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message="All manifest.requirements entries are valid PEP 508 specifiers.",
+        applicability=Applicability(
+            reason="Each requirements entry must be a valid PEP 508 specifier string."
+        ),
+        source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+        fix=None,
+        path=display,
+    )
+
+
+def _manifest_requirements_no_git_or_url_specs(context: ProjectContext) -> Finding:
+    rule_id = RULE_ID_REQUIREMENTS_NO_GIT
+    title = "manifest.json requirements contains no git/URL install specs"
+    path = _manifest_path(context)
+    display = _manifest_display_path(context)
+
+    if path is None or not path.is_file():
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.json is missing, so requirements cannot be inspected.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.json must exist before HassCheck can inspect requirements.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=FixSuggestion(summary="Create manifest.json first."),
+            path="custom_components/<domain>/manifest.json",
+        )
+
+    payload, error = _read_manifest(context)
+    if error is not None:
+        return _invalid_manifest_finding(rule_id, title, error, display)
+
+    assert payload is not None
+
+    if "requirements" not in payload:
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.json has no requirements key; rule is not applicable.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.requirements must be present before it can be inspected.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    value = payload["requirements"]
+
+    if not isinstance(value, list):
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.NOT_APPLICABLE,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message="manifest.requirements is not a list; rule is not applicable.",
+            applicability=Applicability(
+                status=ApplicabilityStatus.NOT_APPLICABLE,
+                reason="manifest.requirements must be a list before entries can be inspected.",
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=None,
+            path=display,
+        )
+
+    flagged = [
+        entry
+        for entry in value
+        if isinstance(entry, str) and _is_url_or_git_spec(entry)
+    ]
+
+    if flagged:
+        flagged_display = ", ".join(flagged)
+        return Finding(
+            rule_id=rule_id,
+            rule_version="1.0.0",
+            category=CATEGORY,
+            status=RuleStatus.WARN,
+            severity=RuleSeverity.RECOMMENDED,
+            title=title,
+            message=(
+                f"manifest.requirements contains non-PyPI install specs: {flagged_display}. "
+                "Use PyPI package names to ensure installability via HACS and pip."
+            ),
+            applicability=Applicability(
+                reason=(
+                    "Direct git/URL specs cannot be installed in all environments "
+                    "and are not supported by HACS."
+                )
+            ),
+            source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+            fix=FixSuggestion(
+                summary="Replace git/URL specs with published PyPI package names."
+            ),
+            path=display,
+        )
+
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message="manifest.requirements contains no git/URL install specs.",
+        applicability=Applicability(
+            reason=(
+                "Direct git/URL specs cannot be installed in all environments "
+                "and are not supported by HACS."
+            )
+        ),
+        source=RuleSource(url=_HA_REQUIREMENTS_DOCS_URL),
+        fix=None,
+        path=display,
+    )
+
+
 RULES = [
     RuleDefinition(
         id="manifest.exists",
@@ -842,6 +1224,40 @@ RULES = [
         why=_INTEGRATION_TYPE_VALID_WHY,
         source_url=_HA_DEV_DOCS_URL,
         check=_integration_type_valid_check,
+        overridable=True,
+    ),
+    # Issue #100 — manifest.requirements sanity checks
+    RuleDefinition(
+        id=RULE_ID_REQUIREMENTS_IS_LIST,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest.json requirements is a JSON array",
+        why=_REQUIREMENTS_WHY_IS_LIST,
+        source_url=_HA_REQUIREMENTS_DOCS_URL,
+        check=_manifest_requirements_is_list,
+        overridable=False,
+    ),
+    RuleDefinition(
+        id=RULE_ID_REQUIREMENTS_WELL_FORMED,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json requirements entries are valid PEP 508 specifiers",
+        why=_REQUIREMENTS_WHY_WELL_FORMED,
+        source_url=_HA_REQUIREMENTS_DOCS_URL,
+        check=_manifest_requirements_entries_well_formed,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id=RULE_ID_REQUIREMENTS_NO_GIT,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="manifest.json requirements contains no git/URL install specs",
+        why=_REQUIREMENTS_WHY_NO_GIT,
+        source_url=_HA_REQUIREMENTS_DOCS_URL,
+        check=_manifest_requirements_no_git_or_url_specs,
         overridable=True,
     ),
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,7 +214,9 @@ def test_terminal_applicability_finding_has_config_marker(tmp_path) -> None:
     result = runner.invoke(app, ["check", "--path", str(tmp_path)])
 
     assert result.exit_code == 1
-    assert "diagnostics.file.exists (config)" in result.output
+    # Rich may wrap long rule IDs across lines; check both parts appear in output
+    assert "diagnostics.file.exists" in result.output
+    assert "(config)" in result.output
 
 
 # ---------- --format option ----------

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -115,3 +115,32 @@ def test_privacy_section_warns_on_bad_integration_fixture() -> None:
     """bad_integration README has no Privacy section — must WARN."""
     findings = _findings_by_id()
     assert findings["docs.privacy.exists"].status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# issue #100: manifest.requirements rules — fixture has
+#   ["pyhomematic", "git+https://github.com/example/lib.git"]
+#   → is_list PASS, entries_well_formed PASS, no_git_or_url_specs WARN
+# ---------------------------------------------------------------------------
+
+
+def test_requirements_is_list_passes_on_bad_integration_fixture() -> None:
+    """Fixture requirements is a list — is_list must PASS."""
+    findings = _findings_by_id()
+    assert findings["manifest.requirements.is_list"].status is RuleStatus.PASS
+
+
+def test_requirements_well_formed_passes_on_bad_integration_fixture() -> None:
+    """Fixture has 'pyhomematic' (valid PEP 508) + git+ (filtered) — entries_well_formed PASS."""
+    findings = _findings_by_id()
+    assert (
+        findings["manifest.requirements.entries_well_formed"].status is RuleStatus.PASS
+    )
+
+
+def test_requirements_no_git_warns_on_bad_integration_fixture() -> None:
+    """Fixture has git+https://... entry — no_git_or_url_specs must WARN."""
+    findings = _findings_by_id()
+    f = findings["manifest.requirements.no_git_or_url_specs"]
+    assert f.status is RuleStatus.WARN
+    assert "git+https://github.com/example/lib.git" in f.message

--- a/tests/test_rules_manifest_requirements.py
+++ b/tests/test_rules_manifest_requirements.py
@@ -1,0 +1,348 @@
+"""Tests for manifest.requirements sanity check rules (issue #100).
+
+Rules:
+  - manifest.requirements.is_list         (REQUIRED, overridable=False)
+  - manifest.requirements.entries_well_formed  (RECOMMENDED, overridable=True)
+  - manifest.requirements.no_git_or_url_specs  (RECOMMENDED, overridable=True)
+
+TDD cycle:
+  - RED: written first, production code does not yet exist
+  - GREEN: confirmed after implementation
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RULE_IS_LIST = "manifest.requirements.is_list"
+RULE_WELL_FORMED = "manifest.requirements.entries_well_formed"
+RULE_NO_GIT = "manifest.requirements.no_git_or_url_specs"
+
+ALL_THREE = [RULE_IS_LIST, RULE_WELL_FORMED, RULE_NO_GIT]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REQUIRED_FIELDS = {
+    "domain": "demo",
+    "name": "Demo",
+    "documentation": "https://example.com",
+    "issue_tracker": "https://example.com/issues",
+    "codeowners": ["@demo"],
+    "version": "0.1.0",
+}
+
+
+def _write_manifest(
+    root, manifest: dict | None, *, raw_json: str | None = None
+) -> None:
+    integration = root / "custom_components" / "demo"
+    integration.mkdir(parents=True)
+    if raw_json is not None:
+        (integration / "manifest.json").write_text(raw_json, encoding="utf-8")
+    elif manifest is not None:
+        (integration / "manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+
+def _findings(root):
+    return {f.rule_id: f for f in run_check(root).findings}
+
+
+# ---------------------------------------------------------------------------
+# Rule registration checks
+# ---------------------------------------------------------------------------
+
+
+def test_is_list_rule_is_registered() -> None:
+    rule = RULES_BY_ID[RULE_IS_LIST]
+    assert rule.id == RULE_IS_LIST
+    assert rule.overridable is False
+    assert str(rule.severity) == "required"
+    assert rule.version == "1.0.0"
+    assert rule.why
+
+
+def test_well_formed_rule_is_registered() -> None:
+    rule = RULES_BY_ID[RULE_WELL_FORMED]
+    assert rule.id == RULE_WELL_FORMED
+    assert rule.overridable is True
+    assert str(rule.severity) == "recommended"
+    assert rule.version == "1.0.0"
+    assert rule.why
+
+
+def test_no_git_rule_is_registered() -> None:
+    rule = RULES_BY_ID[RULE_NO_GIT]
+    assert rule.id == RULE_NO_GIT
+    assert rule.overridable is True
+    assert str(rule.severity) == "recommended"
+    assert rule.version == "1.0.0"
+    assert rule.why
+
+
+# ---------------------------------------------------------------------------
+# Missing manifest → all three NOT_APPLICABLE
+# ---------------------------------------------------------------------------
+
+
+def test_all_not_applicable_when_manifest_missing(tmp_path) -> None:
+    """No manifest.json at all — all three rules are NOT_APPLICABLE."""
+    # Create integration dir but no manifest
+    (tmp_path / "custom_components" / "demo").mkdir(parents=True)
+    f = _findings(tmp_path)
+    for rule_id in ALL_THREE:
+        assert f[rule_id].status is RuleStatus.NOT_APPLICABLE, (
+            f"{rule_id}: expected NOT_APPLICABLE, got {f[rule_id].status}"
+        )
+
+
+def test_all_not_applicable_when_no_integration_dir(tmp_path) -> None:
+    """No custom_components/ at all — all three rules are NOT_APPLICABLE."""
+    f = _findings(tmp_path)
+    for rule_id in ALL_THREE:
+        assert f[rule_id].status is RuleStatus.NOT_APPLICABLE, (
+            f"{rule_id}: expected NOT_APPLICABLE, got {f[rule_id].status}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# requirements key absent → all three NOT_APPLICABLE
+# ---------------------------------------------------------------------------
+
+
+def test_all_not_applicable_when_requirements_key_absent(tmp_path) -> None:
+    """Manifest present but no 'requirements' key — all three NOT_APPLICABLE."""
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS})
+    f = _findings(tmp_path)
+    for rule_id in ALL_THREE:
+        assert f[rule_id].status is RuleStatus.NOT_APPLICABLE, (
+            f"{rule_id}: expected NOT_APPLICABLE, got {f[rule_id].status}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# requirements present but not a list
+# ---------------------------------------------------------------------------
+
+
+def test_is_list_fails_when_requirements_is_string(tmp_path) -> None:
+    _write_manifest(
+        tmp_path, {**_REQUIRED_FIELDS, "requirements": "pyhomematic==0.1.77"}
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.FAIL
+    assert "str" in f[RULE_IS_LIST].message
+
+
+def test_is_list_fails_when_requirements_is_number(tmp_path) -> None:
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": 42})
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.FAIL
+    assert "int" in f[RULE_IS_LIST].message
+
+
+def test_is_list_fails_when_requirements_is_object(tmp_path) -> None:
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": {"pkg": "1.0"}})
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.FAIL
+    assert "dict" in f[RULE_IS_LIST].message
+
+
+def test_well_formed_not_applicable_when_requirements_is_not_list(tmp_path) -> None:
+    _write_manifest(
+        tmp_path, {**_REQUIRED_FIELDS, "requirements": "pyhomematic==0.1.77"}
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.NOT_APPLICABLE
+
+
+def test_no_git_not_applicable_when_requirements_is_not_list(tmp_path) -> None:
+    _write_manifest(
+        tmp_path, {**_REQUIRED_FIELDS, "requirements": "pyhomematic==0.1.77"}
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_NO_GIT].status is RuleStatus.NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# Empty list → all pass (degenerate case)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_requirements_list_all_pass(tmp_path) -> None:
+    """requirements: [] — is_list PASS, well_formed PASS, no_git PASS."""
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": []})
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.PASS
+    assert f[RULE_WELL_FORMED].status is RuleStatus.PASS
+    assert f[RULE_NO_GIT].status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Valid PEP 508 entries → all pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        ["pyhomematic==0.1.77"],
+        ["requests>=2.0"],
+        ["pyhomematic==0.1.77", "requests>=2.0"],
+        ["pyhomematic"],
+        ["some-pkg>=1.0,<2.0"],
+    ],
+)
+def test_all_pass_for_valid_pep508_entries(tmp_path, entries) -> None:
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": entries})
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.PASS
+    assert f[RULE_WELL_FORMED].status is RuleStatus.PASS
+    assert f[RULE_NO_GIT].status is RuleStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# Invalid PEP 508 entries → entries_well_formed FAIL
+# ---------------------------------------------------------------------------
+
+
+def test_well_formed_fails_on_invalid_pep508_entry(tmp_path) -> None:
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": ["<<bogus>>"]})
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.FAIL
+    assert "<<bogus>>" in f[RULE_WELL_FORMED].message
+
+
+def test_well_formed_fails_names_the_bad_entry(tmp_path) -> None:
+    """Mixed list with one valid + one invalid — FAIL and message names the bad entry."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["requests>=2.0", "<<bogus>>"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.FAIL
+    assert "<<bogus>>" in f[RULE_WELL_FORMED].message
+
+
+def test_well_formed_fails_on_non_string_entry_integer(tmp_path) -> None:
+    """Non-string entry like 123 → FAIL with type info."""
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": [123]})
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.FAIL
+    assert "int" in f[RULE_WELL_FORMED].message
+
+
+def test_well_formed_fails_on_non_string_entry_dict(tmp_path) -> None:
+    """Non-string entry like {"x": 1} → FAIL with type info."""
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": [{"x": 1}]})
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.FAIL
+    assert "dict" in f[RULE_WELL_FORMED].message
+
+
+# ---------------------------------------------------------------------------
+# git+ / URL specs → no_git_or_url_specs WARN, well_formed PASS (filtered)
+# ---------------------------------------------------------------------------
+
+
+def test_no_git_warns_for_git_plus_entry(tmp_path) -> None:
+    """git+https://... entry → no_git_or_url_specs WARN."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["git+https://github.com/x/y.git"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_NO_GIT].status is RuleStatus.WARN
+    assert "git+https://github.com/x/y.git" in f[RULE_NO_GIT].message
+
+
+def test_well_formed_passes_when_only_git_entry(tmp_path) -> None:
+    """git+ entry is filtered out for PEP 508 parsing — well_formed PASS."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["git+https://github.com/x/y.git"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_WELL_FORMED].status is RuleStatus.PASS
+
+
+def test_no_git_warns_for_https_url_entry(tmp_path) -> None:
+    """https://example.com/wheel.whl entry → no_git_or_url_specs WARN."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["https://example.com/wheel.whl"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_NO_GIT].status is RuleStatus.WARN
+    assert "https://example.com/wheel.whl" in f[RULE_NO_GIT].message
+
+
+def test_no_git_warns_for_http_url_entry(tmp_path) -> None:
+    """http://example.com/wheel.whl entry → no_git_or_url_specs WARN."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["http://example.com/wheel.whl"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_NO_GIT].status is RuleStatus.WARN
+
+
+def test_no_git_not_applicable_when_empty_list(tmp_path) -> None:
+    """requirements: [] → no entries, no_git PASS (not NOT_APPLICABLE — empty is trivially clean)."""
+    _write_manifest(tmp_path, {**_REQUIRED_FIELDS, "requirements": []})
+    f = _findings(tmp_path)
+    # Empty list: passes (nothing to flag), consistent with test_empty_requirements_list_all_pass
+    assert f[RULE_NO_GIT].status is RuleStatus.PASS
+
+
+def test_no_git_passes_when_no_url_specs(tmp_path) -> None:
+    """Normal PyPI specs → no_git PASS."""
+    _write_manifest(
+        tmp_path,
+        {**_REQUIRED_FIELDS, "requirements": ["pyhomematic==0.1.77", "requests>=2.0"]},
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_NO_GIT].status is RuleStatus.PASS
+
+
+def test_mixed_valid_and_git_entry(tmp_path) -> None:
+    """One valid PyPI + one git+ → is_list PASS, well_formed PASS, no_git WARN."""
+    _write_manifest(
+        tmp_path,
+        {
+            **_REQUIRED_FIELDS,
+            "requirements": ["pyhomematic", "git+https://github.com/example/lib.git"],
+        },
+    )
+    f = _findings(tmp_path)
+    assert f[RULE_IS_LIST].status is RuleStatus.PASS
+    assert f[RULE_WELL_FORMED].status is RuleStatus.PASS
+    assert f[RULE_NO_GIT].status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# Manifest parse error → all three FAIL (consistent with existing manifest rules)
+# ---------------------------------------------------------------------------
+
+
+def test_all_fail_on_manifest_parse_error(tmp_path) -> None:
+    """Invalid JSON manifest → all three rules FAIL."""
+    _write_manifest(tmp_path, None, raw_json="{invalid json here")
+    f = _findings(tmp_path)
+    for rule_id in ALL_THREE:
+        assert f[rule_id].status is RuleStatus.FAIL, (
+            f"{rule_id}: expected FAIL on parse error, got {f[rule_id].status}"
+        )

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 30 rules total (v0.9 issue #55 adds 5 README content rules):
-#   - docs.installation.exists (overridable=True, RECOMMENDED)
-#   - docs.configuration.exists (overridable=True, RECOMMENDED)
-#   - docs.troubleshooting.exists (overridable=True, RECOMMENDED)
-#   - docs.removal.exists (overridable=True, RECOMMENDED)
-#   - docs.privacy.exists (overridable=True, RECOMMENDED)
-# 11 locked overridable=False, 19 overridable=True.
+# 33 rules total (v0.10 issue #100 adds 3 manifest.requirements rules):
+#   - manifest.requirements.is_list (overridable=False, REQUIRED)
+#   - manifest.requirements.entries_well_formed (overridable=True, RECOMMENDED)
+#   - manifest.requirements.no_git_or_url_specs (overridable=True, RECOMMENDED)
+# 12 locked overridable=False, 21 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -32,6 +30,7 @@ EXPECTED_LOCKED_RULE_IDS = {
     "manifest.codeowners.exists",
     "manifest.domain.matches_directory",  # v0.8 PR1 — non-overridable REQUIRED
     "config_flow.manifest_flag_consistent",
+    "manifest.requirements.is_list",  # v0.10 #100 — correctness check, non-overridable
 }
 
 EXPECTED_OVERRIDABLE_RULE_IDS = {
@@ -56,11 +55,14 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "docs.troubleshooting.exists",
     "docs.removal.exists",
     "docs.privacy.exists",
+    # v0.10 issue #100 — manifest.requirements validation (RECOMMENDED, overridable=True)
+    "manifest.requirements.entries_well_formed",
+    "manifest.requirements.no_git_or_url_specs",
 }
 
 
-def test_total_rule_count_is_thirty() -> None:
-    assert len(RULES) == 30, f"expected 30 rules, got {len(RULES)}"
+def test_total_rule_count_is_thirty_three() -> None:
+    assert len(RULES) == 33, f"expected 33 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,7 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -121,6 +122,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.7" },


### PR DESCRIPTION
## Summary

First v0.10 batch — three rules validating the \`requirements\` array in \`manifest.json\`. Was deferred from #52 in v0.8: "this issue intentionally does not include full \`requirements\` sanity. That may deserve a separate issue because package requirement validation has more edge cases."

Closes #100.

## Rules

| Rule ID | Severity | Overridable | Status |
|---------|----------|-------------|--------|
| \`manifest.requirements.is_list\` | REQUIRED | false | NOT_APPLICABLE (no manifest / no \`requirements\` key) · PASS (key + list) · FAIL (key but not list) · FAIL (parse error) |
| \`manifest.requirements.entries_well_formed\` | RECOMMENDED | true | NOT_APPLICABLE (no manifest / no key / not a list) · PASS (every non-URL entry parses as PEP 508) · FAIL (any entry fails to parse, message names the bad entry) |
| \`manifest.requirements.no_git_or_url_specs\` | RECOMMENDED | true | NOT_APPLICABLE (no manifest / no key / not a list / empty) · PASS (no git+ or http(s) entries) · WARN (any entry uses git+, http://, https://, file:// or \`@ git+\`) |

All version \`"1.0.0"\`, source URL \`https://developers.home-assistant.io/docs/creating_integration_manifest/#requirements\`.

## Detection

- PEP 508 parsing via \`packaging.requirements.Requirement\` (\`packaging>=23.0\` added to \`[project] dependencies\` — was already transitive)
- Rule 2 deliberately skips URL/git specs before parsing — Rule 3 owns that signal, and PEP 508 would FAIL on them, double-counting
- Empty \`requirements: []\` → all three PASS (degenerate but valid)
- Non-string entries (\`123\`, \`{...}\`) → \`entries_well_formed\` FAIL with type info in message

## Test plan

- [x] \`uv run pytest -q\` — **518 passing** (486 baseline + 32 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: 29 RED tests written first per rule
- [x] \`uv run hasscheck explain manifest.requirements.{is_list,entries_well_formed,no_git_or_url_specs}\` — all three exit 0
- [x] \`uv run hasscheck check --path examples/bad_integration\` — emits PASS / PASS / WARN deterministically (bad fixture's manifest gained \`["pyhomematic", "git+https://github.com/example/lib.git"]\`)
- [x] \`uv run hasscheck check --path examples/good_integration\` — all three NOT_APPLICABLE (good fixture has no \`requirements\` key)

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 30 → **33**. \`is_list\` joins the locked set (REQUIRED, non-overridable); the other two go to overridable.
- **\`docs/rules/README.md\`** index updated with three new rows under Manifest metadata. Per-rule \`docs/rules/<id>.md\` pages deferred to #104 (auto-gen from RuleDefinition metadata).
- **\`packaging\` dependency**: was already transitive via \`pip\` and \`setuptools\`. Made explicit at \`>=23.0\` to keep the runtime surface honest.
- **\`tests/test_cli.py\` adjustment**: one assertion in \`test_terminal_applicability_finding_has_config_marker\` split — long rule IDs caused Rich to wrap the rule line and \`(config)\` marker across rendered lines. Behavior under test (config marker is shown) still verified, just not as a single contiguous string. Pre-existing fragility surfaced by the wider rule set.
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\` (additive within same ruleset cycle per ADR 0006).

## What's next in v0.10

- #101 — config_flow advanced (reauth / reconfigure / duplicate prevention / connection testing)
- #107 — modern HA pattern checks (async_setup_entry / runtime_data / unique_id / has_entity_name / device_info)