### PR TITLE
chore(release): bump to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-05-02
+
+### Added
+- **Per-rule settings** in `hasscheck.yaml` (#117). `RuleOverride` gains an optional `settings: dict[str, Any] | None` field so users can tune per-rule behavior without monkey-patching:
+  ```yaml
+  rules:
+    maintenance.recent_commit.detected:
+      settings:
+        max_age_months: 18
+  ```
+- **`get_rule_setting(context, rule_id, key, default)`** helper in `src/hasscheck/rules/base.py` for rule check functions to read configured values with default fallback.
+- **`ProjectContext.rule_settings: dict[str, dict[str, Any]]`** — populated by `checker.py` from the loaded `HassCheckConfig` and forwarded through `detect_project()`.
+- **#109 maintenance rules now read configurable thresholds**:
+  - `maintenance.recent_commit.detected` reads `max_age_months` (default `12`)
+  - `maintenance.recent_release.detected` reads `max_age_months` (default `12`)
+  - `_resolve_max_age()` validates the configured value is `int > 0`; falls back to default on bad input (string, negative, zero, missing, wrong type)
+- **Four more README content rules** in `src/hasscheck/rules/docs_readme.py` (#102) — same factory + heading-only heuristic as v0.9 PR #97:
+  - `docs.examples.exists` — examples, example, usage, demo
+  - `docs.supported_devices.exists` — supported, devices, services, hardware, compatibility, models
+  - `docs.limitations.exists` — limitations, caveats, known limitations, restrictions
+  - `docs.hacs_instructions.exists` — hacs, custom repository, hacs install
+- **`examples/good_integration/README.md`** — extended with four new sections (Examples, Supported Devices, Limitations, HACS Installation) so the positive integration test continues asserting PASS across the full docs rule pack.
+
+### Removed
+- **`imports_async_redact` field** from `_DiagnosticsSignals` in `src/hasscheck/rules/diagnostics.py` (#106). The field was captured by the AST walker but never consulted in PASS resolution — design D6 narrowed PASS to "actual call required, import alone is not evidence." Path B from #106 locks the conservative stance permanently and removes the dead carrier. PASS-resolution behavior unchanged.
+
+### Changed
+- Bumped `version` and `__version__` to `0.12.0`
+
+### Notes
+- `SCHEMA_VERSION` unchanged at `0.3.0` — v0.12 adds a config-file field and removes a private dataclass member; no `Finding` (report) shape changes (additive only per ADR 0009)
+- `DEFAULT_RULESET_ID` unchanged at `hasscheck-ha-2026.5` — same ruleset cycle as v0.8 / v0.9 / v0.10 / v0.11 per ADR 0006
+- Rule count: 48 → **52** (+4)
+- Test count: 737 → **823** (+86 — 25 config + 12 maintenance threshold + 49 README extras)
+- Per-rule docs pages: 48 → **52** (4 new auto-generated via `hasscheck docs-render`)
+- Backward compat: existing `hasscheck.yaml` files work unchanged; missing `settings` block → all rules use hardcoded defaults
+
+[Compare v0.11.0...v0.12.0](https://github.com/Daily-Nerd/hasscheck/compare/v0.11.0...v0.12.0)
+
 ## [0.11.0] — 2026-05-02
 
 ### Added
@@ -294,7 +333,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Initial release](https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.1.0)
 
-[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/Daily-Nerd/hasscheck/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.12.0
 [0.11.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.11.0
 [0.10.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.10.0
 [0.9.0]: https://github.com/Daily-Nerd/hasscheck/releases/tag/v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.11.0"
+version = "0.12.0"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

v0.12.0 ships per-rule settings infrastructure, configurable maintenance thresholds, four more README rules, and a small diagnostics cleanup:

| PR | Issue(s) | Theme |
|----|----------|-------|
| #123 | #117 | per-rule settings in \`hasscheck.yaml\` + #109 maintenance threshold wiring |
| #124 | #106 | drop dead \`imports_async_redact\` field; lock v0.8 conservative stance |
| #125 | #102 | four more README content rules (examples / supported_devices / limitations / hacs_instructions) |

## Test plan

- [x] \`uv sync\` — clean
- [x] \`uv run pytest -q\` — **823 passing**, zero regressions
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck --version\` → \`hasscheck 0.12.0\`
- [x] \`uv run hasscheck docs-render --check\` — "OK: all rule docs are up to date"
- [x] Pre-commit \`hasscheck version consistency\` hook passes

## Numbers

- Rule count: 48 → **52** (+4)
- Test count: 737 → **823** (+86 — 25 config + 12 maintenance threshold + 49 README extras)
- Per-rule docs pages: 48 → **52** (4 new auto-generated)

## Schema / ruleset

- \`SCHEMA_VERSION\` unchanged at \`0.3.0\` — config-file additive field, no \`Finding\` shape change
- \`DEFAULT_RULESET_ID\` unchanged at \`hasscheck-ha-2026.5\` — same ruleset cycle as v0.8 / v0.9 / v0.10 / v0.11

## After merge

Tag \`v0.12.0\` on the merge commit. Same release-tag workflow as v0.10.0 / v0.11.0.

## What's next post-v0.12

- **Coordinated v1.0 launch** (gated on \`hasscheck-web\` prod deploy + repo public flip):
  - hasscheck-web ships #9 (GCP Cloud Run + Neon Postgres + Cloudflare) and #8 (project profile UI)
  - \`hasscheck.io\` goes live
  - OSS repo flips public
  - #15 PyPI trusted publishing lands
  - Tag \`v1.0.0\` simultaneously across both repos
- v0.13+ candidates: #103 prose-only matching for docs.*.exists (data-dependent, post-flip)
- v1.0+ candidates: #67 hub-verified badges via server-side rule re-execution