### PR TITLE
chore(rules): drop dead imports_async_redact field from _DiagnosticsSignals (#106)

### DIFF
--- a/src/hasscheck/rules/diagnostics.py
+++ b/src/hasscheck/rules/diagnostics.py
@@ -31,7 +31,8 @@ _LOCAL_REDACT_RE = re.compile(r"^_?redact(_.*)?$")
 
 @dataclass(frozen=True)
 class _DiagnosticsSignals:
-    imports_async_redact: bool
+    # Per design D6 (v0.8 PR4) and #106 Path B: import without a call is not
+    # evidence of active redaction. PASS resolution requires an actual call.
     calls_async_redact: bool
     calls_local_redact: bool  # local def + call to name matching ^_?redact(_.*)?$
     returns_raw_entry_data: (
@@ -41,7 +42,6 @@ class _DiagnosticsSignals:
 
 def _diagnostics_signals(tree: ast.Module) -> _DiagnosticsSignals:
     """Walk the AST and extract redaction-related signals."""
-    imports_async_redact = False
     calls_async_redact = False
 
     # Collect names of local functions matching the redact pattern
@@ -51,13 +51,6 @@ def _diagnostics_signals(tree: ast.Module) -> _DiagnosticsSignals:
     returns_raw_entry_data = False
 
     for node in ast.walk(tree):
-        # Detect imports of async_redact_data
-        if isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                name = alias.asname or alias.name
-                if name == "async_redact_data" or alias.name == "async_redact_data":
-                    imports_async_redact = True
-
         # Detect calls to async_redact_data (Name or Attribute)
         if isinstance(node, ast.Call):
             func = node.func
@@ -103,7 +96,6 @@ def _diagnostics_signals(tree: ast.Module) -> _DiagnosticsSignals:
     calls_local_redact = bool(local_redact_defs & called_names)
 
     return _DiagnosticsSignals(
-        imports_async_redact=imports_async_redact,
         calls_async_redact=calls_async_redact,
         calls_local_redact=calls_local_redact,
         returns_raw_entry_data=returns_raw_entry_data,


### PR DESCRIPTION
## Summary

Path B per #106. Locks v0.8's conservative "call required for PASS" stance permanently by removing the unused \`imports_async_redact\` field that has been carried since v0.8 PR #89.

Closes #106.

## Background

The v0.8 verify report (PR #89, engram observation #418, suggestion S1) flagged \`imports_async_redact\` as captured but never consulted in PASS resolution. Design D6 deliberately narrowed PASS to:

- \`calls_async_redact\` (HA's blessed helper actually invoked), OR
- \`calls_local_redact\` (a local helper matching \`^_?redact(_.*)?\$\` is both defined AND called)

Import alone — without a call — is not evidence of active redaction. A maintainer who imports the helper but never wires it up should still get a WARN.

#106 offered two paths: A) honor "import OR call", or B) remove the dead field. Path B picked because:

- The conservative stance has been the actual behavior for two release cycles (v0.8, v0.9, v0.10, v0.11)
- No external signal pushing for more permissive evaluation
- Keeping the field invites future contributors to wire it up incorrectly
- Issue's own framing called the v0.8 decision "correct"

## What changed

\`src/hasscheck/rules/diagnostics.py\`:
- \`_DiagnosticsSignals\` dataclass loses \`imports_async_redact: bool\`
- Dataclass gains a comment explaining the design (so the field doesn't get reintroduced)
- \`_diagnostics_signals()\` loses the \`ast.ImportFrom\` walk branch that populated the dropped field

No callsite was using \`imports_async_redact\`, so PASS-resolution behavior is unchanged.

## Test plan

- [x] \`uv run pytest -q\` — **774 passing**, zero regressions
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck docs-render --check\` — "OK: all rule docs are up to date" (no rule metadata changed)
- [x] No test changes needed — no test asserted on \`imports_async_redact\`

## Notes

- **Rule count audit**: unchanged at 48
- **\`SCHEMA_VERSION\`**: unchanged at \`0.3.0\`
- **\`DEFAULT_RULESET_ID\`**: unchanged at \`hasscheck-ha-2026.5\` — internal refactor, no rule semantic change

## What's next in v0.12

- #102 more README content rules (examples / supported devices / limitations / HACS-specific)