### PR TITLE
feat(rules): modern HA pattern checks — async_setup_entry / runtime_data / unique_id / has_entity_name / device_info (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ Per-rule documentation pages with status behavior tables, fix instructions, and 
 | `config_flow.reconfigure_step.exists` | `config_flow.py` defines `async_step_reconfigure` (AST inspection). |
 | `config_flow.unique_id.set` | `config_flow.py` calls `async_set_unique_id` (AST inspection). |
 | `config_flow.connection_test` | A discovery-flow step awaits a non-plumbing call (AST heuristic). |
+| `init.async_setup_entry.defined` | `__init__.py` defines `async_setup_entry` (AST inspection). |
+| `init.runtime_data.used` | `__init__.py` accesses `entry.runtime_data` (HA 2024.4+ pattern, AST inspection). |
+| `entity.unique_id.set` | At least one entity platform sets `_attr_unique_id` (AST inspection). |
+| `entity.has_entity_name.set` | At least one entity platform sets `_attr_has_entity_name = True` (AST inspection). |
+| `entity.device_info.set` | At least one entity platform sets `_attr_device_info` or returns `DeviceInfo` (AST inspection). |
 
 ### Diagnostics and repairs
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # HassCheck Rule Index
 
-All 33 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
+All 42 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
 
 ## HACS structure
 
@@ -41,6 +41,11 @@ All 33 rules, grouped by category. Rules with a dedicated docs page are linked; 
 | `config_flow.reconfigure_step.exists` | `config_flow.py` defines `async_step_reconfigure` (AST inspection). | (no docs page yet) |
 | `config_flow.unique_id.set` | `config_flow.py` calls `async_set_unique_id` (AST inspection). | (no docs page yet) |
 | `config_flow.connection_test` | A discovery-flow step awaits a non-plumbing call (AST heuristic). | (no docs page yet) |
+| `init.async_setup_entry.defined` | `__init__.py` defines `async_setup_entry` (AST inspection). | (no docs page yet) |
+| `init.runtime_data.used` | `__init__.py` accesses `entry.runtime_data` (HA 2024.4+ pattern, AST inspection). | (no docs page yet) |
+| `entity.unique_id.set` | At least one entity platform sets `_attr_unique_id` (AST inspection). | (no docs page yet) |
+| `entity.has_entity_name.set` | At least one entity platform sets `_attr_has_entity_name = True` (AST inspection). | (no docs page yet) |
+| `entity.device_info.set` | At least one entity platform sets `_attr_device_info` or returns `DeviceInfo` (AST inspection). | (no docs page yet) |
 
 ## Diagnostics and repairs
 

--- a/examples/bad_integration/custom_components/demo_bad/__init__.py
+++ b/examples/bad_integration/custom_components/demo_bad/__init__.py
@@ -1,0 +1,12 @@
+"""Demo integration — intentionally lacks async_setup_entry and runtime_data usage.
+
+Used by hasscheck fixtures to exercise init.* rules.
+"""
+
+DOMAIN = "demo_bad"
+
+
+def setup(hass, config):
+    """Legacy synchronous setup — does not use config entries."""
+    hass.data.setdefault(DOMAIN, {})
+    return True

--- a/src/hasscheck/ast_utils.py
+++ b/src/hasscheck/ast_utils.py
@@ -6,6 +6,18 @@ import ast
 from pathlib import Path
 
 
+def has_async_function(tree: ast.Module, name: str) -> bool:
+    """Return True if tree contains any AsyncFunctionDef with the given name.
+
+    Uses ast.walk so it finds the function at any nesting depth
+    (module-level or as a class method).
+    """
+    return any(
+        isinstance(node, ast.AsyncFunctionDef) and node.name == name
+        for node in ast.walk(tree)
+    )
+
+
 def parse_module(path: Path) -> tuple[ast.Module | None, str | None]:
     """Parse a Python file with the standard library AST module.
 

--- a/src/hasscheck/rules/config_flow.py
+++ b/src/hasscheck/rules/config_flow.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Iterable
 from typing import Any
 
+from hasscheck.ast_utils import has_async_function as _has_async_function_shared
 from hasscheck.ast_utils import parse_module
 from hasscheck.models import (
     Applicability,
@@ -108,15 +109,8 @@ def _read_manifest(context: ProjectContext) -> tuple[dict[str, Any] | None, str 
 
 
 def _has_async_function(tree: ast.Module, name: str) -> bool:
-    """Return True if tree contains any AsyncFunctionDef with the given name.
-
-    Uses ast.walk so it finds the function at any nesting depth
-    (module-level or as a class method).
-    """
-    return any(
-        isinstance(node, ast.AsyncFunctionDef) and node.name == name
-        for node in ast.walk(tree)
-    )
+    """Thin wrapper delegating to hasscheck.ast_utils.has_async_function."""
+    return _has_async_function_shared(tree, name)
 
 
 def _has_async_function_any(tree: ast.Module, names: Iterable[str]) -> bool:

--- a/src/hasscheck/rules/entity.py
+++ b/src/hasscheck/rules/entity.py
@@ -1,0 +1,553 @@
+"""Rules checking entity platform patterns for modern HA integrations (issue #107).
+
+Rules:
+  - entity.unique_id.set
+  - entity.has_entity_name.set
+  - entity.device_info.set
+
+Category: modern_ha_patterns
+Severity: RECOMMENDED
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from pathlib import Path
+
+from hasscheck.ast_utils import parse_module
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "modern_ha_patterns"
+
+_SOURCE_CHECKED_AT = "2026-05-01"
+
+_UNIQUE_ID_SOURCE = (
+    "https://developers.home-assistant.io/docs/entity_registry_index/#unique-id"
+)
+_HAS_ENTITY_NAME_SOURCE = (
+    "https://developers.home-assistant.io/docs/core/entity/"
+    "#has_entity_name-true-mandatory-for-new-integrations"
+)
+_DEVICE_INFO_SOURCE = (
+    "https://developers.home-assistant.io/docs/device_registry_index/#defining-devices"
+)
+
+# Canonical set of HA platform names (Source: homeassistant/const.py Platform enum)
+_HA_PLATFORM_NAMES: frozenset[str] = frozenset(
+    {
+        "air_quality",
+        "alarm_control_panel",
+        "binary_sensor",
+        "button",
+        "calendar",
+        "camera",
+        "climate",
+        "conversation",
+        "cover",
+        "date",
+        "datetime",
+        "device_tracker",
+        "event",
+        "fan",
+        "geo_location",
+        "humidifier",
+        "image",
+        "image_processing",
+        "lawn_mower",
+        "light",
+        "lock",
+        "media_player",
+        "notify",
+        "number",
+        "remote",
+        "scene",
+        "select",
+        "sensor",
+        "siren",
+        "stt",
+        "switch",
+        "text",
+        "time",
+        "todo",
+        "tts",
+        "update",
+        "vacuum",
+        "valve",
+        "wake_word",
+        "water_heater",
+        "weather",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _display_path(path: Path, context: ProjectContext, fallback: str) -> str:
+    if path is None:
+        return fallback
+    return str(path.relative_to(context.root))
+
+
+def _make_not_applicable(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    message: str,
+    reason: str,
+    path: str,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason=reason,
+        ),
+        source=RuleSource(url=source_url),
+        fix=None,
+        path=path,
+    )
+
+
+def _make_finding(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    *,
+    status: RuleStatus,
+    message: str,
+    reason: str,
+    path: str,
+    fix: FixSuggestion | None = None,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(reason=reason),
+        source=RuleSource(url=source_url),
+        fix=fix,
+        path=path,
+    )
+
+
+def _iter_platform_files(integration_path: Path) -> Iterable[Path]:
+    """Yield existing HA platform files in the integration directory."""
+    for name in _HA_PLATFORM_NAMES:
+        candidate = integration_path / f"{name}.py"
+        if candidate.is_file():
+            yield candidate
+
+
+def _inspect_entity_files_for(
+    integration_path: Path,
+    predicate,
+) -> tuple[bool, list[str]]:
+    """Inspect all platform files with predicate.
+
+    Returns (any_match, parse_errors) where:
+    - any_match: True if at least one file satisfied the predicate
+    - parse_errors: list of file paths (as str) that failed to parse
+    """
+    any_match = False
+    parse_errors: list[str] = []
+
+    for path in _iter_platform_files(integration_path):
+        tree, error = parse_module(path)
+        if error is not None:
+            parse_errors.append(str(path))
+            continue
+        assert tree is not None
+        if predicate(tree):
+            any_match = True
+
+    return any_match, parse_errors
+
+
+# ---------------------------------------------------------------------------
+# Detection predicates
+# ---------------------------------------------------------------------------
+
+
+def _entity_file_sets_unique_id(tree: ast.Module) -> bool:
+    """Return True if the module assigns _attr_unique_id (class or self attr)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_attr_unique_id":
+                    return True
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "_attr_unique_id"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    return True
+        if isinstance(node, ast.AnnAssign):
+            target = node.target
+            if isinstance(target, ast.Name) and target.id == "_attr_unique_id":
+                return True
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "_attr_unique_id"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                return True
+    return False
+
+
+def _entity_file_has_entity_name_true(tree: ast.Module) -> bool:
+    """Return True if _attr_has_entity_name is assigned literal True."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets_match = False
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "_attr_has_entity_name":
+                targets_match = True
+                break
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "_attr_has_entity_name"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                targets_match = True
+                break
+        if not targets_match:
+            continue
+        # Value must be literal True
+        if isinstance(node.value, ast.Constant) and node.value.value is True:
+            return True
+    return False
+
+
+def _entity_file_sets_device_info(tree: ast.Module) -> bool:
+    """Return True if the module sets _attr_device_info OR has a device_info
+    method/property returning DeviceInfo(...).
+    """
+    for node in ast.walk(tree):
+        # Path 1: _attr_device_info assignment (class or self attribute)
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == "_attr_device_info":
+                    return True
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "_attr_device_info"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    return True
+        # Path 2: any function/method named "device_info" returning DeviceInfo(...)
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "device_info"
+        ):
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Return) and isinstance(inner.value, ast.Call):
+                    func = inner.value.func
+                    if isinstance(func, ast.Name) and func.id == "DeviceInfo":
+                        return True
+                    if isinstance(func, ast.Attribute) and func.attr == "DeviceInfo":
+                        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Shared gating for entity rules
+# ---------------------------------------------------------------------------
+
+
+def _gate_entity_rule(
+    context: ProjectContext,
+    rule_id: str,
+    title: str,
+    source_url: str,
+) -> tuple[Finding | None, Path | None, str]:
+    """Shared gating for entity platform rules.
+
+    Returns (early_finding, integration_path, display_path).
+    If early_finding is not None, caller should return it immediately.
+    """
+    fallback_path = "custom_components/<domain>/"
+
+    if context.integration_path is None:
+        return (
+            _make_not_applicable(
+                rule_id,
+                title,
+                source_url,
+                message="No integration directory was detected.",
+                reason="custom_components/<domain>/ must exist before HassCheck can inspect entity platforms.",
+                path=fallback_path,
+            ),
+            None,
+            fallback_path,
+        )
+
+    display = _display_path(context.integration_path, context, fallback_path)
+
+    # Check if any platform files exist
+    platform_files = list(_iter_platform_files(context.integration_path))
+    if not platform_files:
+        return (
+            _make_not_applicable(
+                rule_id,
+                title,
+                source_url,
+                message="No entity platform files found in the integration directory.",
+                reason="At least one HA platform file (sensor.py, light.py, etc.) must exist for this rule to apply.",
+                path=display,
+            ),
+            None,
+            display,
+        )
+
+    return None, context.integration_path, display
+
+
+# ---------------------------------------------------------------------------
+# Check functions
+# ---------------------------------------------------------------------------
+
+
+def entity_unique_id_set(context: ProjectContext) -> Finding:
+    """Check that at least one entity platform file sets _attr_unique_id."""
+    rule_id = "entity.unique_id.set"
+    title = "Entity sets _attr_unique_id"
+
+    early, integration_path, display = _gate_entity_rule(
+        context, rule_id, title, _UNIQUE_ID_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert integration_path is not None
+    any_match, parse_errors = _inspect_entity_files_for(
+        integration_path, _entity_file_sets_unique_id
+    )
+
+    if any_match:
+        return _make_finding(
+            rule_id,
+            title,
+            _UNIQUE_ID_SOURCE,
+            status=RuleStatus.PASS,
+            message="At least one entity platform file sets _attr_unique_id.",
+            reason="A unique ID is required for entities to support the entity registry and avoid duplicates.",
+            path=display,
+        )
+
+    if parse_errors:
+        return _make_finding(
+            rule_id,
+            title,
+            _UNIQUE_ID_SOURCE,
+            status=RuleStatus.WARN,
+            message=f"Could not parse some platform files; _attr_unique_id presence cannot be determined. Files: {', '.join(parse_errors)}",
+            reason="Platform files exist but contain syntax errors.",
+            path=display,
+            fix=FixSuggestion(summary="Fix syntax errors in platform files."),
+        )
+
+    return _make_finding(
+        rule_id,
+        title,
+        _UNIQUE_ID_SOURCE,
+        status=RuleStatus.WARN,
+        message="No entity platform file sets _attr_unique_id; entities will not be registered in the entity registry.",
+        reason="A unique ID is required for entities to support the entity registry and avoid duplicates.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Set self._attr_unique_id or the class attribute _attr_unique_id in each entity class.",
+            docs_url=_UNIQUE_ID_SOURCE,
+        ),
+    )
+
+
+def entity_has_entity_name_set(context: ProjectContext) -> Finding:
+    """Check that at least one entity platform file sets _attr_has_entity_name = True."""
+    rule_id = "entity.has_entity_name.set"
+    title = "Entity sets _attr_has_entity_name = True"
+
+    early, integration_path, display = _gate_entity_rule(
+        context, rule_id, title, _HAS_ENTITY_NAME_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert integration_path is not None
+    any_match, parse_errors = _inspect_entity_files_for(
+        integration_path, _entity_file_has_entity_name_true
+    )
+
+    if any_match:
+        return _make_finding(
+            rule_id,
+            title,
+            _HAS_ENTITY_NAME_SOURCE,
+            status=RuleStatus.PASS,
+            message="At least one entity platform file sets _attr_has_entity_name = True.",
+            reason="_attr_has_entity_name = True is mandatory for new integrations per HA 2023.x+ guidelines.",
+            path=display,
+        )
+
+    if parse_errors:
+        return _make_finding(
+            rule_id,
+            title,
+            _HAS_ENTITY_NAME_SOURCE,
+            status=RuleStatus.WARN,
+            message=f"Could not parse some platform files; _attr_has_entity_name presence cannot be determined. Files: {', '.join(parse_errors)}",
+            reason="Platform files exist but contain syntax errors.",
+            path=display,
+            fix=FixSuggestion(summary="Fix syntax errors in platform files."),
+        )
+
+    return _make_finding(
+        rule_id,
+        title,
+        _HAS_ENTITY_NAME_SOURCE,
+        status=RuleStatus.WARN,
+        message="No entity platform file sets _attr_has_entity_name = True; entity naming may not follow HA guidelines.",
+        reason="_attr_has_entity_name = True is mandatory for new integrations per HA 2023.x+ guidelines.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Add _attr_has_entity_name = True to each entity class.",
+            docs_url=_HAS_ENTITY_NAME_SOURCE,
+        ),
+    )
+
+
+def entity_device_info_set(context: ProjectContext) -> Finding:
+    """Check that at least one entity platform file sets device_info."""
+    rule_id = "entity.device_info.set"
+    title = "Entity sets device_info"
+
+    early, integration_path, display = _gate_entity_rule(
+        context, rule_id, title, _DEVICE_INFO_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert integration_path is not None
+    any_match, parse_errors = _inspect_entity_files_for(
+        integration_path, _entity_file_sets_device_info
+    )
+
+    if any_match:
+        return _make_finding(
+            rule_id,
+            title,
+            _DEVICE_INFO_SOURCE,
+            status=RuleStatus.PASS,
+            message="At least one entity platform file sets device_info.",
+            reason="Providing device_info groups entities under a device in the device registry.",
+            path=display,
+        )
+
+    if parse_errors:
+        return _make_finding(
+            rule_id,
+            title,
+            _DEVICE_INFO_SOURCE,
+            status=RuleStatus.WARN,
+            message=f"Could not parse some platform files; device_info presence cannot be determined. Files: {', '.join(parse_errors)}",
+            reason="Platform files exist but contain syntax errors.",
+            path=display,
+            fix=FixSuggestion(summary="Fix syntax errors in platform files."),
+        )
+
+    return _make_finding(
+        rule_id,
+        title,
+        _DEVICE_INFO_SOURCE,
+        status=RuleStatus.WARN,
+        message="No entity platform file sets device_info; entities will not be grouped under a device.",
+        reason="Providing device_info groups entities under a device in the device registry.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Set self._attr_device_info = DeviceInfo(...) in each entity class.",
+            docs_url=_DEVICE_INFO_SOURCE,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule registry entries
+# ---------------------------------------------------------------------------
+
+RULES: list[RuleDefinition] = [
+    RuleDefinition(
+        id="entity.unique_id.set",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="Entity sets _attr_unique_id",
+        why=(
+            "A unique ID is required for entities to be tracked across restarts, to support "
+            "entity customisation and to avoid duplicates in the entity registry. "
+            "Note: this rule uses AST inspection; it checks for _attr_unique_id assignments "
+            "at class level or via self._attr_unique_id in any platform file."
+        ),
+        source_url=_UNIQUE_ID_SOURCE,
+        check=entity_unique_id_set,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="entity.has_entity_name.set",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="Entity sets _attr_has_entity_name = True",
+        why=(
+            "_attr_has_entity_name = True is mandatory for new integrations as of HA 2023.x. "
+            "It enables proper entity naming conventions where the device name is the prefix. "
+            "Note: this rule only triggers PASS for literal True; False is treated as absent."
+        ),
+        source_url=_HAS_ENTITY_NAME_SOURCE,
+        check=entity_has_entity_name_set,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="entity.device_info.set",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="Entity sets device_info",
+        why=(
+            "Providing device_info groups entities under a device in the device registry, "
+            "improving the user experience in Settings → Devices & Services. "
+            "Note: this rule uses AST inspection; it checks for _attr_device_info assignment "
+            "or a device_info property/method returning DeviceInfo(...)."
+        ),
+        source_url=_DEVICE_INFO_SOURCE,
+        check=entity_device_info_set,
+        overridable=True,
+    ),
+]

--- a/src/hasscheck/rules/init_module.py
+++ b/src/hasscheck/rules/init_module.py
@@ -1,0 +1,305 @@
+"""Rules checking __init__.py patterns for modern HA integrations (issue #107).
+
+Rules:
+  - init.async_setup_entry.defined
+  - init.runtime_data.used
+
+Category: modern_ha_patterns
+Severity: RECOMMENDED
+"""
+
+from __future__ import annotations
+
+import ast
+
+from hasscheck.ast_utils import has_async_function, parse_module
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "modern_ha_patterns"
+_INIT_FILE = "__init__.py"
+
+_SOURCE_CHECKED_AT = "2026-05-01"
+
+_ASYNC_SETUP_ENTRY_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_index/#an-example"
+)
+_RUNTIME_DATA_SOURCE = (
+    "https://developers.home-assistant.io/docs/config_entries_index/#runtime_data"
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _display_path(path, context: ProjectContext, fallback: str) -> str:
+    if path is None:
+        return fallback
+    return str(path.relative_to(context.root))
+
+
+def _make_not_applicable(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    message: str,
+    reason: str,
+    path: str,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason=reason,
+        ),
+        source=RuleSource(url=source_url),
+        fix=None,
+        path=path,
+    )
+
+
+def _make_finding(
+    rule_id: str,
+    title: str,
+    source_url: str,
+    *,
+    status: RuleStatus,
+    message: str,
+    reason: str,
+    path: str,
+    fix: FixSuggestion | None = None,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(reason=reason),
+        source=RuleSource(url=source_url),
+        fix=fix,
+        path=path,
+    )
+
+
+def _gate_init_rule(
+    context: ProjectContext,
+    rule_id: str,
+    title: str,
+    source_url: str,
+) -> tuple[Finding | None, ast.Module | None, str]:
+    """Shared gating for __init__.py rules.
+
+    Returns (early_finding, tree, display_path).
+    If early_finding is not None, the caller should return it immediately.
+    """
+    fallback_path = f"custom_components/<domain>/{_INIT_FILE}"
+
+    if context.integration_path is None:
+        return (
+            _make_not_applicable(
+                rule_id,
+                title,
+                source_url,
+                message="No integration directory was detected.",
+                reason=f"custom_components/<domain>/ must exist before HassCheck can inspect {_INIT_FILE}.",
+                path=fallback_path,
+            ),
+            None,
+            fallback_path,
+        )
+
+    init_path = context.integration_path / _INIT_FILE
+    display = _display_path(init_path, context, fallback_path)
+
+    if not init_path.is_file():
+        return (
+            _make_not_applicable(
+                rule_id,
+                title,
+                source_url,
+                message=f"{_INIT_FILE} does not exist; this rule cannot be checked.",
+                reason=f"{_INIT_FILE} must exist before this rule can run.",
+                path=display,
+            ),
+            None,
+            display,
+        )
+
+    tree, error = parse_module(init_path)
+    if error is not None:
+        return (
+            _make_finding(
+                rule_id,
+                title,
+                source_url,
+                status=RuleStatus.WARN,
+                message=f"{_INIT_FILE} could not be parsed ({error}); {title.lower()} cannot be determined.",
+                reason=f"{_INIT_FILE} exists but has a syntax error.",
+                path=display,
+                fix=FixSuggestion(summary=f"Fix syntax errors in {_INIT_FILE}."),
+            ),
+            None,
+            display,
+        )
+
+    return None, tree, display
+
+
+# ---------------------------------------------------------------------------
+# Detection predicates
+# ---------------------------------------------------------------------------
+
+
+def _has_runtime_data_usage(tree: ast.Module) -> bool:
+    """Return True if any Attribute with attr='runtime_data' is accessed on
+    a Name whose id is in {entry, config_entry, _entry}.
+    """
+    targets = {"entry", "config_entry", "_entry"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "runtime_data":
+            if isinstance(node.value, ast.Name) and node.value.id in targets:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Check functions
+# ---------------------------------------------------------------------------
+
+
+def init_async_setup_entry_defined(context: ProjectContext) -> Finding:
+    """Check that __init__.py defines async_setup_entry."""
+    rule_id = "init.async_setup_entry.defined"
+    title = "__init__.py defines async_setup_entry"
+
+    early, tree, display = _gate_init_rule(
+        context, rule_id, title, _ASYNC_SETUP_ENTRY_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if has_async_function(tree, "async_setup_entry"):
+        return _make_finding(
+            rule_id,
+            title,
+            _ASYNC_SETUP_ENTRY_SOURCE,
+            status=RuleStatus.PASS,
+            message="__init__.py defines async_setup_entry.",
+            reason="async_setup_entry is the standard entry point for config-entry-based integrations.",
+            path=display,
+        )
+
+    return _make_finding(
+        rule_id,
+        title,
+        _ASYNC_SETUP_ENTRY_SOURCE,
+        status=RuleStatus.WARN,
+        message="__init__.py does not define async_setup_entry; the integration may not support config entries.",
+        reason="async_setup_entry is the standard entry point for config-entry-based integrations.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Add async_setup_entry(hass, entry) to __init__.py.",
+            docs_url=_ASYNC_SETUP_ENTRY_SOURCE,
+        ),
+    )
+
+
+def init_runtime_data_used(context: ProjectContext) -> Finding:
+    """Check that __init__.py uses entry.runtime_data (HA 2024.4+ pattern)."""
+    rule_id = "init.runtime_data.used"
+    title = "__init__.py uses entry.runtime_data"
+
+    early, tree, display = _gate_init_rule(
+        context, rule_id, title, _RUNTIME_DATA_SOURCE
+    )
+    if early is not None:
+        return early
+
+    assert tree is not None
+    if _has_runtime_data_usage(tree):
+        return _make_finding(
+            rule_id,
+            title,
+            _RUNTIME_DATA_SOURCE,
+            status=RuleStatus.PASS,
+            message="__init__.py uses entry.runtime_data.",
+            reason="entry.runtime_data is the HA 2024.4+ recommended way to store per-entry runtime objects.",
+            path=display,
+        )
+
+    return _make_finding(
+        rule_id,
+        title,
+        _RUNTIME_DATA_SOURCE,
+        status=RuleStatus.WARN,
+        message=(
+            "__init__.py does not use entry.runtime_data; "
+            "consider migrating from hass.data to entry.runtime_data."
+        ),
+        reason="entry.runtime_data is the HA 2024.4+ recommended way to store per-entry runtime objects.",
+        path=display,
+        fix=FixSuggestion(
+            summary="Replace hass.data[DOMAIN][entry.entry_id] with entry.runtime_data = <your object>.",
+            docs_url=_RUNTIME_DATA_SOURCE,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule registry entries
+# ---------------------------------------------------------------------------
+
+RULES: list[RuleDefinition] = [
+    RuleDefinition(
+        id="init.async_setup_entry.defined",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="__init__.py defines async_setup_entry",
+        why=(
+            "async_setup_entry is the standard entry point for config-entry-based integrations. "
+            "Without it, the integration cannot be loaded by Home Assistant when a config entry exists. "
+            "Note: this rule uses AST inspection and cannot detect async_setup_entry defined only in "
+            "a base class or via dynamic attribute assignment."
+        ),
+        source_url=_ASYNC_SETUP_ENTRY_SOURCE,
+        check=init_async_setup_entry_defined,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="init.runtime_data.used",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="__init__.py uses entry.runtime_data",
+        why=(
+            "entry.runtime_data is the HA 2024.4+ recommended way to store per-entry runtime objects "
+            "instead of the older hass.data[DOMAIN][entry.entry_id] pattern. "
+            "Note: this rule uses AST inspection; it looks for attribute access on names "
+            "'entry', 'config_entry', or '_entry'."
+        ),
+        source_url=_RUNTIME_DATA_SOURCE,
+        check=init_runtime_data_used,
+        overridable=True,
+    ),
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -7,7 +7,9 @@ from hasscheck.rules.config_flow import RULES as CONFIG_FLOW_RULES
 from hasscheck.rules.diagnostics import RULES as DIAGNOSTICS_RULES
 from hasscheck.rules.docs import RULES as DOCS_RULES
 from hasscheck.rules.docs_readme import RULES as DOCS_README_RULES
+from hasscheck.rules.entity import RULES as ENTITY_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
+from hasscheck.rules.init_module import RULES as INIT_MODULE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 from hasscheck.rules.repairs import RULES as REPAIRS_RULES
 from hasscheck.rules.repository import RULES as REPOSITORY_RULES
@@ -25,6 +27,8 @@ RULES = [
     *REPOSITORY_RULES,
     *TESTS_RULES,
     *CI_RULES,
+    *INIT_MODULE_RULES,
+    *ENTITY_RULES,
 ]
 RULES_BY_ID: dict[str, RuleDefinition] = {}
 for _rule in RULES:

--- a/tests/test_examples_bad_integration.py
+++ b/tests/test_examples_bad_integration.py
@@ -175,3 +175,24 @@ def test_connection_test_warns_on_bad_integration_fixture() -> None:
     """Fixture config_flow.py has no discovery-flow step — connection_test must WARN."""
     findings = _findings_by_id()
     assert findings["config_flow.connection_test"].status is RuleStatus.WARN
+
+
+# ---------------------------------------------------------------------------
+# issue #107: init.* rules — bad_integration __init__.py lacks async_setup_entry
+# and runtime_data usage → both WARN.
+# entity.* rules are NOT_APPLICABLE (no platform files in bad fixture).
+# ---------------------------------------------------------------------------
+
+
+def test_init_async_setup_entry_warns_on_bad_integration_fixture() -> None:
+    """Fixture __init__.py has no async_setup_entry — must WARN."""
+    findings = _findings_by_id()
+    f = findings["init.async_setup_entry.defined"]
+    assert f.status is RuleStatus.WARN
+
+
+def test_init_runtime_data_warns_on_bad_integration_fixture() -> None:
+    """Fixture __init__.py has no runtime_data usage — must WARN."""
+    findings = _findings_by_id()
+    f = findings["init.runtime_data.used"]
+    assert f.status is RuleStatus.WARN

--- a/tests/test_rules_entity.py
+++ b/tests/test_rules_entity.py
@@ -1,0 +1,400 @@
+"""Tests for entity rules (issue #107, v0.10 third batch).
+
+TDD cycle:
+  - RED: written first, before production code exists
+  - GREEN: confirmed after implementation
+
+Rules covered:
+  - entity.unique_id.set
+  - entity.has_entity_name.set
+  - entity.device_info.set
+
+Spec: issue #107 — modern HA pattern checks
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "test_integration",
+    manifest: str | None = None,
+    platform_files: dict[str, str] | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with optional manifest and platform files.
+
+    platform_files: dict mapping filename (e.g. 'sensor.py') to source content.
+    """
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0"}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+
+    if platform_files:
+        for fname, src in platform_files.items():
+            (integration / fname).write_text(src, encoding="utf-8")
+
+    return integration
+
+
+def _finding_for(root: Path, rule_id: str):
+    return {f.rule_id: f for f in run_check(root).findings}[rule_id]
+
+
+# ===========================================================================
+# entity.unique_id.set
+# ===========================================================================
+
+UNIQUE_ID_RULE = "entity.unique_id.set"
+
+_UNIQUE_ID_CLASS_ATTR = """\
+class MySensor:
+    _attr_unique_id = "my-sensor-uid"
+"""
+
+_UNIQUE_ID_SELF_ATTR = """\
+class MySensor:
+    def __init__(self, entry):
+        self._attr_unique_id = entry.entry_id
+"""
+
+_UNIQUE_ID_ABSENT = """\
+class MySensor:
+    def __init__(self, entry):
+        self._attr_name = "My Sensor"
+"""
+
+_UNIQUE_ID_ANNOTATED = """\
+class MySensor:
+    _attr_unique_id: str = "annotated-uid"
+"""
+
+
+class TestEntityUniqueIdSet:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[UNIQUE_ID_RULE]
+        assert rule.id == UNIQUE_ID_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_class_attribute(self, tmp_path: Path) -> None:
+        """PASS: class-level _attr_unique_id = ... assignment."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _UNIQUE_ID_CLASS_ATTR}
+        )
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_self_attr_in_init(self, tmp_path: Path) -> None:
+        """PASS: self._attr_unique_id = ... in __init__."""
+        _write_integration(tmp_path, platform_files={"sensor.py": _UNIQUE_ID_SELF_ATTR})
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_annotated_class_attribute(self, tmp_path: Path) -> None:
+        """PASS: annotated class attribute _attr_unique_id: str = ..."""
+        _write_integration(tmp_path, platform_files={"sensor.py": _UNIQUE_ID_ANNOTATED})
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        """WARN: platform file exists but _attr_unique_id not set."""
+        _write_integration(tmp_path, platform_files={"sensor.py": _UNIQUE_ID_ABSENT})
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: no integration detected."""
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_platform_files(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: integration exists but no platform files."""
+        _write_integration(tmp_path)  # no platform files
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        """WARN: platform file has syntax error."""
+        bad_src = "def broken(\n    # unclosed\n"
+        _write_integration(tmp_path, platform_files={"sensor.py": bad_src})
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_pass_any_platform_file_qualifies(self, tmp_path: Path) -> None:
+        """PASS: one platform has the pattern, another does not — any-match."""
+        _write_integration(
+            tmp_path,
+            platform_files={
+                "sensor.py": _UNIQUE_ID_ABSENT,
+                "light.py": _UNIQUE_ID_CLASS_ATTR,
+            },
+        )
+        f = _finding_for(tmp_path, UNIQUE_ID_RULE)
+        assert f.status is RuleStatus.PASS
+
+
+# ===========================================================================
+# entity.has_entity_name.set
+# ===========================================================================
+
+HAS_ENTITY_NAME_RULE = "entity.has_entity_name.set"
+
+_HAS_ENTITY_NAME_TRUE = """\
+class MySensor:
+    _attr_has_entity_name = True
+"""
+
+_HAS_ENTITY_NAME_FALSE = """\
+class MySensor:
+    _attr_has_entity_name = False
+"""
+
+_HAS_ENTITY_NAME_SELF_TRUE = """\
+class MySensor:
+    def __init__(self):
+        self._attr_has_entity_name = True
+"""
+
+_HAS_ENTITY_NAME_ABSENT = """\
+class MySensor:
+    _attr_name = "My Sensor"
+"""
+
+
+class TestEntityHasEntityNameSet:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[HAS_ENTITY_NAME_RULE]
+        assert rule.id == HAS_ENTITY_NAME_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_class_level_true(self, tmp_path: Path) -> None:
+        """PASS: _attr_has_entity_name = True at class level."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _HAS_ENTITY_NAME_TRUE}
+        )
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_self_attr_true(self, tmp_path: Path) -> None:
+        """PASS: self._attr_has_entity_name = True in __init__."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _HAS_ENTITY_NAME_SELF_TRUE}
+        )
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_set_to_false(self, tmp_path: Path) -> None:
+        """WARN: _attr_has_entity_name = False should NOT trigger PASS — only True counts."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _HAS_ENTITY_NAME_FALSE}
+        )
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        """WARN: platform file exists but _attr_has_entity_name not set."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _HAS_ENTITY_NAME_ABSENT}
+        )
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: no integration detected."""
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_platform_files(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: integration exists but no platform files."""
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        """WARN: platform file has syntax error."""
+        bad_src = "def broken(\n    # unclosed\n"
+        _write_integration(tmp_path, platform_files={"sensor.py": bad_src})
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_pass_any_platform_file_qualifies(self, tmp_path: Path) -> None:
+        """PASS: second file has True — any-match semantics."""
+        _write_integration(
+            tmp_path,
+            platform_files={
+                "sensor.py": _HAS_ENTITY_NAME_ABSENT,
+                "light.py": _HAS_ENTITY_NAME_TRUE,
+            },
+        )
+        f = _finding_for(tmp_path, HAS_ENTITY_NAME_RULE)
+        assert f.status is RuleStatus.PASS
+
+
+# ===========================================================================
+# entity.device_info.set
+# ===========================================================================
+
+DEVICE_INFO_RULE = "entity.device_info.set"
+
+_DEVICE_INFO_CLASS_ATTR = """\
+from homeassistant.helpers.device_registry import DeviceInfo
+
+class MySensor:
+    _attr_device_info = DeviceInfo(identifiers={("test", "uid")})
+"""
+
+_DEVICE_INFO_SELF_ATTR = """\
+from homeassistant.helpers.device_registry import DeviceInfo
+
+class MySensor:
+    def __init__(self, entry):
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="My Device",
+        )
+"""
+
+_DEVICE_INFO_PROPERTY = """\
+from homeassistant.helpers.device_registry import DeviceInfo
+
+class MySensor:
+    @property
+    def device_info(self):
+        return DeviceInfo(identifiers={("test", "uid")}, name="Test")
+"""
+
+_DEVICE_INFO_ASYNC_PROPERTY = """\
+from homeassistant.helpers.device_registry import DeviceInfo
+
+class MySensor:
+    async def device_info(self):
+        return DeviceInfo(identifiers={("test", "uid")})
+"""
+
+_DEVICE_INFO_MODULE_ATTR = """\
+from homeassistant.helpers.entity import DeviceInfo
+
+class MySensor:
+    _attr_device_info: DeviceInfo
+"""
+
+_DEVICE_INFO_ABSENT = """\
+class MySensor:
+    _attr_name = "My Sensor"
+    _attr_unique_id = "uid-1"
+"""
+
+
+class TestEntityDeviceInfoSet:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[DEVICE_INFO_RULE]
+        assert rule.id == DEVICE_INFO_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_class_attr(self, tmp_path: Path) -> None:
+        """PASS: class-level _attr_device_info = ..."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _DEVICE_INFO_CLASS_ATTR}
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_self_attr_in_init(self, tmp_path: Path) -> None:
+        """PASS: self._attr_device_info = ... in __init__."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _DEVICE_INFO_SELF_ATTR}
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_device_info_property_returning_device_info(
+        self, tmp_path: Path
+    ) -> None:
+        """PASS: device_info property returns DeviceInfo(...)."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _DEVICE_INFO_PROPERTY}
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_async_device_info_method(self, tmp_path: Path) -> None:
+        """PASS: async device_info method returning DeviceInfo(...)."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _DEVICE_INFO_ASYNC_PROPERTY}
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_annotated_class_attribute(self, tmp_path: Path) -> None:
+        """PASS: annotated _attr_device_info (no value) counts as assignment."""
+        _write_integration(
+            tmp_path, platform_files={"sensor.py": _DEVICE_INFO_MODULE_ATTR}
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        """WARN: platform file exists but no device_info pattern."""
+        _write_integration(tmp_path, platform_files={"sensor.py": _DEVICE_INFO_ABSENT})
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: no integration detected."""
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_platform_files(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: integration exists but no platform files."""
+        _write_integration(tmp_path)
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        """WARN: platform file has syntax error."""
+        bad_src = "def broken(\n    # unclosed\n"
+        _write_integration(tmp_path, platform_files={"sensor.py": bad_src})
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_pass_any_platform_file_qualifies(self, tmp_path: Path) -> None:
+        """PASS: one file has device_info, other does not — any-match."""
+        _write_integration(
+            tmp_path,
+            platform_files={
+                "sensor.py": _DEVICE_INFO_ABSENT,
+                "light.py": _DEVICE_INFO_SELF_ATTR,
+            },
+        )
+        f = _finding_for(tmp_path, DEVICE_INFO_RULE)
+        assert f.status is RuleStatus.PASS

--- a/tests/test_rules_init_module.py
+++ b/tests/test_rules_init_module.py
@@ -1,0 +1,238 @@
+"""Tests for init_module rules (issue #107, v0.10 third batch).
+
+TDD cycle:
+  - RED: written first, before production code exists
+  - GREEN: confirmed after implementation
+
+Rules covered:
+  - init.async_setup_entry.defined
+  - init.runtime_data.used
+
+Spec: issue #107 — modern HA pattern checks
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "test_integration",
+    manifest: str | None = None,
+    init_src: str | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with optional manifest and __init__.py."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0"}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+
+    if init_src is not None:
+        (integration / "__init__.py").write_text(init_src, encoding="utf-8")
+
+    return integration
+
+
+def _finding_for(root: Path, rule_id: str):
+    return {f.rule_id: f for f in run_check(root).findings}[rule_id]
+
+
+# ===========================================================================
+# init.async_setup_entry.defined
+# ===========================================================================
+
+ASYNC_SETUP_ENTRY_RULE = "init.async_setup_entry.defined"
+
+
+class TestAsyncSetupEntryDefined:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[ASYNC_SETUP_ENTRY_RULE]
+        assert rule.id == ASYNC_SETUP_ENTRY_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_when_async_setup_entry_at_module_level(self, tmp_path: Path) -> None:
+        """PASS: __init__.py defines async_setup_entry at module level."""
+        src = """\
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    entry.runtime_data = MyCoordinator(hass, entry)
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_when_async_setup_entry_inside_class(self, tmp_path: Path) -> None:
+        """PASS: ast.walk finds async_setup_entry at any depth."""
+        src = """\
+class FakeModule:
+    async def async_setup_entry(self, hass, entry):
+        return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        """WARN: __init__.py exists but no async_setup_entry."""
+        src = """\
+DOMAIN = "test_integration"
+
+def setup(hass, config):
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: no integration_path detected."""
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_init_file(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: integration exists but no __init__.py."""
+        _write_integration(tmp_path)  # no init_src
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        """WARN: parse error in __init__.py."""
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+    def test_sync_setup_entry_does_not_pass(self, tmp_path: Path) -> None:
+        """WARN: sync def setup_entry does not qualify — must be AsyncFunctionDef."""
+        src = """\
+def async_setup_entry(hass, entry):
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, ASYNC_SETUP_ENTRY_RULE)
+        assert f.status is RuleStatus.WARN
+
+
+# ===========================================================================
+# init.runtime_data.used
+# ===========================================================================
+
+RUNTIME_DATA_RULE = "init.runtime_data.used"
+
+
+class TestRuntimeDataUsed:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[RUNTIME_DATA_RULE]
+        assert rule.id == RUNTIME_DATA_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "modern_ha_patterns"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_when_entry_runtime_data_assigned(self, tmp_path: Path) -> None:
+        """PASS: entry.runtime_data = ... assignment detected."""
+        src = """\
+async def async_setup_entry(hass, entry):
+    entry.runtime_data = MyCoordinator(hass, entry)
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_when_config_entry_runtime_data_read(self, tmp_path: Path) -> None:
+        """PASS: config_entry.runtime_data access detected."""
+        src = """\
+async def async_unload_entry(hass, config_entry):
+    coordinator = config_entry.runtime_data
+    return await coordinator.async_unload()
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_pass_when_underscore_entry_used(self, tmp_path: Path) -> None:
+        """PASS: _entry.runtime_data access detected."""
+        src = """\
+async def async_setup_entry(hass, _entry):
+    data = _entry.runtime_data
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.PASS
+
+    def test_warn_when_pattern_absent(self, tmp_path: Path) -> None:
+        """WARN: __init__.py exists but no runtime_data usage."""
+        src = """\
+async def async_setup_entry(hass, entry):
+    hass.data.setdefault("test", {})
+    hass.data["test"][entry.entry_id] = MyClass(hass, entry)
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.WARN
+
+    def test_not_applicable_when_no_integration_directory(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: no integration_path detected."""
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_when_no_init_file(self, tmp_path: Path) -> None:
+        """NOT_APPLICABLE: integration exists but no __init__.py."""
+        _write_integration(tmp_path)  # no init_src
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.NOT_APPLICABLE
+
+    def test_warn_on_syntax_error(self, tmp_path: Path) -> None:
+        """WARN: parse error in __init__.py."""
+        src = """\
+def broken(
+    # unclosed paren
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.WARN
+        assert "could not be parsed" in f.message
+
+    def test_other_runtime_data_attribute_does_not_pass(self, tmp_path: Path) -> None:
+        """WARN: other.runtime_data (not entry/config_entry/_entry) does not qualify."""
+        src = """\
+async def async_setup_entry(hass, entry):
+    value = hass.runtime_data
+    return True
+"""
+        _write_integration(tmp_path, init_src=src)
+        f = _finding_for(tmp_path, RUNTIME_DATA_RULE)
+        assert f.status is RuleStatus.WARN

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 37 rules total (v0.10 issue #101 adds 4 config_flow advanced rules):
-#   - config_flow.reauth_step.exists (overridable=True, RECOMMENDED)
-#   - config_flow.reconfigure_step.exists (overridable=True, RECOMMENDED)
-#   - config_flow.unique_id.set (overridable=True, RECOMMENDED)
-#   - config_flow.connection_test (overridable=True, RECOMMENDED)
-# 12 locked overridable=False, 25 overridable=True.
+# 42 rules total (v0.10 issue #107 adds 5 modern HA pattern rules):
+#   - init.async_setup_entry.defined (overridable=True, RECOMMENDED)
+#   - init.runtime_data.used (overridable=True, RECOMMENDED)
+#   - entity.unique_id.set (overridable=True, RECOMMENDED)
+#   - entity.has_entity_name.set (overridable=True, RECOMMENDED)
+#   - entity.device_info.set (overridable=True, RECOMMENDED)
+# 12 locked overridable=False, 30 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -64,11 +65,17 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "config_flow.reconfigure_step.exists",
     "config_flow.unique_id.set",
     "config_flow.connection_test",
+    # v0.10 issue #107 — modern HA pattern checks (RECOMMENDED, overridable=True)
+    "init.async_setup_entry.defined",
+    "init.runtime_data.used",
+    "entity.unique_id.set",
+    "entity.has_entity_name.set",
+    "entity.device_info.set",
 }
 
 
-def test_total_rule_count_is_thirty_seven() -> None:
-    assert len(RULES) == 37, f"expected 37 rules, got {len(RULES)}"
+def test_total_rule_count_is_forty_two() -> None:
+    assert len(RULES) == 42, f"expected 42 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

Third v0.10 batch — five rules covering HA 2024.4+ recommended integration patterns. Heaviest of the v0.10 trio: two new rule modules, multi-file AST scan across the entity-platform surface, and a small \`ast_utils\` helper extraction.

Closes #107.

## Rules

| Rule ID | Scope | Detection |
|---------|-------|-----------|
| \`init.async_setup_entry.defined\` | \`__init__.py\` | \`AsyncFunctionDef\` named \`async_setup_entry\` (any depth) |
| \`init.runtime_data.used\` | \`__init__.py\` | Attribute access \`entry.runtime_data\` / \`config_entry.runtime_data\` (HA 2024.4+ pattern) |
| \`entity.unique_id.set\` | Entity platform files | \`_attr_unique_id\` assignment (class-level or \`self.\` instance-level) in any platform file |
| \`entity.has_entity_name.set\` | Entity platform files | \`_attr_has_entity_name = True\` (literal True) in any platform file |
| \`entity.device_info.set\` | Entity platform files | \`_attr_device_info\` assignment OR a \`device_info\` method/property returning \`DeviceInfo(...)\` in any platform file |

All five: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=modern_ha_patterns\`.

## Status semantics (uniform)

- **NOT_APPLICABLE** — no integration / for \`init.*\`: no \`__init__.py\` / for \`entity.*\`: no platform files (hub-only integrations qualify)
- **PASS** — AST detects pattern in any inspected file
- **WARN** — file(s) present but pattern absent
- **WARN** — parse error in any inspected file (consistent with v0.8/v0.10 stance)

## Architecture

- **New module**: \`src/hasscheck/rules/init_module.py\` — \`init.*\` rules
- **New module**: \`src/hasscheck/rules/entity.py\` — \`entity.*\` rules. Owns the canonical \`_HA_PLATFORM_NAMES\` frozenset (~40 platform names sourced from HA core's \`Platform\` enum) and a \`_iter_platform_files()\` helper that yields existing \`<platform>.py\` files in the integration directory.
- **\`ast_utils.has_async_function(tree, name)\`** — extracted from the inline \`_has_async_function\` previously living in \`config_flow.py\`. Now a public helper (third extraction after \`parse_module\` in #93). \`config_flow.py\`'s local copy delegates to the public version. Same precedent as \`parse_module\`: extract once a third caller appears.

No new applicability flags. The rules gate purely on file existence; \`APPLICABILITY_FLAGS_BY_RULE\` is unchanged.

## Test plan

- [x] \`uv run pytest -q\` — **606 passing** (558 baseline + 48 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: 46 RED tests written first across two new test files
- [x] \`uv run hasscheck explain init.{async_setup_entry.defined,runtime_data.used}\` + \`entity.{unique_id.set,has_entity_name.set,device_info.set}\` — all five exit 0
- [x] \`uv run hasscheck check --path examples/bad_integration\` — 2 \`init.*\` WARNs (after fixture gained a minimal \`__init__.py\` with legacy \`setup()\` instead of \`async_setup_entry\`), 3 \`entity.*\` NOT_APPLICABLE (no platform files in fixture)
- [x] False-positive guards covered: \`_attr_has_entity_name = False\` does NOT trigger PASS; conditional-only \`unique_id\` set does (matches HA's \"any setting beats nothing\" stance)

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 37 → **42**. All five overridable.
- **Bad fixture extension**: added \`examples/bad_integration/custom_components/demo_bad/__init__.py\` with a minimal legacy \`setup()\` function. Lacks \`async_setup_entry\` and \`runtime_data\` — both \`init.*\` rules WARN deterministically. No platform files added — entity rules stay NOT_APPLICABLE for this fixture; the platform-file surface deserves its own dedicated fixture (deferred).
- **README "Modern HA Patterns"** + **\`docs/rules/README.md\`** index — both updated with five new rows. Doc count bumped 33 → 42. Per-rule pages deferred to #104.
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\` (additive within ruleset cycle per ADR 0006).

## v0.10 status after this PR

- ✅ #100 — manifest.requirements (3 rules) — merged in #112
- ✅ #101 — config_flow advanced (4 rules) — merged in #113
- 🟢 #107 — modern HA patterns (5 rules) — **this PR**

After merge: rule count 42, test count 606. Logical next step: cut v0.10.0 release.