### PR TITLE
feat(rules): config_flow advanced — reauth / reconfigure / unique_id / connection_test (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ Per-rule documentation pages with status behavior tables, fix instructions, and 
 | `config_flow.file.exists` | Integration has `config_flow.py`. |
 | `config_flow.manifest_flag_consistent` | `config_flow.py` and manifest `config_flow: true` agree. |
 | `config_flow.user_step.exists` | `config_flow.py` defines `async_step_user` (AST inspection). |
+| `config_flow.reauth_step.exists` | `config_flow.py` defines `async_step_reauth` or `async_step_reauth_confirm` (AST inspection). |
+| `config_flow.reconfigure_step.exists` | `config_flow.py` defines `async_step_reconfigure` (AST inspection). |
+| `config_flow.unique_id.set` | `config_flow.py` calls `async_set_unique_id` (AST inspection). |
+| `config_flow.connection_test` | A discovery-flow step awaits a non-plumbing call (AST heuristic). |
 
 ### Diagnostics and repairs
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -37,6 +37,10 @@ All 33 rules, grouped by category. Rules with a dedicated docs page are linked; 
 | `config_flow.file.exists` | Integration has `config_flow.py`. | (no docs page yet) |
 | `config_flow.manifest_flag_consistent` | `config_flow.py` and manifest `config_flow: true` agree. | (no docs page yet) |
 | `config_flow.user_step.exists` | `config_flow.py` defines `async_step_user` (AST inspection). | [config_flow.user_step.exists.md](config_flow.user_step.exists.md) |
+| `config_flow.reauth_step.exists` | `config_flow.py` defines `async_step_reauth` or `async_step_reauth_confirm` (AST inspection). | (no docs page yet) |
+| `config_flow.reconfigure_step.exists` | `config_flow.py` defines `async_step_reconfigure` (AST inspection). | (no docs page yet) |
+| `config_flow.unique_id.set` | `config_flow.py` calls `async_set_unique_id` (AST inspection). | (no docs page yet) |
+| `config_flow.connection_test` | A discovery-flow step awaits a non-plumbing call (AST heuristic). | (no docs page yet) |
 
 ## Diagnostics and repairs
 

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -23,6 +23,11 @@ APPLICABILITY_FLAGS_BY_RULE = {
     "config_flow.file.exists": "uses_config_flow",
     "config_flow.manifest_flag_consistent": "uses_config_flow",
     "config_flow.user_step.exists": "uses_config_flow",
+    # v0.10 issue #101 — advanced config_flow rules
+    "config_flow.reauth_step.exists": "uses_config_flow",
+    "config_flow.reconfigure_step.exists": "uses_config_flow",
+    "config_flow.unique_id.set": "uses_config_flow",
+    "config_flow.connection_test": "uses_config_flow",
 }
 
 CATEGORY_LABELS = {

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import json
+from collections.abc import Iterable
 from typing import Any
 
 from hasscheck.ast_utils import parse_module
@@ -28,6 +29,47 @@ USER_STEP_SOURCE = (
 )
 MANIFEST_SOURCE = (
     "https://developers.home-assistant.io/docs/creating_integration_manifest"
+)
+
+# ---------------------------------------------------------------------------
+# Constants for advanced detection rules (#101)
+# ---------------------------------------------------------------------------
+_REAUTH_STEP_NAMES = frozenset({"async_step_reauth", "async_step_reauth_confirm"})
+_DISCOVERY_FLOW_STEPS = frozenset(
+    {
+        "async_step_user",
+        "async_step_zeroconf",
+        "async_step_dhcp",
+        "async_step_bluetooth",
+        "async_step_usb",
+    }
+)
+# Calls that count as flow plumbing only — not real connection work
+_FLOW_PLUMBING_CALLS = frozenset(
+    {
+        "async_show_form",
+        "async_create_entry",
+        "async_abort",
+        "async_set_unique_id",
+        "_abort_if_unique_id_configured",
+    }
+)
+
+_REAUTH_STEP_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_config_flow_handler/"
+    "#reauthentication"
+)
+_RECONFIGURE_STEP_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_config_flow_handler/"
+    "#reconfigure"
+)
+_UNIQUE_ID_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_config_flow_handler/"
+    "#unique-ids"
+)
+_CONNECTION_TEST_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_config_flow_handler/"
+    "#defining-the-flow"
 )
 
 
@@ -75,6 +117,63 @@ def _has_async_function(tree: ast.Module, name: str) -> bool:
         isinstance(node, ast.AsyncFunctionDef) and node.name == name
         for node in ast.walk(tree)
     )
+
+
+def _has_async_function_any(tree: ast.Module, names: Iterable[str]) -> bool:
+    """True if any AsyncFunctionDef matches one of the given names."""
+    name_set = frozenset(names)
+    return any(
+        isinstance(node, ast.AsyncFunctionDef) and node.name in name_set
+        for node in ast.walk(tree)
+    )
+
+
+def _module_calls_name(tree: ast.Module, target: str) -> bool:
+    """True if any Call's func is a Name(id=target) or Attribute(attr=target)."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == target:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == target:
+            return True
+    return False
+
+
+def _has_connection_test(tree: ast.Module) -> bool:
+    """True if any discovery-flow step awaits a non-plumbing call.
+
+    Scans all AsyncFunctionDef nodes whose name is in _DISCOVERY_FLOW_STEPS.
+    Inside each, looks for Await expressions on a Call where the callee is
+    not a flow-step name (async_step_*) and not in _FLOW_PLUMBING_CALLS.
+    Any such awaited call is considered real connection work.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if node.name not in _DISCOVERY_FLOW_STEPS:
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Await):
+                continue
+            call = inner.value
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            if isinstance(func, ast.Name):
+                callee = func.id
+            elif isinstance(func, ast.Attribute):
+                callee = func.attr
+            else:
+                continue
+            # async_step_* calls are flow routing — not connection work
+            if callee.startswith("async_step_"):
+                continue
+            if callee in _FLOW_PLUMBING_CALLS:
+                continue
+            return True
+    return False
 
 
 def config_flow_user_step_exists(context: ProjectContext) -> Finding:
@@ -462,6 +561,309 @@ _USER_STEP_WHY = (
     "those cases will produce a false WARN."
 )
 
+
+# ---------------------------------------------------------------------------
+# Helper: shared NOT_APPLICABLE / gating logic for v0.10 AST rules
+# ---------------------------------------------------------------------------
+
+
+def _make_not_applicable_finding(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    message: str,
+    reason: str,
+    path: str,
+    applicability_source: str | None = None,
+    fix: FixSuggestion | None = None,
+) -> Finding:
+    applicability_kwargs: dict = {
+        "status": ApplicabilityStatus.NOT_APPLICABLE,
+        "reason": reason,
+    }
+    if applicability_source is not None:
+        applicability_kwargs["source"] = applicability_source
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(**applicability_kwargs),
+        source=RuleSource(url=source_url),
+        fix=fix,
+        path=path,
+    )
+
+
+def _make_ast_rule_finding(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    *,
+    status: RuleStatus,
+    message: str,
+    reason: str,
+    path: str,
+    fix: FixSuggestion | None = None,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(reason=reason),
+        source=RuleSource(url=source_url),
+        fix=fix,
+        path=path,
+    )
+
+
+def _gate_config_flow_ast_rule(
+    context: ProjectContext,
+    rule_id: str,
+    title: str,
+    source_url: str,
+) -> tuple[Finding | None, ast.Module | None, str]:
+    """Shared gating: check integration_path, applicability, file existence, parse.
+
+    Returns (early_finding, tree, display_path).
+    If early_finding is not None, the caller should return it immediately.
+    """
+    fallback_path = "custom_components/<domain>/config_flow.py"
+
+    if context.integration_path is None:
+        return (
+            _make_not_applicable_finding(
+                rule_id,
+                title,
+                source_url,
+                message="No integration directory was detected.",
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect config_flow.py.",
+                path=fallback_path,
+            ),
+            None,
+            fallback_path,
+        )
+
+    config_flow_path = context.integration_path / "config_flow.py"
+    display = _display_path(config_flow_path, context, fallback_path)
+
+    if context.applicability and context.applicability.uses_config_flow is False:
+        return (
+            _make_not_applicable_finding(
+                rule_id,
+                title,
+                source_url,
+                message="Project config declares this integration does not use config flow UI setup.",
+                reason="hasscheck.yaml declares uses_config_flow: false.",
+                path=display,
+                applicability_source="config",
+            ),
+            None,
+            display,
+        )
+
+    if not config_flow_path.is_file():
+        return (
+            _make_not_applicable_finding(
+                rule_id,
+                title,
+                source_url,
+                message="config_flow.py does not exist; this rule cannot be checked.",
+                reason="config_flow.py must exist before this rule can run.",
+                path=display,
+            ),
+            None,
+            display,
+        )
+
+    tree, error = parse_module(config_flow_path)
+    if error is not None:
+        return (
+            _make_ast_rule_finding(
+                rule_id,
+                title,
+                source_url,
+                status=RuleStatus.WARN,
+                message=f"config_flow.py could not be parsed ({error}); {title.lower()} cannot be determined.",
+                reason="config_flow.py exists but has a syntax error.",
+                path=display,
+                fix=FixSuggestion(summary="Fix syntax errors in config_flow.py."),
+            ),
+            None,
+            display,
+        )
+
+    return None, tree, display
+
+
+# ---------------------------------------------------------------------------
+# Check functions — v0.10 advanced config_flow rules (#101)
+# ---------------------------------------------------------------------------
+
+
+def config_flow_reauth_step_exists(context: ProjectContext) -> Finding:
+    """Check that config_flow.py defines async_step_reauth or async_step_reauth_confirm."""
+    rule_id = "config_flow.reauth_step.exists"
+    title = "config_flow.py defines a reauthentication step"
+
+    early, tree, display = _gate_config_flow_ast_rule(
+        context, rule_id, title, _REAUTH_STEP_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if _has_async_function_any(tree, _REAUTH_STEP_NAMES):
+        return _make_ast_rule_finding(
+            rule_id,
+            title,
+            _REAUTH_STEP_SOURCE,
+            status=RuleStatus.PASS,
+            message="config_flow.py defines a reauthentication step (async_step_reauth or async_step_reauth_confirm).",
+            reason="Reauthentication allows users to fix expired credentials without removing and re-adding the integration.",
+            path=display,
+        )
+
+    return _make_ast_rule_finding(
+        rule_id,
+        title,
+        _REAUTH_STEP_SOURCE,
+        status=RuleStatus.WARN,
+        message="config_flow.py does not define async_step_reauth or async_step_reauth_confirm; reauthentication is not supported.",
+        reason="Reauthentication allows users to fix expired credentials without removing and re-adding the integration.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Add async_step_reauth (and optionally async_step_reauth_confirm) to your ConfigFlow class.",
+            docs_url=_REAUTH_STEP_SOURCE,
+        ),
+    )
+
+
+def config_flow_reconfigure_step_exists(context: ProjectContext) -> Finding:
+    """Check that config_flow.py defines async_step_reconfigure."""
+    rule_id = "config_flow.reconfigure_step.exists"
+    title = "config_flow.py defines a reconfigure step"
+
+    early, tree, display = _gate_config_flow_ast_rule(
+        context, rule_id, title, _RECONFIGURE_STEP_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if _has_async_function(tree, "async_step_reconfigure"):
+        return _make_ast_rule_finding(
+            rule_id,
+            title,
+            _RECONFIGURE_STEP_SOURCE,
+            status=RuleStatus.PASS,
+            message="config_flow.py defines async_step_reconfigure.",
+            reason="Reconfigure lets users update integration settings (e.g. host/port) without removing and re-adding it.",
+            path=display,
+        )
+
+    return _make_ast_rule_finding(
+        rule_id,
+        title,
+        _RECONFIGURE_STEP_SOURCE,
+        status=RuleStatus.WARN,
+        message="config_flow.py does not define async_step_reconfigure; users cannot update settings from the UI.",
+        reason="Reconfigure lets users update integration settings (e.g. host/port) without removing and re-adding it.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Add async_step_reconfigure to your ConfigFlow class.",
+            docs_url=_RECONFIGURE_STEP_SOURCE,
+        ),
+    )
+
+
+def config_flow_unique_id_set(context: ProjectContext) -> Finding:
+    """Check that config_flow.py calls async_set_unique_id."""
+    rule_id = "config_flow.unique_id.set"
+    title = "config_flow.py sets a unique ID"
+
+    early, tree, display = _gate_config_flow_ast_rule(
+        context, rule_id, title, _UNIQUE_ID_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if _module_calls_name(tree, "async_set_unique_id"):
+        return _make_ast_rule_finding(
+            rule_id,
+            title,
+            _UNIQUE_ID_SOURCE,
+            status=RuleStatus.PASS,
+            message="config_flow.py calls async_set_unique_id.",
+            reason="Setting a unique ID prevents duplicate config entries and enables entity deduplication.",
+            path=display,
+        )
+
+    return _make_ast_rule_finding(
+        rule_id,
+        title,
+        _UNIQUE_ID_SOURCE,
+        status=RuleStatus.WARN,
+        message="config_flow.py does not call async_set_unique_id; duplicate config entries may occur.",
+        reason="Setting a unique ID prevents duplicate config entries and enables entity deduplication.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Call self.async_set_unique_id(<device-identifier>) before creating the entry.",
+            docs_url=_UNIQUE_ID_SOURCE,
+        ),
+    )
+
+
+def config_flow_connection_test(context: ProjectContext) -> Finding:
+    """Check that at least one discovery-flow step awaits a non-plumbing call."""
+    rule_id = "config_flow.connection_test"
+    title = "config_flow.py tests the connection before creating the entry"
+
+    early, tree, display = _gate_config_flow_ast_rule(
+        context, rule_id, title, _CONNECTION_TEST_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if _has_connection_test(tree):
+        return _make_ast_rule_finding(
+            rule_id,
+            title,
+            _CONNECTION_TEST_SOURCE,
+            status=RuleStatus.PASS,
+            message="config_flow.py awaits a non-plumbing call inside a discovery-flow step — connection testing detected.",
+            reason="Testing the connection during setup gives users immediate feedback and prevents broken entries.",
+            path=display,
+        )
+
+    return _make_ast_rule_finding(
+        rule_id,
+        title,
+        _CONNECTION_TEST_SOURCE,
+        status=RuleStatus.WARN,
+        message=(
+            "No connection test detected in config_flow.py. "
+            "Discovery-flow steps (async_step_user, async_step_zeroconf, etc.) "
+            "appear to only call flow plumbing methods."
+        ),
+        reason="Testing the connection during setup gives users immediate feedback and prevents broken entries.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Add a connection test (e.g. await validate_input(hass, data)) inside async_step_user.",
+            docs_url=_CONNECTION_TEST_SOURCE,
+        ),
+    )
+
+
 RULES = [
     RuleDefinition(
         id="config_flow.user_step.exists",
@@ -495,5 +897,69 @@ RULES = [
         source_url=CONFIG_FLOW_SOURCE,
         check=config_flow_manifest_flag_consistent,
         overridable=False,
+    ),
+    RuleDefinition(
+        id="config_flow.reauth_step.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py defines a reauthentication step",
+        why=(
+            "Reauthentication lets users recover from expired OAuth tokens or changed passwords "
+            "without removing and re-adding the integration. "
+            "Note: this rule uses AST inspection and cannot detect methods inherited from a base class."
+        ),
+        source_url=_REAUTH_STEP_SOURCE,
+        check=config_flow_reauth_step_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="config_flow.reconfigure_step.exists",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py defines a reconfigure step",
+        why=(
+            "Reconfigure lets users update integration settings (e.g. host, port, API key) "
+            "without removing and re-adding the integration. "
+            "Note: this rule uses AST inspection and cannot detect methods inherited from a base class."
+        ),
+        source_url=_RECONFIGURE_STEP_SOURCE,
+        check=config_flow_reconfigure_step_exists,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="config_flow.unique_id.set",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py sets a unique ID",
+        why=(
+            "Setting a unique ID via async_set_unique_id prevents duplicate config entries "
+            "and enables entity deduplication across restarts. "
+            "Note: this rule uses AST inspection; it detects any call to async_set_unique_id "
+            "anywhere in the module."
+        ),
+        source_url=_UNIQUE_ID_SOURCE,
+        check=config_flow_unique_id_set,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="config_flow.connection_test",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="config_flow.py tests the connection before creating the entry",
+        why=(
+            "Testing the connection during setup gives users immediate feedback when credentials "
+            "or network settings are wrong, preventing broken config entries. "
+            "Note: this rule uses a heuristic — it checks whether any discovery-flow step "
+            "(async_step_user, async_step_zeroconf, etc.) awaits a call that is not pure flow "
+            "plumbing (async_show_form, async_create_entry, etc.). False negatives are possible "
+            "if connection logic lives in a helper called without await."
+        ),
+        source_url=_CONNECTION_TEST_SOURCE,
+        check=config_flow_connection_test,
+        overridable=True,
     ),
 ]

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -144,3 +144,34 @@ def test_requirements_no_git_warns_on_bad_integration_fixture() -> None:
     f = findings["manifest.requirements.no_git_or_url_specs"]
     assert f.status is RuleStatus.WARN
     assert "git+https://github.com/example/lib.git" in f.message
+
+
+# ---------------------------------------------------------------------------
+# issue #101: config_flow advanced rules — bad fixture has async_step_setup
+# (no reauth, no reconfigure, no unique_id, no discovery-flow step)
+# All four must WARN.
+# ---------------------------------------------------------------------------
+
+
+def test_reauth_step_warns_on_bad_integration_fixture() -> None:
+    """Fixture config_flow.py has no reauth step — must WARN."""
+    findings = _findings_by_id()
+    assert findings["config_flow.reauth_step.exists"].status is RuleStatus.WARN
+
+
+def test_reconfigure_step_warns_on_bad_integration_fixture() -> None:
+    """Fixture config_flow.py has no reconfigure step — must WARN."""
+    findings = _findings_by_id()
+    assert findings["config_flow.reconfigure_step.exists"].status is RuleStatus.WARN
+
+
+def test_unique_id_set_warns_on_bad_integration_fixture() -> None:
+    """Fixture config_flow.py has no async_set_unique_id call — must WARN."""
+    findings = _findings_by_id()
+    assert findings["config_flow.unique_id.set"].status is RuleStatus.WARN
+
+
+def test_connection_test_warns_on_bad_integration_fixture() -> None:
+    """Fixture config_flow.py has no discovery-flow step — connection_test must WARN."""
+    findings = _findings_by_id()
+    assert findings["config_flow.connection_test"].status is RuleStatus.WARN

--- a/tests/test_project_applicability_context.py
+++ b/tests/test_project_applicability_context.py
@@ -41,14 +41,23 @@ def test_project_applicability_softens_missing_optional_files(tmp_path: Path) ->
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
         "config_flow.user_step.exists",  # v0.8 PR3 — also responds to uses_config_flow
+        # v0.10 issue #101 — advanced config_flow rules
+        "config_flow.reauth_step.exists",
+        "config_flow.reconfigure_step.exists",
+        "config_flow.unique_id.set",
+        "config_flow.connection_test",
     ):
         assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
         assert findings[rule_id].applicability.source == "config"
 
-    assert report.summary.applicability_applied.count == 6
+    assert report.summary.applicability_applied.count == 10
     assert report.summary.applicability_applied.rule_ids == [
+        "config_flow.connection_test",
         "config_flow.file.exists",
         "config_flow.manifest_flag_consistent",
+        "config_flow.reauth_step.exists",
+        "config_flow.reconfigure_step.exists",
+        "config_flow.unique_id.set",
         "config_flow.user_step.exists",
         "diagnostics.file.exists",
         "diagnostics.redaction.used",
@@ -93,8 +102,17 @@ def test_project_applicability_natural_pass_wins(tmp_path: Path) -> None:
     # diagnostics.redaction.used is also suppressed via config (supports_diagnostics=False).
     assert findings["diagnostics.redaction.used"].status is RuleStatus.NOT_APPLICABLE
     assert findings["diagnostics.redaction.used"].applicability.source == "config"
-    # Both config_flow.user_step.exists and diagnostics.redaction.used suppressed via config.
-    assert report.summary.applicability_applied.count == 2
+    # v0.10 issue #101: 4 advanced config_flow rules also suppressed via uses_config_flow=False.
+    for rule_id in (
+        "config_flow.reauth_step.exists",
+        "config_flow.reconfigure_step.exists",
+        "config_flow.unique_id.set",
+        "config_flow.connection_test",
+    ):
+        assert findings[rule_id].status is RuleStatus.NOT_APPLICABLE
+        assert findings[rule_id].applicability.source == "config"
+    # config_flow.user_step.exists + diagnostics.redaction.used + 4 advanced rules = 6
+    assert report.summary.applicability_applied.count == 6
 
 
 def test_project_applicability_does_not_hide_config_flow_mismatch(

--- a/tests/test_rules_config_flow_advanced.py
+++ b/tests/test_rules_config_flow_advanced.py
@@ -1,0 +1,459 @@
+"""Tests for config_flow advanced detection rules (issue #101, v0.10 second batch).
+
+TDD cycle:
+  - RED: written first, before production code exists
+  - GREEN: confirmed after implementation
+
+Rules covered:
+  - config_flow.reauth_step.exists
+  - config_flow.reconfigure_step.exists
+  - config_flow.unique_id.set
+  - config_flow.connection_test
+
+Spec: issue #101 — config_flow advanced detection
+Source: https://developers.home-assistant.io/docs/config_entries_config_flow_handler
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "test_integration",
+    manifest: str | None = None,
+    config_flow_src: str | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with optional manifest and config_flow.py."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0", "config_flow": true}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+
+    if config_flow_src is not None:
+        (integration / "config_flow.py").write_text(config_flow_src, encoding="utf-8")
+
+    return integration
+
+
+def _finding_for(root: Path, rule_id: str):
+    return {f.rule_id: f for f in run_check(root).findings}[rule_id]
+
+
+# ===========================================================================
+# config_flow.reauth_step.exists
+# ===========================================================================
+
+REAUTH_RULE = "config_flow.reauth_step.exists"
+
+
+class TestReauthStepExists:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[REAUTH_RULE]
+        assert rule.id == REAUTH_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_with_async_step_reauth(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_reauth(self, entry_data=None):
+        return self.async_show_form(step_id="reauth")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_with_async_step_reauth_confirm(self, tmp_path: Path) -> None:
+        """Alternate name: async_step_reauth_confirm also qualifies."""
+        src = """\
+class MyFlow:
+    async def async_step_reauth_confirm(self, user_input=None):
+        return self.async_show_form(step_id="reauth_confirm")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        return self.async_show_form(step_id="user")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_config_flow_file(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_uses_config_flow_false(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_reauth(self, entry_data=None):
+        return {}
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        (tmp_path / "hasscheck.yaml").write_text(
+            "applicability:\n  uses_config_flow: false\n", encoding="utf-8"
+        )
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, REAUTH_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+
+# ===========================================================================
+# config_flow.reconfigure_step.exists
+# ===========================================================================
+
+RECONFIG_RULE = "config_flow.reconfigure_step.exists"
+
+
+class TestReconfigureStepExists:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[RECONFIG_RULE]
+        assert rule.id == RECONFIG_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_with_async_step_reconfigure(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_reconfigure(self, user_input=None):
+        return self.async_show_form(step_id="reconfigure")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        return self.async_show_form(step_id="user")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_config_flow_file(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_uses_config_flow_false(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_reconfigure(self, user_input=None):
+        return {}
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        (tmp_path / "hasscheck.yaml").write_text(
+            "applicability:\n  uses_config_flow: false\n", encoding="utf-8"
+        )
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, RECONFIG_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+
+# ===========================================================================
+# config_flow.unique_id.set
+# ===========================================================================
+
+UNIQUE_ID_RULE = "config_flow.unique_id.set"
+
+
+class TestUniqueIdSet:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[UNIQUE_ID_RULE]
+        assert rule.id == UNIQUE_ID_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_with_self_async_set_unique_id(self, tmp_path: Path) -> None:
+        """Most common: self.async_set_unique_id(value)."""
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        await self.async_set_unique_id("my-device-id")
+        return self.async_create_entry(title="Test", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_with_await_self_async_set_unique_id(self, tmp_path: Path) -> None:
+        """await self.async_set_unique_id(...) form."""
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        await self.async_set_unique_id(self.device.serial)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title="Test", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_with_bare_name_async_set_unique_id(self, tmp_path: Path) -> None:
+        """Less common: bare call async_set_unique_id(value) without self."""
+        src = """\
+async def async_set_unique_id(value):
+    pass
+
+async def configure():
+    async_set_unique_id("some-id")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_no_unique_id_call(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        return self.async_create_entry(title="Test", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_config_flow_file(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_uses_config_flow_false(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        await self.async_set_unique_id("id")
+        return self.async_create_entry(title="Test", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        (tmp_path / "hasscheck.yaml").write_text(
+            "applicability:\n  uses_config_flow: false\n", encoding="utf-8"
+        )
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+
+# ===========================================================================
+# config_flow.connection_test
+# ===========================================================================
+
+CONN_TEST_RULE = "config_flow.connection_test"
+
+
+class TestConnectionTest:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[CONN_TEST_RULE]
+        assert rule.id == CONN_TEST_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_when_async_step_user_awaits_validate_input(
+        self, tmp_path: Path
+    ) -> None:
+        """PASS: async_step_user awaits validate_input(...) — non-flow call."""
+        src = """\
+async def validate_input(hass, data):
+    client = MyClient(data["host"])
+    await client.connect()
+    return {"title": data["host"]}
+
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        info = await validate_input(self.hass, user_input)
+        return self.async_create_entry(title=info["title"], data=user_input)
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_when_zeroconf_step_awaits_external_call(self, tmp_path: Path) -> None:
+        """PASS: async_step_zeroconf awaits external_call(...) alongside plumbing calls."""
+        src = """\
+class MyFlow:
+    async def async_step_zeroconf(self, discovery_info=None):
+        await self.async_set_unique_id(discovery_info.hostname)
+        await external_call(discovery_info.host)
+        return self.async_abort(reason="already_configured")
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_async_step_user_only_calls_show_form_and_create_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """WARN: only plumbing calls — no connection testing."""
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        if user_input is None:
+            return self.async_show_form(step_id="user")
+        return self.async_create_entry(title="Test", data=user_input)
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_warn_when_async_step_user_only_calls_unique_id_and_abort(
+        self, tmp_path: Path
+    ) -> None:
+        """WARN: only unique_id + abort — no real connection work."""
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        await self.async_set_unique_id("fixed-id")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title="T", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_warn_when_no_discovery_flow_steps_present(self, tmp_path: Path) -> None:
+        """WARN: no async_step_user/zeroconf/dhcp/bluetooth/usb — vacuously WARN."""
+        src = """\
+class MyFlow:
+    async def async_step_setup(self, user_input=None):
+        return {}
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_pass_when_dhcp_step_awaits_real_call(self, tmp_path: Path) -> None:
+        """PASS: async_step_dhcp awaits check_device(...)."""
+        src = """\
+class MyFlow:
+    async def async_step_dhcp(self, discovery_info=None):
+        result = await check_device(discovery_info.ip)
+        if not result:
+            return self.async_abort(reason="not_supported")
+        return self.async_create_entry(title="Device", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_not_applicable_when_no_config_flow_file(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_uses_config_flow_false(self, tmp_path: Path) -> None:
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        await validate_input(self.hass, user_input)
+        return self.async_create_entry(title="T", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        (tmp_path / "hasscheck.yaml").write_text(
+            "applicability:\n  uses_config_flow: false\n", encoding="utf-8"
+        )
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+    def test_async_step_flow_step_calls_do_not_qualify(self, tmp_path: Path) -> None:
+        """WARN: awaiting another async_step_* call is still plumbing, not connection work."""
+        src = """\
+class MyFlow:
+    async def async_step_user(self, user_input=None):
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None):
+        return self.async_create_entry(title="T", data={})
+"""
+        _write_integration(tmp_path, config_flow_src=src)
+        f = _finding_for(tmp_path, CONN_TEST_RULE)
+        assert f.status is RuleStatus.WARN

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 33 rules total (v0.10 issue #100 adds 3 manifest.requirements rules):
-#   - manifest.requirements.is_list (overridable=False, REQUIRED)
-#   - manifest.requirements.entries_well_formed (overridable=True, RECOMMENDED)
-#   - manifest.requirements.no_git_or_url_specs (overridable=True, RECOMMENDED)
-# 12 locked overridable=False, 21 overridable=True.
+# 37 rules total (v0.10 issue #101 adds 4 config_flow advanced rules):
+#   - config_flow.reauth_step.exists (overridable=True, RECOMMENDED)
+#   - config_flow.reconfigure_step.exists (overridable=True, RECOMMENDED)
+#   - config_flow.unique_id.set (overridable=True, RECOMMENDED)
+#   - config_flow.connection_test (overridable=True, RECOMMENDED)
+# 12 locked overridable=False, 25 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -58,11 +59,16 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     # v0.10 issue #100 — manifest.requirements validation (RECOMMENDED, overridable=True)
     "manifest.requirements.entries_well_formed",
     "manifest.requirements.no_git_or_url_specs",
+    # v0.10 issue #101 — advanced config_flow rules (RECOMMENDED, overridable=True)
+    "config_flow.reauth_step.exists",
+    "config_flow.reconfigure_step.exists",
+    "config_flow.unique_id.set",
+    "config_flow.connection_test",
 }
 
 
-def test_total_rule_count_is_thirty_three() -> None:
-    assert len(RULES) == 33, f"expected 33 rules, got {len(RULES)}"
+def test_total_rule_count_is_thirty_seven() -> None:
+    assert len(RULES) == 37, f"expected 37 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

Second v0.10 batch — four AST-based rules deepening config flow inspection beyond the foundational \`config_flow.user_step.exists\` shipped in v0.8 (#54). Closes #101.

## Rules

| Rule ID | Detection |
|---------|-----------|
| \`config_flow.reauth_step.exists\` | \`AsyncFunctionDef\` named \`async_step_reauth\` OR \`async_step_reauth_confirm\` |
| \`config_flow.reconfigure_step.exists\` | \`AsyncFunctionDef\` named \`async_step_reconfigure\` |
| \`config_flow.unique_id.set\` | \`Call\` to \`async_set_unique_id\` (Name or Attribute) anywhere in the module |
| \`config_flow.connection_test\` | Heuristic: any discovery flow step (\`async_step_user\` / \`zeroconf\` / \`dhcp\` / \`bluetooth\` / \`usb\`) awaits a call outside the plumbing set (\`async_show_form\`, \`async_create_entry\`, \`async_abort\`, \`async_set_unique_id\`, \`_abort_if_unique_id_configured\`, any \`async_step_*\`) |

All four: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=modern_ha_patterns\`.

## Status semantics (uniform across all four)

- **NOT_APPLICABLE** — no integration / no \`config_flow.py\` / \`uses_config_flow=False\`
- **PASS** — AST detects the pattern
- **WARN** — file exists but pattern absent
- **WARN** — parse error (consistent with v0.8 \`user_step.exists\` and \`diagnostics.redaction.used\`)

## Helpers added (in \`config_flow.py\`)

- \`_has_async_function_any(tree, names)\` — multi-name variant of existing \`_has_async_function\`
- \`_module_calls_name(tree, target)\` — finds \`Name(id=target)\` or \`Attribute(attr=target)\` calls
- \`_has_connection_test(tree)\` — discovery-flow-step awaited-call heuristic
- Module constants: \`_REAUTH_STEP_NAMES\`, \`_DISCOVERY_FLOW_STEPS\`, \`_FLOW_PLUMBING_CALLS\`

All reuse \`hasscheck.ast_utils.parse_module\` from #93 — no new inline copies.

## Test plan

- [x] \`uv run pytest -q\` — **558 passing** (518 baseline + 40 new), zero regressions
- [x] \`uv run ruff check\` — clean (3 auto-fixed by hook: \`typing.Iterable\` → \`collections.abc.Iterable\`, return-type annotation quoting, unused import)
- [x] Strict TDD: 36 RED tests written first across 4 rule classes
- [x] \`uv run hasscheck explain config_flow.{reauth_step.exists,reconfigure_step.exists,unique_id.set,connection_test}\` — all four exit 0
- [x] \`uv run hasscheck check --path examples/bad_integration\` — 4 new WARNs deterministic
- [x] Connection-test false-positive guards covered: \`async_show_form\` only, \`async_create_entry\` only, \`async_set_unique_id\` only, all \`async_step_*\` chained — none trigger PASS

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 33 → **37**. All four overridable.
- **\`APPLICABILITY_FLAGS_BY_RULE\`** in \`checker.py\` extended — all four new rules respond to \`uses_config_flow=False\`.
- **\`tests/test_project_applicability_context.py\`** count assertions updated: 6→10 and 2→6 to reflect the four new gated rules.
- **README "Modern HA Patterns"** table extended with four rows; \`docs/rules/README.md\` index updated. Per-rule pages deferred to #104.
- **Bad fixture unchanged** — its existing minimal \`config_flow.py\` stub (with \`async_step_setup\`, no other plumbing) naturally produces WARN for all four new rules. No fixture edits needed; the four new whitelist assertions are pure additions.
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\` (additive within ruleset cycle per ADR 0006).

## What's next in v0.10

- #107 — modern HA pattern checks (async_setup_entry / runtime_data / unique_id / has_entity_name / device_info). Heaviest of the v0.10 trio — multi-file AST scan covering \`__init__.py\` and entity-platform files.