### PR TITLE
docs(demo): add demo.sh + recording.md for visual demo workflow (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,18 @@ HassCheck starts as a local CLI. Public badges, hosted reports, and any future h
 
 HassCheck is designed to produce concrete next steps, not a vague score.
 
+<!-- demo:gif -->
+<!-- The GIF below is rendered from `docs/demo.sh`. See `docs/recording.md` to regenerate. -->
+<!-- Drop the embed back in once `docs/demo.gif` is checked in: -->
+<!-- ![HassCheck demo](docs/demo.gif) -->
+
 ```bash
 uv run hasscheck check --path examples/bad_integration
 uv run hasscheck scaffold diagnostics --path examples/bad_integration --dry-run
 ```
 
-See [`docs/demo.md`](docs/demo.md) for the full workflow.
+See [`docs/demo.md`](docs/demo.md) for the full walkthrough or
+[`docs/recording.md`](docs/recording.md) to regenerate the visual demo.
 
 ## How HassCheck relates to other tools
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,5 +1,8 @@
 # HassCheck demo
 
+> **Visual demo**: see [`docs/demo.gif`](demo.gif) when rendered. The GIF is generated from
+> [`docs/demo.sh`](demo.sh) — see [`docs/recording.md`](recording.md) to regenerate.
+
 Run HassCheck against the tracked `bad_integration` fixture, see findings, run a scaffold, see improvement.
 
 ## 1. Check the bad fixture

--- a/docs/demo.sh
+++ b/docs/demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Deterministic walkthrough of HassCheck against a copy of the bad_integration
+# fixture. Used as the input for the asciinema/vhs recording in `docs/`.
+#
+# Run interactively to record:
+#   asciinema rec --command='bash docs/demo.sh' docs/demo.cast
+#
+# Then convert to GIF:
+#   agg --theme github-dark --speed 1.2 docs/demo.cast docs/demo.gif
+#
+# The script copies the tracked fixture to /tmp so scaffold writes do not
+# pollute the repo. No real-user data, no secrets, no fabricated output.
+set -euo pipefail
+
+DEMO_DIR="$(mktemp -d -t hasscheck-demo.XXXXXX)"
+trap 'rm -rf "${DEMO_DIR}"' EXIT
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cp -R "${REPO_ROOT}/examples/bad_integration/." "${DEMO_DIR}/"
+
+# Pause helper — slow enough to read, fast enough to stay under 90 seconds.
+pause() {
+  sleep "${1:-1.5}"
+}
+
+cmd() {
+  printf '%s\n' ''
+  printf '%s\n' "\$ $*"
+  pause 0.6
+  "$@" || true
+  pause 1.5
+}
+
+clear
+printf '%s\n' 'HassCheck — local quality signals for HA custom integrations'
+printf '%s\n' '------------------------------------------------------------'
+pause 1.5
+
+# 1. Initial check against the bad fixture.
+cmd uv run hasscheck check --path "${DEMO_DIR}"
+
+# 2. Explain a single finding.
+cmd uv run hasscheck explain manifest.domain.matches_directory
+
+# 3. Preview a fix scaffold.
+cmd uv run hasscheck scaffold diagnostics --path "${DEMO_DIR}" --dry-run
+
+# 4. Apply the scaffold and re-check to show movement.
+cmd uv run hasscheck scaffold diagnostics --path "${DEMO_DIR}"
+cmd uv run hasscheck check --path "${DEMO_DIR}"
+
+printf '%s\n' ''
+printf '%s\n' 'Done. See docs/demo.md for the full walkthrough.'
+pause 2.0

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -1,0 +1,74 @@
+# Recording the demo
+
+`docs/demo.sh` is the deterministic source of truth for the visual demo. The
+recording is regenerated from this script — the script is the artifact, the GIF
+is the rendering. If the demo flow changes, edit `demo.sh`, re-record, commit
+both.
+
+## Prerequisites
+
+- [`asciinema`](https://docs.asciinema.org/manual/cli/installation/) — terminal recorder.
+- [`agg`](https://github.com/asciinema/agg) — converts `.cast` files to `.gif`.
+- A working `uv` and the repo's tracked `examples/bad_integration` fixture.
+
+```bash
+brew install asciinema agg
+```
+
+## Record
+
+From the repo root, in an interactive terminal:
+
+```bash
+asciinema rec \
+  --idle-time-limit 1.5 \
+  --command 'bash docs/demo.sh' \
+  docs/demo.cast
+```
+
+`--idle-time-limit 1.5` keeps the recording compact — long pauses inside
+`demo.sh` are clamped to 1.5 seconds during playback.
+
+The recording exits when `demo.sh` finishes. Confirm length is in the 30–90
+second window per acceptance criteria from #105.
+
+## Render to GIF
+
+```bash
+agg --theme github-dark --speed 1.2 docs/demo.cast docs/demo.gif
+```
+
+Tweak `--speed` and `--theme` if the result feels too fast/slow or contrast is
+off on the README's background.
+
+## Commit
+
+```bash
+git add docs/demo.sh docs/demo.cast docs/demo.gif docs/recording.md
+git commit -m "docs(demo): record terminal demo (#105)"
+```
+
+Both the `.cast` (replayable, lightweight) and the `.gif` (universally
+renderable on GitHub) are checked in.
+
+## Embed in README
+
+The README "See it in action" section already reserves the slot. Add the
+embed once the GIF is committed:
+
+```md
+![HassCheck demo](docs/demo.gif)
+```
+
+If you also want an asciinema-player embed, host the `.cast` on
+[asciinema.org](https://asciinema.org/) and paste the iframe — purely
+optional; the GIF works everywhere GitHub does.
+
+## Rules of thumb
+
+- **No real-user data.** The script runs against a `/tmp/` copy of the tracked
+  `bad_integration` fixture; nothing personal.
+- **No fabricated output.** Whatever HassCheck prints is what gets recorded.
+- **No "certified / approved / safe" language** in any caption or alt text.
+- **Regenerable.** A reviewer must be able to run the same `asciinema rec`
+  command and get a functionally identical recording.


### PR DESCRIPTION
## Summary

Last v0.11 batch — ships the deterministic source-of-truth for the visual demo so the maintainer can record it locally and commit the artifacts in a follow-up. Closes #105 except for the rendered \`.cast\` + \`.gif\` files, which require an interactive PTY to produce.

## What lands

- **\`docs/demo.sh\`** — deterministic shell script. Copies \`examples/bad_integration\` to a \`mktemp -d\` so scaffold writes don't pollute the tracked fixture. Runs check → explain → scaffold dry-run → scaffold → re-check. Bounded sleeps for readability. Cleanup trap.
- **\`docs/recording.md\`** — step-by-step instructions for the asciinema rec + agg pipeline, acceptance-criteria reminders (length 30–90s, no real-user data, no fabricated output, no certification language), and the embed snippet for README.
- **\`README.md\` "See it in action"** — placeholder for the GIF (commented out until \`docs/demo.gif\` lands), explicit pointers to \`docs/demo.sh\` and \`docs/recording.md\`.
- **\`docs/demo.md\`** — leading callout linking to the GIF and the recording instructions.

## What ships in a follow-up commit (maintainer-run)

```bash
asciinema rec --idle-time-limit 1.5 --command 'bash docs/demo.sh' docs/demo.cast
agg --theme github-dark --speed 1.2 docs/demo.cast docs/demo.gif
git add docs/demo.cast docs/demo.gif
# uncomment the embed in README.md "See it in action"
git commit -m "docs(demo): record terminal demo (#105)"
```

The pipeline requires \`asciinema\` + \`agg\` (\`brew install asciinema agg\`). Both produce text-trackable artifacts (\`.cast\` is JSON, \`.gif\` is binary but small enough for git).

## Why split apply from recording

Recording requires an interactive terminal session. The agent context running this PR cannot produce a faithful PTY recording. Splitting the script + instructions from the rendered artifact lets:

- The PR review focus on the deterministic source (\`demo.sh\`, \`recording.md\`)
- The maintainer record once and commit, without rebasing this PR
- Future regenerations stay deterministic — anyone with \`asciinema\` + \`agg\` and the script reproduces functionally identical output

## Test plan

- [x] \`bash docs/demo.sh\` — runs cleanly end-to-end against a temp copy of \`examples/bad_integration\`. Exit 0. Output shows the expected check → explain → scaffold → re-check loop.
- [x] \`uv run pytest -q\` — **737 passing**, zero changes (no source code touched)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck docs-render --check\` — "OK: all rule docs are up to date" (CI drift check from #119 still happy)
- [x] No "certify / approved / safe" language in any new file
- [x] Demo runs against the tracked \`bad_integration\` fixture only — no real-user data, no fabricated output

## What's next

After this merges:
- Maintainer runs the recording pipeline locally and commits \`docs/demo.cast\` + \`docs/demo.gif\` (uncommenting the README embed in the same commit)
- v0.11 is feature-complete (#108 + #109 + #104 + #105 all landed)
- Cut v0.11.0 release per the established \`chore(release)\` pattern