### PR TITLE
chore(ci): add workflow_dispatch smoke test for hasscheck.io publish

### DIFF
--- a/.github/workflows/smoke-publish.yml
+++ b/.github/workflows/smoke-publish.yml
@@ -1,0 +1,59 @@
+name: Smoke — publish to hasscheck.io
+
+# One-off manual smoke test for the v1.0 launch. Runs hasscheck against the
+# tracked `examples/good_integration` fixture and publishes the report to the
+# live hub via GitHub OIDC. Validates the full ingest path end-to-end against
+# the deployed Cloud Run service.
+#
+# Trigger:
+#   gh workflow run smoke-publish.yml --repo Daily-Nerd/hasscheck
+#
+# After a successful run, the report appears at:
+#   https://hasscheck.io/Daily-Nerd/hasscheck
+# To withdraw the test report (run the action locally or via gh):
+#   uv run hasscheck publish --withdraw-all --slug Daily-Nerd/hasscheck --force
+#
+# Delete this workflow file after the v1.0 launch validation is done.
+
+on:
+  workflow_dispatch:
+    inputs:
+      endpoint:
+        description: Publish endpoint URL
+        required: false
+        default: https://hasscheck.io
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  smoke:
+    name: Publish good_integration to hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./
+        with:
+          path: examples/good_integration
+          emit-publish: "true"
+          publish-endpoint: ${{ inputs.endpoint }}
+
+      - name: Verify report appears in hub
+        run: |
+          set -euo pipefail
+          ENDPOINT="${{ inputs.endpoint }}"
+          # Cloud Run + Cloudflare can take a few seconds to propagate cache
+          # on the first publish for a slug. Retry briefly.
+          for i in 1 2 3 4 5; do
+            BODY=$(curl -fsSL --max-time 10 "${ENDPOINT}/api/projects/Daily-Nerd/hasscheck" || true)
+            if [ -n "$BODY" ]; then
+              echo "$BODY" | head -c 1000
+              echo
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::Report did not appear at ${ENDPOINT}/api/projects/Daily-Nerd/hasscheck after retries"
+          exit 1


### PR DESCRIPTION
## Summary

One-off \`workflow_dispatch\` smoke test to validate the v0.7 publish handshake end-to-end against the deployed Cloud Run service before the v1.0 launch.

GitHub requires \`workflow_dispatch\` workflows to exist on the default branch before they can be triggered manually, so this gets merged first, then triggered, then deleted in a follow-up.

## What it does

1. Checks out the repo
2. Runs hasscheck against \`examples/good_integration\`
3. Mints a GitHub OIDC token (audience \`hasscheck-web\`)
4. Publishes via the local action with \`emit-publish: true\`
5. Curls \`https://hasscheck.io/api/projects/Daily-Nerd/hasscheck\` (with retry) to confirm ingest

## Trigger after merge

\`\`\`bash
gh workflow run smoke-publish.yml --repo Daily-Nerd/hasscheck
gh run watch --repo Daily-Nerd/hasscheck
\`\`\`

## Cleanup after validation

\`\`\`bash
# Withdraw the test report
uv run hasscheck publish --withdraw-all --slug Daily-Nerd/hasscheck --force

# Delete the workflow
git rm .github/workflows/smoke-publish.yml
git commit -m "chore(ci): remove smoke-publish workflow after v1.0 validation"
\`\`\`

## Risk

- Creates a real \`Daily-Nerd/hasscheck\` project entry on the public hub. Withdrawn immediately after validation per cleanup steps above.
- Uses the live \`https://hasscheck.io\` endpoint by default. Override via the workflow's \`endpoint\` input if testing against a staging URL.

## Path filters

This workflow is in \`.github/workflows/smoke-publish.yml\` — outside the existing CI workflow's path filters (\`src/\`, \`scripts/\`, \`tests/\`, etc.), so the existing CI run isn't affected. Workflow is \`workflow_dispatch\`-only — never runs on push or PR.

## After v1.0 launch

This file is intentionally short-lived and should be deleted once the v1.0 publish path is validated. The ongoing CI workflow already exercises hasscheck in-process via TestClient on the hasscheck-web side.