### PR TITLE
feat(rules): maintenance signal rules — recent_commit / recent_release / changelog (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,14 @@ Per-rule documentation pages with status behavior tables, fix instructions, and 
 | `tests.unload.detected` | `tests/` references `async_unload_entry` or unload test functions. |
 | `ci.github_actions.exists` | Repository has `.github/workflows/*.yml` or `.yaml`. |
 
+### Maintenance
+
+| Rule ID | Signal |
+| --- | --- |
+| `maintenance.recent_commit.detected` | HEAD commit is within the last 12 months (local git history). |
+| `maintenance.recent_release.detected` | Most recent version tag is within the last 12 months (local git tags). |
+| `maintenance.changelog.exists` | Repository has a changelog file (`CHANGELOG.md`, `HISTORY.md`, etc.). |
+
 ## JSON report contract
 
 JSON output includes:

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # HassCheck Rule Index
 
-All 45 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
+All 48 rules, grouped by category. Rules with a dedicated docs page are linked; others show "(no docs page yet)".
 
 ## HACS structure
 
@@ -76,3 +76,11 @@ All 45 rules, grouped by category. Rules with a dedicated docs page are linked; 
 | `tests.setup_entry.detected` | `tests/` references `async_setup_entry` or `async_unload_entry`. | (no docs page yet) |
 | `tests.unload.detected` | `tests/` references `async_unload_entry` or unload test functions. | (no docs page yet) |
 | `ci.github_actions.exists` | Repository has `.github/workflows/*.yml` or `.yaml`. | (no docs page yet) |
+
+## Maintenance
+
+| Rule ID | Signal | Docs |
+|---|---|---|
+| `maintenance.recent_commit.detected` | HEAD commit is within the last 12 months (local git history). | (no docs page yet) |
+| `maintenance.recent_release.detected` | Most recent version tag is within the last 12 months (local git tags). | (no docs page yet) |
+| `maintenance.changelog.exists` | Repository has a changelog file (`CHANGELOG.md`, `HISTORY.md`, etc.). | (no docs page yet) |

--- a/src/hasscheck/rules/maintenance.py
+++ b/src/hasscheck/rules/maintenance.py
@@ -1,0 +1,379 @@
+"""Maintenance signal rules — recent_commit, recent_release, changelog.
+
+These rules check observable maintenance signals using local git history and
+filesystem presence. No GitHub API calls are made; all git operations run via
+subprocess against the local .git directory.
+
+Issue #109 — v0.11 second batch.
+"""
+
+from __future__ import annotations
+
+import math
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    FixSuggestion,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.rules.base import ProjectContext, RuleDefinition
+
+CATEGORY = "maintenance"
+_DOCS_URL = "https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases"
+_SOURCE_CHECKED_AT = "2026-05-01"
+_MAX_AGE_MONTHS = 12
+_SECONDS_PER_MONTH = 30.44 * 86400  # average month in seconds
+_MAX_AGE_SECONDS = _MAX_AGE_MONTHS * _SECONDS_PER_MONTH
+
+_CHANGELOG_FILENAMES = (
+    "CHANGELOG.md",
+    "CHANGELOG",
+    "HISTORY.md",
+    "HISTORY",
+    "RELEASES.md",
+    "NEWS.md",
+)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _is_git_repo(root: Path) -> bool:
+    """Return True if root is inside a git checkout (has .git dir or file)."""
+    return (root / ".git").exists()
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[str | None, str | None]:
+    """Run a git command with a 5-second timeout.
+
+    Returns (stdout, error_msg). On success error_msg is None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None, "git binary not found"
+    except subprocess.TimeoutExpired:
+        return None, "git command timed out"
+    if result.returncode != 0:
+        return None, result.stderr.strip() or f"git exit {result.returncode}"
+    return result.stdout.strip(), None
+
+
+def _head_commit_timestamp(root: Path) -> tuple[int | None, str | None]:
+    """Return (unix_timestamp, error) for the HEAD commit."""
+    out, err = _run_git(["log", "-1", "--format=%ct"], root)
+    if err is not None:
+        return None, err
+    if not out:
+        return None, "no commits"
+    try:
+        return int(out), None
+    except ValueError:
+        return None, f"unexpected git output: {out!r}"
+
+
+def _latest_tag_timestamp(root: Path) -> tuple[int | None, str | None]:
+    """Return (unix_timestamp, error) for the most recent tag.
+
+    Returns (None, "no tags") when the repo has no tags at all.
+    """
+    out, err = _run_git(
+        [
+            "for-each-ref",
+            "--sort=-creatordate",
+            "--format=%(creatordate:unix)",
+            "refs/tags",
+            "--count=1",
+        ],
+        root,
+    )
+    if err is not None:
+        return None, err
+    if not out:
+        return None, "no tags"
+    try:
+        return int(out), None
+    except ValueError:
+        return None, f"unexpected git output: {out!r}"
+
+
+def _format_age(age_seconds: float) -> str:
+    """Format age in seconds as a human-readable string."""
+    months = age_seconds / _SECONDS_PER_MONTH
+    if months >= 1:
+        return f"{math.floor(months)} month{'s' if math.floor(months) != 1 else ''}"
+    days = age_seconds / 86400
+    return f"{math.floor(days)} day{'s' if math.floor(days) != 1 else ''}"
+
+
+def _not_applicable_finding(
+    rule_id: str,
+    rule_version: str,
+    title: str,
+    reason: str,
+    source: RuleSource,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version=rule_version,
+        category=CATEGORY,
+        status=RuleStatus.NOT_APPLICABLE,
+        severity=RuleSeverity.RECOMMENDED,
+        title=title,
+        message=reason,
+        applicability=Applicability(
+            status=ApplicabilityStatus.NOT_APPLICABLE,
+            reason=reason,
+        ),
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule: maintenance.recent_commit.detected
+# ---------------------------------------------------------------------------
+
+_COMMIT_RULE_ID = "maintenance.recent_commit.detected"
+_COMMIT_TITLE = "Repository has a recent commit"
+_COMMIT_SOURCE = RuleSource(url=_DOCS_URL, checked_at=_SOURCE_CHECKED_AT)
+
+
+def recent_commit_check(context: ProjectContext) -> Finding:
+    if not _is_git_repo(context.root):
+        return _not_applicable_finding(
+            _COMMIT_RULE_ID,
+            "1.0.0",
+            _COMMIT_TITLE,
+            "repository is not a git checkout (no .git directory)",
+            _COMMIT_SOURCE,
+        )
+    if not _git_available():
+        return _not_applicable_finding(
+            _COMMIT_RULE_ID,
+            "1.0.0",
+            _COMMIT_TITLE,
+            "git binary not found on PATH",
+            _COMMIT_SOURCE,
+        )
+
+    ts, err = _head_commit_timestamp(context.root)
+    if err is not None:
+        return _not_applicable_finding(
+            _COMMIT_RULE_ID,
+            "1.0.0",
+            _COMMIT_TITLE,
+            f"could not read git history: {err}",
+            _COMMIT_SOURCE,
+        )
+
+    assert ts is not None
+    age = time.time() - ts
+    age_str = _format_age(age)
+    is_recent = age < _MAX_AGE_SECONDS
+
+    return Finding(
+        rule_id=_COMMIT_RULE_ID,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if is_recent else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_COMMIT_TITLE,
+        message=(
+            f"Most recent commit is {age_str} old — within the {_MAX_AGE_MONTHS}-month threshold."
+            if is_recent
+            else f"Most recent commit is {age_str} old — exceeds the {_MAX_AGE_MONTHS}-month threshold."
+        ),
+        applicability=Applicability(
+            reason="An active git history signals ongoing maintenance."
+        ),
+        source=_COMMIT_SOURCE,
+        fix=None
+        if is_recent
+        else FixSuggestion(
+            summary="Make a new commit to indicate active maintenance.",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule: maintenance.recent_release.detected
+# ---------------------------------------------------------------------------
+
+_RELEASE_RULE_ID = "maintenance.recent_release.detected"
+_RELEASE_TITLE = "Repository has a recent release tag"
+_RELEASE_SOURCE = RuleSource(url=_DOCS_URL, checked_at=_SOURCE_CHECKED_AT)
+
+
+def recent_release_check(context: ProjectContext) -> Finding:
+    if not _is_git_repo(context.root):
+        return _not_applicable_finding(
+            _RELEASE_RULE_ID,
+            "1.0.0",
+            _RELEASE_TITLE,
+            "repository is not a git checkout (no .git directory)",
+            _RELEASE_SOURCE,
+        )
+    if not _git_available():
+        return _not_applicable_finding(
+            _RELEASE_RULE_ID,
+            "1.0.0",
+            _RELEASE_TITLE,
+            "git binary not found on PATH",
+            _RELEASE_SOURCE,
+        )
+
+    ts, err = _latest_tag_timestamp(context.root)
+
+    if err == "no tags":
+        return _not_applicable_finding(
+            _RELEASE_RULE_ID,
+            "1.0.0",
+            _RELEASE_TITLE,
+            "no version tags found — repository may not have been released yet",
+            _RELEASE_SOURCE,
+        )
+
+    if err is not None:
+        return _not_applicable_finding(
+            _RELEASE_RULE_ID,
+            "1.0.0",
+            _RELEASE_TITLE,
+            f"could not read git tags: {err}",
+            _RELEASE_SOURCE,
+        )
+
+    assert ts is not None
+    age = time.time() - ts
+    age_str = _format_age(age)
+    is_recent = age < _MAX_AGE_SECONDS
+
+    return Finding(
+        rule_id=_RELEASE_RULE_ID,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if is_recent else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_RELEASE_TITLE,
+        message=(
+            f"Most recent release tag is {age_str} old — within the {_MAX_AGE_MONTHS}-month threshold."
+            if is_recent
+            else f"Most recent release tag is {age_str} old — exceeds the {_MAX_AGE_MONTHS}-month threshold."
+        ),
+        applicability=Applicability(
+            reason="A recent release tag signals active versioning and distribution."
+        ),
+        source=_RELEASE_SOURCE,
+        fix=None
+        if is_recent
+        else FixSuggestion(
+            summary="Create a new release tag (e.g. git tag -a v1.x.x -m 'release').",
+            docs_url=_DOCS_URL,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule: maintenance.changelog.exists
+# ---------------------------------------------------------------------------
+
+_CHANGELOG_RULE_ID = "maintenance.changelog.exists"
+_CHANGELOG_TITLE = "Repository has a changelog file"
+_CHANGELOG_SOURCE = RuleSource(url=_DOCS_URL, checked_at=_SOURCE_CHECKED_AT)
+
+
+def changelog_exists_check(context: ProjectContext) -> Finding:
+    existing = next(
+        (
+            context.root / name
+            for name in _CHANGELOG_FILENAMES
+            if (context.root / name).is_file()
+        ),
+        None,
+    )
+    exists = existing is not None
+
+    return Finding(
+        rule_id=_CHANGELOG_RULE_ID,
+        rule_version="1.0.0",
+        category=CATEGORY,
+        status=RuleStatus.PASS if exists else RuleStatus.WARN,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_CHANGELOG_TITLE,
+        message=(
+            f"Repository contains {existing.name}."
+            if exists
+            else "Repository does not contain a recognized changelog file "
+            f"({', '.join(_CHANGELOG_FILENAMES)})."
+        ),
+        applicability=Applicability(
+            reason="A changelog helps users understand what changed between versions."
+        ),
+        source=_CHANGELOG_SOURCE,
+        fix=None
+        if exists
+        else FixSuggestion(
+            summary="Add a CHANGELOG.md at the repository root describing changes per version.",
+        ),
+        path=existing.name if exists else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule registry export
+# ---------------------------------------------------------------------------
+
+RULES = [
+    RuleDefinition(
+        id=_COMMIT_RULE_ID,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_COMMIT_TITLE,
+        why="An active commit history signals that the integration is actively maintained.",
+        source_url=_DOCS_URL,
+        check=recent_commit_check,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id=_RELEASE_RULE_ID,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_RELEASE_TITLE,
+        why="Recent release tags indicate the integration ships versioned releases for users to install.",
+        source_url=_DOCS_URL,
+        check=recent_release_check,
+        overridable=True,
+    ),
+    RuleDefinition(
+        id=_CHANGELOG_RULE_ID,
+        version="1.0.0",
+        category=CATEGORY,
+        severity=RuleSeverity.RECOMMENDED,
+        title=_CHANGELOG_TITLE,
+        why="A changelog documents version history so users can understand what changed.",
+        source_url=_DOCS_URL,
+        check=changelog_exists_check,
+        overridable=True,
+    ),
+]

--- a/src/hasscheck/rules/registry.py
+++ b/src/hasscheck/rules/registry.py
@@ -10,6 +10,7 @@ from hasscheck.rules.docs_readme import RULES as DOCS_README_RULES
 from hasscheck.rules.entity import RULES as ENTITY_RULES
 from hasscheck.rules.hacs_structure import RULES as HACS_STRUCTURE_RULES
 from hasscheck.rules.init_module import RULES as INIT_MODULE_RULES
+from hasscheck.rules.maintenance import RULES as MAINTENANCE_RULES
 from hasscheck.rules.manifest import RULES as MANIFEST_RULES
 from hasscheck.rules.repairs import RULES as REPAIRS_RULES
 from hasscheck.rules.repository import RULES as REPOSITORY_RULES
@@ -29,6 +30,7 @@ RULES = [
     *CI_RULES,
     *INIT_MODULE_RULES,
     *ENTITY_RULES,
+    *MAINTENANCE_RULES,
 ]
 RULES_BY_ID: dict[str, RuleDefinition] = {}
 for _rule in RULES:

--- a/tests/test_rules_maintenance.py
+++ b/tests/test_rules_maintenance.py
@@ -1,0 +1,293 @@
+"""Tests for maintenance signal rules (issue #109, v0.11 second batch).
+
+TDD cycle:
+  - RED: written first, before production code exists
+  - GREEN: confirmed after implementation
+
+Rules covered:
+  - maintenance.recent_commit.detected
+  - maintenance.recent_release.detected
+  - maintenance.changelog.exists
+
+Spec: issue #109 — maintenance signal rules (git-based, local subprocess only)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from hasscheck.models import RuleStatus
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SECONDS_PER_MONTH = 30.44 * 86400
+
+
+def _init_git_repo(path: Path, commit_offset_seconds: int = 0) -> None:
+    """Initialize a real git repo in path with a single commit.
+
+    commit_offset_seconds: positive = future, negative = past.
+    """
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    ts = str(int(time.time()) + commit_offset_seconds)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_AUTHOR_DATE": ts,
+        "GIT_COMMITTER_DATE": ts,
+    }
+    (path / "README.md").write_text("# Test\n")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _add_tag(path: Path, tag: str, tag_offset_seconds: int = 0) -> None:
+    """Add a lightweight git tag with a forced timestamp."""
+    ts = str(int(time.time()) + tag_offset_seconds)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        # For annotated tags we need these; for lightweight we still export
+        "GIT_COMMITTER_DATE": ts,
+    }
+    subprocess.run(
+        ["git", "tag", "-a", tag, "-m", f"release {tag}"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _check_rule(root: Path, rule_id: str):
+    """Run just the given rule's check function against root."""
+    rule = RULES_BY_ID[rule_id]
+    from hasscheck.rules.base import ProjectContext
+
+    ctx = ProjectContext(root=root, integration_path=None, domain=None)
+    return rule.check(ctx)
+
+
+# ===========================================================================
+# maintenance.recent_commit.detected
+# ===========================================================================
+
+RC_RULE = "maintenance.recent_commit.detected"
+
+
+class TestRecentCommit:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[RC_RULE]
+        assert rule.id == RC_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "maintenance"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_recent_commit(self, tmp_path: Path) -> None:
+        """Commit dated now → PASS."""
+        _init_git_repo(tmp_path)
+        finding = _check_rule(tmp_path, RC_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_old_commit(self, tmp_path: Path) -> None:
+        """Commit dated 18 months ago → WARN."""
+        offset = int(-18 * _SECONDS_PER_MONTH)
+        _init_git_repo(tmp_path, commit_offset_seconds=offset)
+        finding = _check_rule(tmp_path, RC_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_not_applicable_no_git_dir(self, tmp_path: Path) -> None:
+        """No .git directory → NOT_APPLICABLE."""
+        finding = _check_rule(tmp_path, RC_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+        assert "git" in finding.applicability.reason.lower()
+
+    def test_not_applicable_git_not_on_path(self, tmp_path: Path) -> None:
+        """git binary not on PATH → NOT_APPLICABLE."""
+        _init_git_repo(tmp_path)
+        from hasscheck.rules import maintenance
+
+        with patch.object(maintenance, "_git_available", return_value=False):
+            finding = _check_rule(tmp_path, RC_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+        assert "git" in finding.applicability.reason.lower()
+
+    def test_message_contains_age_info_on_pass(self, tmp_path: Path) -> None:
+        """PASS message should contain age information."""
+        _init_git_repo(tmp_path)
+        finding = _check_rule(tmp_path, RC_RULE)
+        assert finding.message  # non-empty
+
+    def test_message_contains_age_info_on_warn(self, tmp_path: Path) -> None:
+        """WARN message should mention age."""
+        offset = int(-18 * _SECONDS_PER_MONTH)
+        _init_git_repo(tmp_path, commit_offset_seconds=offset)
+        finding = _check_rule(tmp_path, RC_RULE)
+        assert "month" in finding.message.lower() or "day" in finding.message.lower()
+
+
+# ===========================================================================
+# maintenance.recent_release.detected
+# ===========================================================================
+
+RR_RULE = "maintenance.recent_release.detected"
+
+
+class TestRecentRelease:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[RR_RULE]
+        assert rule.id == RR_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "maintenance"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_recent_tag(self, tmp_path: Path) -> None:
+        """Annotated tag dated now → PASS."""
+        _init_git_repo(tmp_path)
+        _add_tag(tmp_path, "v1.0.0")
+        finding = _check_rule(tmp_path, RR_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_old_tag(self, tmp_path: Path) -> None:
+        """Tag dated 18 months ago → WARN."""
+        _init_git_repo(tmp_path)
+        offset = int(-18 * _SECONDS_PER_MONTH)
+        _add_tag(tmp_path, "v0.1.0", tag_offset_seconds=offset)
+        finding = _check_rule(tmp_path, RR_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_not_applicable_no_tags(self, tmp_path: Path) -> None:
+        """Repo with commits but no tags → NOT_APPLICABLE."""
+        _init_git_repo(tmp_path)
+        finding = _check_rule(tmp_path, RR_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+        assert "tag" in finding.applicability.reason.lower()
+
+    def test_not_applicable_no_git_dir(self, tmp_path: Path) -> None:
+        """No .git directory → NOT_APPLICABLE."""
+        finding = _check_rule(tmp_path, RR_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_not_applicable_git_not_on_path(self, tmp_path: Path) -> None:
+        """git binary not on PATH → NOT_APPLICABLE."""
+        _init_git_repo(tmp_path)
+        _add_tag(tmp_path, "v1.0.0")
+        from hasscheck.rules import maintenance
+
+        with patch.object(maintenance, "_git_available", return_value=False):
+            finding = _check_rule(tmp_path, RR_RULE)
+        assert finding.status is RuleStatus.NOT_APPLICABLE
+
+    def test_message_contains_age_on_warn(self, tmp_path: Path) -> None:
+        """WARN message should mention age."""
+        _init_git_repo(tmp_path)
+        offset = int(-18 * _SECONDS_PER_MONTH)
+        _add_tag(tmp_path, "v0.1.0", tag_offset_seconds=offset)
+        finding = _check_rule(tmp_path, RR_RULE)
+        assert "month" in finding.message.lower() or "day" in finding.message.lower()
+
+
+# ===========================================================================
+# maintenance.changelog.exists
+# ===========================================================================
+
+CL_RULE = "maintenance.changelog.exists"
+
+
+class TestChangelogExists:
+    def test_rule_is_registered(self) -> None:
+        rule = RULES_BY_ID[CL_RULE]
+        assert rule.id == CL_RULE
+        assert rule.version == "1.0.0"
+        assert rule.category == "maintenance"
+        assert str(rule.severity) == "recommended"
+        assert rule.overridable is True
+        assert rule.why
+
+    def test_pass_changelog_md(self, tmp_path: Path) -> None:
+        """CHANGELOG.md present → PASS."""
+        (tmp_path / "CHANGELOG.md").write_text("# Changelog\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_changelog(self, tmp_path: Path) -> None:
+        """CHANGELOG (no extension) → PASS."""
+        (tmp_path / "CHANGELOG").write_text("changelog\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_history_md(self, tmp_path: Path) -> None:
+        """HISTORY.md → PASS."""
+        (tmp_path / "HISTORY.md").write_text("# History\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_history(self, tmp_path: Path) -> None:
+        """HISTORY (no extension) → PASS."""
+        (tmp_path / "HISTORY").write_text("history\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_releases_md(self, tmp_path: Path) -> None:
+        """RELEASES.md → PASS."""
+        (tmp_path / "RELEASES.md").write_text("# Releases\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_pass_news_md(self, tmp_path: Path) -> None:
+        """NEWS.md → PASS."""
+        (tmp_path / "NEWS.md").write_text("# News\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.PASS
+
+    def test_warn_no_changelog(self, tmp_path: Path) -> None:
+        """No changelog file → WARN."""
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_warn_changelog_is_directory(self, tmp_path: Path) -> None:
+        """CHANGELOG.md is a directory (not a file) → WARN."""
+        (tmp_path / "CHANGELOG.md").mkdir()
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.status is RuleStatus.WARN
+
+    def test_pass_message_includes_filename(self, tmp_path: Path) -> None:
+        """PASS message should name the file found."""
+        (tmp_path / "CHANGELOG.md").write_text("# Changelog\n")
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert "CHANGELOG.md" in finding.message
+
+    def test_warn_message_is_informative(self, tmp_path: Path) -> None:
+        """WARN message should not be empty."""
+        finding = _check_rule(tmp_path, CL_RULE)
+        assert finding.message

--- a/tests/test_rules_meta.py
+++ b/tests/test_rules_meta.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 from hasscheck.rules.registry import RULES
 
 # Canonical audit (from sdd/config-file-support/mixed-status-rule-audit):
-# 45 rules total (v0.11 issue #108 adds 3 integration test detection rules):
-#   - tests.config_flow.detected (overridable=True, RECOMMENDED)
-#   - tests.setup_entry.detected (overridable=True, RECOMMENDED)
-#   - tests.unload.detected (overridable=True, RECOMMENDED)
-# 12 locked overridable=False, 33 overridable=True.
+# 48 rules total (v0.11 issue #109 adds 3 maintenance signal rules):
+#   - maintenance.recent_commit.detected (overridable=True, RECOMMENDED)
+#   - maintenance.recent_release.detected (overridable=True, RECOMMENDED)
+#   - maintenance.changelog.exists (overridable=True, RECOMMENDED)
+# 12 locked overridable=False, 36 overridable=True.
 EXPECTED_LOCKED_RULE_IDS = {
     "hacs.custom_components.exists",
     "hacs.file.parseable",  # mixed-status: WARN missing, FAIL invalid JSON
@@ -73,11 +73,15 @@ EXPECTED_OVERRIDABLE_RULE_IDS = {
     "tests.config_flow.detected",
     "tests.setup_entry.detected",
     "tests.unload.detected",
+    # v0.11 issue #109 — maintenance signal rules (RECOMMENDED, overridable=True)
+    "maintenance.recent_commit.detected",
+    "maintenance.recent_release.detected",
+    "maintenance.changelog.exists",
 }
 
 
-def test_total_rule_count_is_forty_five() -> None:
-    assert len(RULES) == 45, f"expected 45 rules, got {len(RULES)}"
+def test_total_rule_count_is_forty_eight() -> None:
+    assert len(RULES) == 48, f"expected 48 rules, got {len(RULES)}"
 
 
 def test_every_rule_declares_overridable_bool() -> None:


### PR DESCRIPTION
## Summary

Second v0.11 batch — three rules surfacing the maintenance signal locally so users see whether an integration is actively maintained before they install. Local git only — no GitHub API calls (no rate limits, works offline).

Closes #109.

## Rules

| Rule ID | Detection |
|---------|-----------|
| \`maintenance.recent_commit.detected\` | \`git log -1 --format=%ct\` HEAD timestamp. PASS if within 12 months. WARN otherwise. NOT_APPLICABLE if no \`.git/\` or git not on PATH. |
| \`maintenance.recent_release.detected\` | Most recent tag timestamp via \`git for-each-ref --sort=-creatordate refs/tags --count=1\`. PASS if within 12 months. WARN if older. NOT_APPLICABLE if no tags exist (unreleased ≠ abandoned) or no git. |
| \`maintenance.changelog.exists\` | File presence at repo root: \`CHANGELOG.md\`, \`CHANGELOG\`, \`HISTORY.md\`, \`HISTORY\`, \`RELEASES.md\`, \`NEWS.md\`. PASS if any exists. WARN otherwise. |

All three: \`severity=RECOMMENDED\`, \`overridable=True\`, \`version="1.0.0"\`, \`category=maintenance\`.

## Threshold note

\`_MAX_AGE_MONTHS = 12\` is **hardcoded** for v0.11. Issue #109's acceptance criterion specified configurable thresholds via \`hasscheck.yaml\`, but the existing \`HassCheckConfig\` only supports \`RuleOverride(status, reason)\` — no arbitrary per-rule settings. **Follow-up issue #117** tracks adding the settings infrastructure.

## Subprocess strategy

- All git invocations: \`shutil.which("git")\` PATH check first → \`subprocess.run\` with \`timeout=5.0\` and \`check=False\` → tuple return \`(stdout | None, error_msg | None)\`
- \`FileNotFoundError\` → "git binary not found" → NOT_APPLICABLE (clean signal for tarball installs / vendored code)
- \`subprocess.TimeoutExpired\` → "git command timed out" → NOT_APPLICABLE (defensive against pathological histories)
- Pylance correlation-narrowing assertions (\`assert ts is not None\` after error early-returns) — same pattern from PR3 \`ast_utils\` extraction

## Test plan

- [x] \`uv run pytest -q\` — **664 passing** (639 baseline + 25 new), zero regressions
- [x] \`uv run ruff check\` — clean
- [x] Strict TDD: 25 RED tests written first; each test \`git init\`s a real repo in \`tmp_path\` and uses \`GIT_AUTHOR_DATE\`/\`GIT_COMMITTER_DATE\` env vars to construct fixtures with known commit/tag dates
- [x] \`uv run hasscheck explain maintenance.{recent_commit.detected,recent_release.detected,changelog.exists}\` — all three exit 0
- [x] \`uv run hasscheck check --path .\` (the hasscheck repo itself) — PASS on all three (recent commit, v0.10.0 tag from this morning, \`CHANGELOG.md\` present)
- [x] \`uv run hasscheck check --path examples/bad_integration\` — 2 git rules NOT_APPLICABLE (no \`.git/\` in fixture subpath), changelog WARN

## Notes

- **Rule count audit** (\`tests/test_rules_meta.py\`): 45 → **48**. All three overridable.
- **README** + **\`docs/rules/README.md\`** — new "Maintenance" section after Tests and CI. Doc count bumped 45 → 48. Per-rule pages deferred to #104.
- **No fixture changes**. Bad fixture's NOT_APPLICABLE responses are the right signal (no \`.git/\` at \`examples/bad_integration/\`).
- **Schema unchanged** at \`0.3.0\`. \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\`.
- **Performance**: each rule completes in well under the 500ms target; \`git log -1\` is O(1) regardless of history depth.

## What's next in v0.11

- **#117** (newly opened) — per-rule settings infrastructure (unblocks configurable thresholds for these rules)
- #104 auto-generate per-rule docs from RuleDefinition metadata (closes the 41-rule gap in \`docs/rules/\`)
- #105 demo terminal asciinema recording