### PR TITLE
feat(rules): integration test detection — config_flow / setup_entry / unload (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ Per-rule documentation pages with status behavior tables, fix instructions, and 
 | Rule ID | Signal |
 | --- | --- |
 | `tests.folder.exists` | Repository has `tests/`. |
+| `tests.config_flow.detected` | `tests/` contains config flow test coverage (filename, import, or function name). |
+| `tests.setup_entry.detected` | `tests/` references `async_setup_entry` or `async_unload_entry`. |
+| `tests.unload.detected` | `tests/` references `async_unload_entry` or unload test functions. |
 | `ci.github_actions.exists` | Repository has `.github/workflows/*.yml` or `.yaml`. |
 
 ## JSON report contract

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # HassCheck Rule Index
 
-All 42 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
+All 45 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
 
 ## HACS structure
 
@@ -72,4 +72,7 @@ All 42 rules, grouped by category. Rules with a dedicated docs page are linked; 
 | Rule ID | Signal | Docs |
 |---|---|---|
 | `tests.folder.exists` | Repository has `tests/`. | (no docs page yet) |
+| `tests.config_flow.detected` | `tests/` contains config flow test coverage (filename, import, or function name). | (no docs page yet) |
+| `tests.setup_entry.detected` | `tests/` references `async_setup_entry` or `async_unload_entry`. | (no docs page yet) |
+| `tests.unload.detected` | `tests/` references `async_unload_entry` or unload test functions. | (no docs page yet) |
 | `ci.github_actions.exists` | Repository has `.github/workflows/*.yml` or `.yaml`. | (no docs page yet) |

--- a/src/hasscheck/rules/tests.py
+++ b/src/hasscheck/rules/tests.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import ast
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from hasscheck.ast_utils import parse_module
 from hasscheck.models import (
     Applicability,
+    ApplicabilityStatus,
     Finding,
     FixSuggestion,
     RuleSeverity,
@@ -12,6 +19,22 @@ from hasscheck.rules.base import ProjectContext, RuleDefinition
 
 CATEGORY = "tests_ci"
 TESTS_SOURCE = "https://developers.home-assistant.io/docs/development_testing/"
+_SOURCE_CHECKED_AT = "2026-05-01"
+
+# ---------------------------------------------------------------------------
+# Regex patterns for new detection rules (#108)
+# ---------------------------------------------------------------------------
+_CONFIG_FLOW_FILE_RE = re.compile(r"^test_config_flow.*\.py$")
+_CONFIG_FLOW_FUNC_RE = re.compile(r"^test_(config_flow|async_step)")
+_SETUP_ENTRY_NAMES = frozenset({"async_setup_entry", "async_unload_entry"})
+_UNLOAD_NAMES = frozenset({"async_unload_entry"})
+_UNLOAD_FUNC_RE = re.compile(r"^test_(unload|async_unload)")
+_SETUP_FUNC_RE = re.compile(r"^test_(setup_entry|async_setup_entry)")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for tests.folder.exists (pre-existing rule)
+# ---------------------------------------------------------------------------
 
 
 def tests_folder_exists(context: ProjectContext) -> Finding:
@@ -42,6 +65,281 @@ def tests_folder_exists(context: ProjectContext) -> Finding:
     )
 
 
+# ---------------------------------------------------------------------------
+# Helpers for detection rules (#108)
+# ---------------------------------------------------------------------------
+
+
+def _iter_test_files(root: Path) -> Iterable[Path]:
+    """Yield all .py files under <root>/tests/ if the folder exists."""
+    tests_dir = root / "tests"
+    if not tests_dir.is_dir():
+        return
+    yield from tests_dir.rglob("*.py")
+
+
+def _module_imports(tree: ast.Module, target: str) -> bool:
+    """True if any import statement references a name containing *target*."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if target in alias.name:
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if target in module:
+                return True
+            for alias in node.names:
+                if target in alias.name:
+                    return True
+    return False
+
+
+def _module_function_names(tree: ast.Module) -> Iterable[str]:
+    """Yield names of all FunctionDef and AsyncFunctionDef nodes in the tree."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node.name
+
+
+def _module_references_name(tree: ast.Module, target: str) -> bool:
+    """True if any Name or Attribute node references *target*."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == target:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == target:
+            return True
+    return False
+
+
+def _make_detection_not_applicable(
+    rule_id: str,
+    title: str,
+    reason: str,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=reason,
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason=reason,
+        ),
+        source=RuleSource(url=TESTS_SOURCE),
+        fix=None,
+        path="tests",
+    )
+
+
+def _make_detection_finding(
+    rule_id: str,
+    title: str,
+    *,
+    status: RuleStatus,
+    message: str,
+    fix: FixSuggestion | None = None,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=status,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=message,
+        applicability=Applicability(
+            reason="Integration tests validate that setup, teardown, and config flow work correctly."
+        ),
+        source=RuleSource(url=TESTS_SOURCE),
+        fix=fix,
+        path="tests",
+    )
+
+
+def _gate_detection_rule(
+    context: ProjectContext,
+    rule_id: str,
+    title: str,
+) -> Finding | None:
+    """Return a NOT_APPLICABLE finding if the rule cannot run, else None."""
+    if context.integration_path is None:
+        return _make_detection_not_applicable(
+            rule_id,
+            title,
+            "No integration directory was detected.",
+        )
+    tests_dir = context.root / "tests"
+    if not tests_dir.is_dir():
+        return _make_detection_not_applicable(
+            rule_id,
+            title,
+            "no tests/ folder; tests.folder.exists owns this signal.",
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check functions — test detection rules (#108)
+# ---------------------------------------------------------------------------
+
+
+def tests_config_flow_detected(context: ProjectContext) -> Finding:
+    """Detect whether any test file covers config_flow paths."""
+    rule_id = "tests.config_flow.detected"
+    title = "tests cover config_flow"
+
+    early = _gate_detection_rule(context, rule_id, title)
+    if early is not None:
+        return early
+
+    has_parse_errors = False
+    for path in _iter_test_files(context.root):
+        # Filename pattern check — no parsing needed
+        if _CONFIG_FLOW_FILE_RE.match(path.name):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"Config flow test file detected: {path.name}.",
+            )
+
+        tree, error = parse_module(path)
+        if error is not None:
+            has_parse_errors = True
+            continue
+
+        assert tree is not None
+        if _module_imports(tree, "config_flow"):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"Config flow import detected in {path.name}.",
+            )
+        if any(_CONFIG_FLOW_FUNC_RE.match(fn) for fn in _module_function_names(tree)):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"Config flow test function detected in {path.name}.",
+            )
+
+    warn_message = "tests/ folder exists but no config_flow test coverage detected." + (
+        " (some files could not be parsed)" if has_parse_errors else ""
+    )
+    return _make_detection_finding(
+        rule_id,
+        title,
+        status=RuleStatus.WARN,
+        message=warn_message,
+        fix=FixSuggestion(
+            summary="Add tests/test_config_flow.py to test the config flow user step.",
+            docs_url=TESTS_SOURCE,
+        ),
+    )
+
+
+def tests_setup_entry_detected(context: ProjectContext) -> Finding:
+    """Detect whether any test file covers async_setup_entry or async_unload_entry."""
+    rule_id = "tests.setup_entry.detected"
+    title = "tests cover async_setup_entry"
+
+    early = _gate_detection_rule(context, rule_id, title)
+    if early is not None:
+        return early
+
+    has_parse_errors = False
+    for path in _iter_test_files(context.root):
+        tree, error = parse_module(path)
+        if error is not None:
+            has_parse_errors = True
+            continue
+
+        assert tree is not None
+        for name in _SETUP_ENTRY_NAMES:
+            if _module_references_name(tree, name):
+                return _make_detection_finding(
+                    rule_id,
+                    title,
+                    status=RuleStatus.PASS,
+                    message=f"{name} reference detected in {path.name}.",
+                )
+        if any(_SETUP_FUNC_RE.match(fn) for fn in _module_function_names(tree)):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"setup_entry test function detected in {path.name}.",
+            )
+
+    warn_message = (
+        "tests/ folder exists but no async_setup_entry test coverage detected."
+        + (" (some files could not be parsed)" if has_parse_errors else "")
+    )
+    return _make_detection_finding(
+        rule_id,
+        title,
+        status=RuleStatus.WARN,
+        message=warn_message,
+        fix=FixSuggestion(
+            summary="Add a test that calls async_setup_entry and async_unload_entry.",
+            docs_url=TESTS_SOURCE,
+        ),
+    )
+
+
+def tests_unload_detected(context: ProjectContext) -> Finding:
+    """Detect whether any test file covers async_unload_entry."""
+    rule_id = "tests.unload.detected"
+    title = "tests cover async_unload_entry"
+
+    early = _gate_detection_rule(context, rule_id, title)
+    if early is not None:
+        return early
+
+    has_parse_errors = False
+    for path in _iter_test_files(context.root):
+        tree, error = parse_module(path)
+        if error is not None:
+            has_parse_errors = True
+            continue
+
+        assert tree is not None
+        if _module_references_name(tree, "async_unload_entry"):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"async_unload_entry reference detected in {path.name}.",
+            )
+        if any(_UNLOAD_FUNC_RE.match(fn) for fn in _module_function_names(tree)):
+            return _make_detection_finding(
+                rule_id,
+                title,
+                status=RuleStatus.PASS,
+                message=f"Unload test function detected in {path.name}.",
+            )
+
+    warn_message = (
+        "tests/ folder exists but no async_unload_entry test coverage detected."
+        + (" (some files could not be parsed)" if has_parse_errors else "")
+    )
+    return _make_detection_finding(
+        rule_id,
+        title,
+        status=RuleStatus.WARN,
+        message=warn_message,
+        fix=FixSuggestion(
+            summary="Add a test that calls async_unload_entry to verify clean teardown.",
+            docs_url=TESTS_SOURCE,
+        ),
+    )
+
+
 RULES = [
     RuleDefinition(
         id="tests.folder.exists",
@@ -53,5 +351,54 @@ RULES = [
         source_url=TESTS_SOURCE,
         check=tests_folder_exists,
         overridable=True,
-    )
+    ),
+    RuleDefinition(
+        id="tests.config_flow.detected",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="tests cover config_flow",
+        why=(
+            "Config flow tests verify that users can set up, authenticate, and configure "
+            "the integration from the UI. Without them, regressions in the setup path "
+            "may go undetected across Home Assistant upgrades. "
+            "This rule uses heuristic static inspection: filename pattern, import analysis, "
+            "and function name matching — no test execution is performed."
+        ),
+        source_url=TESTS_SOURCE,
+        check=tests_config_flow_detected,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="tests.setup_entry.detected",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="tests cover async_setup_entry",
+        why=(
+            "async_setup_entry is the primary integration lifecycle hook. Testing it ensures "
+            "the integration loads correctly and fails gracefully on bad configuration. "
+            "This rule uses heuristic static inspection: Name/Attribute references to "
+            "async_setup_entry / async_unload_entry, and function name matching."
+        ),
+        source_url=TESTS_SOURCE,
+        check=tests_setup_entry_detected,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id="tests.unload.detected",
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title="tests cover async_unload_entry",
+        why=(
+            "Testing async_unload_entry ensures the integration cleans up resources properly "
+            "when removed or reloaded. Missing unload tests can hide resource leaks. "
+            "This rule uses heuristic static inspection: Name/Attribute references to "
+            "async_unload_entry, and function name matching."
+        ),
+        source_url=TESTS_SOURCE,
+        check=tests_unload_detected,
+        overridable=True,
+    ),
 ]

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 42 rules total (v0.10 issue #107 adds 5 modern HA pattern rules):
-#   - init.async_setup_entry.defined (overridable=True, RECOMMENDED)
-#   - init.runtime_data.used (overridable=True, RECOMMENDED)
-#   - entity.unique_id.set (overridable=True, RECOMMENDED)
-#   - entity.has_entity_name.set (overridable=True, RECOMMENDED)
-#   - entity.device_info.set (overridable=True, RECOMMENDED)
-# 12 locked overridable=False, 30 overridable=True.
+# 45 rules total (v0.11 issue #108 adds 3 integration test detection rules):
+#   - tests.config_flow.detected (overridable=True, RECOMMENDED)
+#   - tests.setup_entry.detected (overridable=True, RECOMMENDED)
+#   - tests.unload.detected (overridable=True, RECOMMENDED)
+# 12 locked overridable=False, 33 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -71,11 +69,15 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "entity.unique_id.set",
     "entity.has_entity_name.set",
     "entity.device_info.set",
+    # v0.11 issue #108 — integration test detection (RECOMMENDED, overridable=True)
+    "tests.config_flow.detected",
+    "tests.setup_entry.detected",
+    "tests.unload.detected",
 }
 
 
-def test_total_rule_count_is_forty_two() -> None:
-    assert len(RULES) == 42, f"expected 42 rules, got {len(RULES)}"
+def test_total_rule_count_is_forty_five() -> None:
+    assert len(RULES) == 45, f"expected 45 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:

--- a/tests/test_rules_tests_detection.py
+++ b/tests/test_rules_tests_detection.py
@@ -1,0 +1,371 @@
+"""Tests for integration test detection rules (issue #108, v0.11 first batch).
+
+TDD cycle:
+  - RED: written first, before production code exists
+  - GREEN: confirmed after implementation
+
+Rules covered:
+  - tests.config_flow.detected
+  - tests.setup_entry.detected
+  - tests.unload.detected
+
+Spec: issue #108 — integration test detection (heuristic, static inspection only)
+Source: https://developers.home-assistant.io/docs/development_testing/
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hasscheck.checker import run_check
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_integration(
+    root: Path,
+    *,
+    dir_name: str = "demo",
+    manifest: str | None = None,
+) -> Path:
+    """Create custom_components/<dir_name>/ with a manifest.json."""
+    integration = root / "custom_components" / dir_name
+    integration.mkdir(parents=True)
+
+    mf = manifest or (
+        '{"domain": "'
+        + dir_name
+        + '", "name": "Test", "documentation": "https://example.com",'
+        ' "issue_tracker": "https://example.com/issues", "codeowners": ["@test"],'
+        ' "version": "0.1.0"}'
+    )
+    (integration / "manifest.json").write_text(mf, encoding="utf-8")
+    return integration
+
+
+def _write_tests_dir(root: Path) -> Path:
+    """Create tests/ directory at repo root."""
+    tests_dir = root / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    return tests_dir
+
+
+def _finding_for(root: Path, rule_id: str):
+    return {f.rule_id: f for f in run_check(root).findings}[rule_id]
+
+
+# ===========================================================================
+# tests.config_flow.detected
+# ===========================================================================
+
+CF_RULE = "tests.config_flow.detected"
+
+
+class TestConfigFlowDetected:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[CF_RULE]
+        assert rule.id == CF_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "tests_ci"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_not_applicable_without_integration(self, tmp_path: Path) -> None:
+        """No integration directory → NOT_APPLICABLE."""
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_without_tests_folder(self, tmp_path: Path) -> None:
+        """Integration exists but tests/ missing → NOT_APPLICABLE."""
+        _write_integration(tmp_path)
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_pass_by_filename(self, tmp_path: Path) -> None:
+        """tests/test_config_flow.py filename pattern → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_config_flow.py").write_text("", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_filename_variant(self, tmp_path: Path) -> None:
+        """tests/test_config_flow_user.py also matches filename pattern → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_config_flow_user.py").write_text("", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_ast_import(self, tmp_path: Path) -> None:
+        """File imports from config_flow module → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "from custom_components.demo.config_flow import DemoConfigFlow\n"
+        (tests / "test_things.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_function_name(self, tmp_path: Path) -> None:
+        """Function named test_config_flow_user_step → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "def test_config_flow_user_step():\n    pass\n"
+        (tests / "test_things.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_async_step_function_name(self, tmp_path: Path) -> None:
+        """Function named test_async_step_user → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "async def test_async_step_user():\n    pass\n"
+        (tests / "test_things.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_when_tests_dir_exists_but_no_match(self, tmp_path: Path) -> None:
+        """tests/ folder with unrelated test file → WARN."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "def test_something_else():\n    pass\n"
+        (tests / "test_unrelated.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_warn_empty_tests_dir(self, tmp_path: Path) -> None:
+        """Empty tests/ folder → WARN."""
+        _write_integration(tmp_path)
+        _write_tests_dir(tmp_path)
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_parse_error_tolerated_other_file_passes(self, tmp_path: Path) -> None:
+        """Syntax error in one file is skipped; another file that matches → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+        (tests / "test_config_flow.py").write_text("", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_parse_error_all_files_broken_warns(self, tmp_path: Path) -> None:
+        """All test files have syntax errors and no filename match → WARN."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+        (tests / "test_also_broken.py").write_text("class )(:\n", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, CF_RULE)
+        assert finding.status is RuleStatus.WARN
+
+
+# ===========================================================================
+# tests.setup_entry.detected
+# ===========================================================================
+
+SE_RULE = "tests.setup_entry.detected"
+
+
+class TestSetupEntryDetected:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[SE_RULE]
+        assert rule.id == SE_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "tests_ci"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_not_applicable_without_integration(self, tmp_path: Path) -> None:
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_without_tests_folder(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_pass_by_name_reference(self, tmp_path: Path) -> None:
+        """AST Name node referencing async_setup_entry → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "result = await async_setup_entry(hass, entry)\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_attribute_reference(self, tmp_path: Path) -> None:
+        """AST Attribute node referencing async_setup_entry → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "mock.async_setup_entry.return_value = True\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_unload_reference(self, tmp_path: Path) -> None:
+        """async_unload_entry reference also counts → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "await async_unload_entry(hass, entry)\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_function_name_setup(self, tmp_path: Path) -> None:
+        """Function named test_setup_entry_ok → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "async def test_setup_entry_ok():\n    pass\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_function_name_async_setup(self, tmp_path: Path) -> None:
+        """Function named test_async_setup_entry_success → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "async def test_async_setup_entry_success():\n    pass\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_when_no_match(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "def test_something_else():\n    pass\n"
+        (tests / "test_unrelated.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_parse_error_tolerated_other_file_passes(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+        src = "async def test_async_setup_entry_ok():\n    pass\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_parse_error_all_files_broken_warns(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, SE_RULE)
+        assert finding.status is RuleStatus.WARN
+
+
+# ===========================================================================
+# tests.unload.detected
+# ===========================================================================
+
+UNLOAD_RULE = "tests.unload.detected"
+
+
+class TestUnloadDetected:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[UNLOAD_RULE]
+        assert rule.id == UNLOAD_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "tests_ci"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_not_applicable_without_integration(self, tmp_path: Path) -> None:
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_without_tests_folder(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_pass_by_name_reference(self, tmp_path: Path) -> None:
+        """async_unload_entry Name reference → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "await async_unload_entry(hass, entry)\n"
+        (tests / "test_unload.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_attribute_reference(self, tmp_path: Path) -> None:
+        """async_unload_entry Attribute reference → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "mock.async_unload_entry.return_value = True\n"
+        (tests / "test_unload.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_function_name_unload(self, tmp_path: Path) -> None:
+        """Function named test_unload_entry → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "async def test_unload_entry():\n    pass\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_by_function_name_async_unload(self, tmp_path: Path) -> None:
+        """Function named test_async_unload_works → PASS."""
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "async def test_async_unload_works():\n    pass\n"
+        (tests / "test_init.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_when_no_match(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        src = "def test_something_else():\n    pass\n"
+        (tests / "test_unrelated.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_parse_error_tolerated_other_file_passes(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+        src = "async def test_unload_ok():\n    pass\n"
+        (tests / "test_unload.py").write_text(src, encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_parse_error_all_files_broken_warns(self, tmp_path: Path) -> None:
+        _write_integration(tmp_path)
+        tests = _write_tests_dir(tmp_path)
+        (tests / "test_broken.py").write_text("def (((:\n", encoding="utf-8")
+
+        finding = _finding_for(tmp_path, UNLOAD_RULE)
+        assert finding.status is RuleStatus.WARN


### PR DESCRIPTION
## Summary

First v0.11 batch — three heuristic rules detecting whether the integration's \`tests/\` folder actually covers config flow, setup entry, and unload paths. Currently \`tests.folder.exists\` only confirms the folder is present.

Closes #108.

## Rules

| Rule ID | Detection (any of) |
|---------|--------------------|
| \`tests.config_flow.detected\` | Filename matches \`^test_config_flow.*\.py$\` · OR AST imports a \`config_flow\` module · OR contains a function named \`test_config_flow_*\` / \`test_async_step_*\` |
| \`tests.setup_entry.detected\` | AST references \`async_setup_entry\` or \`async_unload_entry\` · OR has a function named \`test_setup_entry_*\` / \`test_async_setup_entry*\` |
| \`tests.unload.detected\` | AST references \`async_unload_entry\` · OR has a function named \`test_unload_*\` / \`test_async_unload*\` |

All three: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=tests_ci\` (matches the existing rule module's category constant).

## Status semantics (uniform)

- **NOT_APPLICABLE** — no integration / no \`tests/\` folder (delegate to existing \`tests.folder.exists\`)
- **PASS** — pattern detected in any test file
- **WARN** — \`tests/\` folder exists but no matching pattern
- Parse errors tolerated — skip the file, only WARN if NO files match anywhere AND parse errors prevented full inspection

## Test plan

- [x] \`uv run pytest -q\` — **639 passing** (606 baseline + 33 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: 33 RED tests written first across 3 rule classes
- [x] \`uv run hasscheck explain tests.{config_flow.detected,setup_entry.detected,unload.detected}\` — all three exit 0
- [x] \`uv run hasscheck check --path examples/bad_integration\` — 3 NOT_APPLICABLE (no \`tests/\` folder, correct)
- [x] \`uv run hasscheck check --path examples/good_integration\` — 3 WARN (existing \`test_placeholder.py\` doesn't match any signal — correct)

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 42 → **45**. All three overridable.
- **README** "Tests and CI" + **\`docs/rules/README.md\`** index — both updated with three new rows. Doc count bumped 42 → 45. Per-rule pages deferred to #104.
- **No fixture changes**. Bad fixture has no \`tests/\` folder → NOT_APPLICABLE is the correct signal. Good fixture has a placeholder → WARN is the correct signal. Forcing PASS would require fabricating realistic test files which deserves its own follow-up if richer fixtures are wanted.
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\`.

## What's next in v0.11

- #109 maintenance signal rules (recent commit / recent release / changelog presence)
- #104 auto-generate per-rule docs from RuleDefinition metadata (closes the 30-rule gap in \`docs/rules/\`)
- #105 demo terminal asciinema recording