### PR TITLE
fix(action): badge step uses installed hasscheck, not .venv/bin/python (#128)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,10 +88,14 @@ runs:
       if: inputs.emit-badges == 'true'
       shell: bash
       run: |
-        .venv/bin/python -m hasscheck badge \
+        ARGS=""
+        if [ "${{ inputs.no-config }}" = "true" ]; then
+          ARGS="--no-config"
+        fi
+        hasscheck badge \
           --path "${{ inputs.path }}" \
           --out-dir "${{ inputs.badges-out-dir }}" \
-          ${{ inputs.no-config == 'true' && '--no-config' || '' }}
+          $ARGS
 
     - name: Upload badges artifact
       if: inputs.emit-badges == 'true'

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -81,3 +81,17 @@ def test_publish_step_calls_hasscheck_publish_with_endpoint():
     assert "hasscheck publish" in run_block
     assert "--to" in run_block
     assert "publish-endpoint" in run_block
+
+
+def test_badge_step_uses_installed_hasscheck_executable_not_venv():
+    """Regression for #128: badge step previously used .venv/bin/python which
+    breaks in any consuming repo without a .venv at the workspace root."""
+    cfg = yaml.safe_load(Path("action.yml").read_text())
+    steps = cfg["runs"]["steps"]
+    badge_step = next((s for s in steps if s.get("name") == "Generate badges"), None)
+    assert badge_step is not None
+    run_block = badge_step["run"]
+    assert ".venv" not in run_block, (
+        ".venv path leaks into the badge step — breaks in consuming repos. See #128."
+    )
+    assert "hasscheck badge" in run_block


### PR DESCRIPTION
## Summary

Pre-launch P0 fix surfaced by the v1.0 review. The badge step in \`action.yml\` invoked \`.venv/bin/python -m hasscheck badge ...\`, which resolves only inside the hasscheck repo's own dev tree. In any consuming repository that runs \`Daily-Nerd/hasscheck@vX\` with \`emit-badges: 'true'\`, there is no \`.venv\` at the workspace root and the step fails with "No such file or directory."

Closes #128.

## What changed

- \`action.yml\` — badge step now uses the same install-then-call shape every other step uses (\`hasscheck badge ...\`), with the same \`--no-config\` propagation pattern as the \`check\` and \`publish\` steps.
- \`tests/test_action_yml.py\` — new \`test_badge_step_uses_installed_hasscheck_executable_not_venv\` regression test asserting \`.venv\` does NOT appear in the badge step's run block AND \`hasscheck badge\` does.

## Test plan

- [x] \`uv run pytest tests/test_action_yml.py -q\` — **12 passed** (11 baseline + 1 regression)
- [x] \`uv run pytest -q\` — full suite green
- [x] \`uv run ruff check\` — clean
- [x] Pre-commit \`check yaml\` hook passes

## Notes

- This is a silent landmine before today: local hasscheck CI passes (its \`.venv\` exists) but any external maintainer enabling \`emit-badges: 'true'\` would see the step fail.
- No behavior change for any other step. The \`--no-config\` propagation matches the existing pattern from \`Run hasscheck\` and \`Generate markdown report\`.
- Pre-flip launch blocker per the v1.0 review. Should ship before the OSS repo flips public so external first-time users hit the fixed path.

## What's next post-merge

The other v1.0 review findings live as separate issues:
- **#129** P0 docs(readme): Current status block says v0.9.0; package is v0.12.0
- **#130** P1 feat(schema): add optional \`report.provenance\` block (schema bump 0.3.0 → 0.4.0)
- **#131** P1 feat(cli): \`hasscheck publish --dry-run\`
- **#132** docs: Upgrade Radar v1.0 positioning + ADR 0010 status taxonomy