### PR TITLE
docs(readme): sync Current status to v0.12.0; refresh idea.md ladder + roadmap (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,18 @@ HassCheck is intentionally not a replacement for hassfest and does not assign Ho
 
 ## Current status
 
-**Latest release**: v0.9.0 — rule depth, AST-based config flow + diagnostics inspection, README content rules, and adoption-focused docs.
+**Current package version**: v0.12.0 — alpha.
 
-**In progress**: v0.10 — rule expansion (modern HA pattern checks, manifest.requirements sanity, advanced config flow signals). See open issues for the working backlog.
+The CLI, GitHub Action, JSON report contract, rule docs, local badge generation, opt-in publishing flow, and per-rule settings are all shipped. 52 rules across HACS structure, manifest metadata, modern HA patterns, diagnostics, docs, tests/CI, and maintenance. Auto-generated per-rule docs page for every registered rule.
+
+The hub at [hasscheck.io](https://hasscheck.io) is operational and accepts opt-in published reports via GitHub OIDC.
+
+**Current development focus**:
+
+- Verified report provenance display on the hub
+- Hub-verified badges (#67) — replaces self-reported committed badge JSON
+- Upgrade Radar status taxonomy for v1.0 (#132)
+- PyPI trusted publishing (#15) once release discipline is ready
 
 ## GitHub Action
 
@@ -73,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Daily-Nerd/hasscheck@v0.9.0
+      - uses: Daily-Nerd/hasscheck@v0.12.0
         with:
           comment-pr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -92,7 +101,7 @@ jobs:
 | `emit-publish` | `false` | Publish the report to a hosted HassCheck service. Requires workflow `permissions: id-token: write` |
 | `publish-endpoint` | `https://hasscheck.io` | Publish endpoint URL when `emit-publish: 'true'` |
 
-> The hosted reports endpoint (`hasscheck.io`) launches alongside the public release. Until then, `emit-publish: 'true'` works against a self-hosted endpoint via the `publish-endpoint` input or `HASSCHECK_PUBLISH_ENDPOINT` env var. The local CLI (without `--emit-publish`) is fully functional and is the recommended starting point.
+> The hosted reports endpoint at `hasscheck.io` is operational. Publishing requires `permissions: id-token: write` on the workflow so HassCheck can mint a GitHub OIDC token; the hub validates the token's repository claim before accepting the report. The local CLI (without `emit-publish`) remains fully functional and is the recommended starting point if you don't want to publish.
 
 **Outputs:** `exit-code` — `0` when no FAIL findings, `1` when one or more FAIL findings.
 
@@ -115,7 +124,7 @@ This writes per-category JSON files and a `manifest.json` to `badges/`. Commit t
 Add `emit-badges: 'true'` to your HassCheck action step:
 
 ```yaml
-- uses: Daily-Nerd/hasscheck@v0.9.0
+- uses: Daily-Nerd/hasscheck@v0.12.0
   with:
     emit-badges: 'true'
     badges-out-dir: 'badges'

--- a/idea.md
+++ b/idea.md
@@ -9,18 +9,20 @@ Working name: **HassCheck**
 
 > ⚠️ **This document is the original product brief.** It captures the founding
 > vision and is preserved as-is below. The Section 3 ladder and Section 15
-> roadmap have been refreshed to reflect shipped reality through v0.9.0.
+> roadmap have been refreshed to reflect shipped reality through v0.12.0.
 > For per-release detail see [`CHANGELOG.md`](./CHANGELOG.md). For
 > architecture decisions and per-feature design see
 > [`docs/`](./docs/README.md) and [`docs/decisions/`](./docs/decisions/).
 >
-> **Implementation status (2026-05-01):**
-> - **Latest released**: `v0.9.0` — rule depth (30 rules), AST-based config
->   flow + diagnostics inspection, README content rules, adoption docs.
-> - **In progress**: `v0.10.x` — rule expansion. See open GitHub issues
->   (#100, #101, #102, #107, #108, #109) for the working backlog.
-> - **Hosted endpoint** (`hasscheck.io`): launching alongside the OSS public
->   flip; built in the private `hasscheck-web` repo per ADR 0008.
+> **Implementation status (2026-05-02):**
+> - **Latest released**: `v0.12.0` — 52 rules, per-rule settings in
+>   `hasscheck.yaml`, auto-generated per-rule docs, demo recording assets.
+> - **In progress**: pre-v1.0 polish. See open GitHub issues #128–#132 for
+>   the launch-blocker backlog plus #15 (PyPI publish), #67 (hub-verified
+>   badges), #103 (prose-only doc heuristics).
+> - **Hosted endpoint** (`hasscheck.io`): live and accepting opt-in published
+>   reports via GitHub OIDC. Built in the private `hasscheck-web` repo per
+>   ADR 0008.
 
 ## Executive correction
 
@@ -156,22 +158,32 @@ That distinction matters.
 # 3. Product ladder
 
 ```text
-v0.1   Local CLI                                                  [shipped]
-v0.2   Stable JSON report schema + applicability + overrides      [shipped]
-v0.3   Rule explanations + source links                           [shipped]
-v0.4   Scaffolding / fix helpers                                  [shipped]
-v0.5   GitHub Action + unified --format flag                      [shipped]
-v0.6   Opt-in badges                                              [shipped]
-v0.7   Opt-in hosted reports (OIDC publish)                       [shipped]
-v0.8   Rule depth + publish polish + LICENSE/metadata             [shipped]
-v0.9   AST helper extraction + README content rules + adoption    [shipped]
-       docs (comparison + per-rule pages + demo walkthrough)
-v0.10  Rule expansion: manifest.requirements, config_flow         [in progress]
-       advanced (reauth/reconfigure/duplicate/connection),
-       modern HA pattern checks (async_setup_entry, runtime_data,
-       unique_id, has_entity_name, device_info)
-v1.0   Opt-in project hub — discovery from voluntarily published  [planned]
-       reports, hub-verified badges, server-side rule re-execution
+v0.1    Local CLI                                                 [shipped]
+v0.2    Stable JSON report schema + applicability + overrides     [shipped]
+v0.3    Rule explanations + source links                          [shipped]
+v0.4    Scaffolding / fix helpers                                 [shipped]
+v0.5    GitHub Action + unified --format flag                     [shipped]
+v0.6    Opt-in badges                                             [shipped]
+v0.7    Opt-in hosted reports (OIDC publish)                      [shipped]
+v0.8    Rule depth + publish polish + LICENSE/metadata            [shipped]
+v0.9    AST helper extraction + README content rules + adoption   [shipped]
+        docs (comparison + per-rule pages + demo walkthrough)
+v0.10   Rule expansion: manifest.requirements, config_flow        [shipped]
+        advanced (reauth/reconfigure/duplicate/connection),
+        modern HA pattern checks (async_setup_entry, runtime_data,
+        unique_id, has_entity_name, device_info)
+v0.11   Test detection + maintenance signals + auto-generated     [shipped]
+        per-rule docs + demo recording
+v0.12   Per-rule settings in hasscheck.yaml + four more docs.*    [shipped]
+        rules + diagnostics field cleanup
+v0.13.x Pre-v1.0 polish: report.provenance schema field,          [in progress]
+        hasscheck publish --dry-run, action.yml + README
+        consistency, Upgrade Radar positioning + ADR 0010
+v1.0    Opt-in project hub with verified Upgrade Radar — discovery [planned]
+        from voluntarily published reports, OIDC-verified
+        provenance display, hub-generated badges replacing
+        self-reported committed JSON, status taxonomy
+        (Fresh / Warnings / Failing / Stale / Unverified)
 ```
 
 Each rung adds value the previous rung cannot deliver alone. The hub only
@@ -995,55 +1007,105 @@ CONTRIBUTING.md + CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
 README "Current status" + emit-publish framing aligned with reality
 ```
 
-## Month 7 — Public flip + PyPI (v0.10.x) [in progress]
+## Month 7 — Rule expansion (v0.10) [shipped]
 
 Goal:
 
-> Reach maintainers. Distribution unblocks community feedback.
+> Make the rule surface deep enough that hosted reports carry signal.
+
+Shipped:
+
+```text
+manifest.requirements sanity (#100) — is_list, entries_well_formed
+  (PEP 508), no_git_or_url_specs
+config_flow advanced (#101) — reauth_step, reconfigure_step,
+  unique_id.set, connection_test heuristic
+modern HA pattern checks (#107) — async_setup_entry,
+  runtime_data, entity unique_id, has_entity_name, device_info
+ast_utils.has_async_function helper extraction
+```
+
+## Month 7.5 — Test detection + maintenance + docs tooling (v0.11) [shipped]
+
+Goal:
+
+> Close the rule-docs scaling gap and add maintenance signals.
+
+Shipped:
+
+```text
+test detection rules (#108) — config_flow / setup_entry / unload
+maintenance signals (#109) — recent_commit, recent_release,
+  changelog presence (local git only, no GitHub API)
+auto-generated per-rule docs from RuleDefinition metadata (#104),
+  CI drift check for stale pages
+demo recording assets (#105) — docs/demo.sh + docs/recording.md +
+  docs/demo.gif rendered via asciinema + agg
+```
+
+## Month 7.6 — Per-rule settings + more docs rules (v0.12) [shipped]
+
+Goal:
+
+> Make rules tunable without monkey-patching; close the docs.* tail.
+
+Shipped:
+
+```text
+per-rule settings in hasscheck.yaml (#117) — RuleOverride.settings
+  + ProjectContext.rule_settings + get_rule_setting helper; wires
+  #109 maintenance thresholds
+four more docs.*.exists rules (#102) — examples, supported_devices,
+  limitations, hacs_instructions
+diagnostics field cleanup (#106) — drop dead imports_async_redact;
+  lock conservative "call required" PASS stance
+```
+
+## Month 8 — Pre-v1.0 polish (v0.13.x) [in progress]
+
+Goal:
+
+> Close the v1.0 review punch list. Make the launch surface coherent.
 
 Sequenced deliverables:
 
 ```text
-hasscheck.io launches alongside repo public flip
-PyPI trusted publishing (#15)
-manifest.requirements sanity rule (#100)
-config_flow advanced — reauth / reconfigure / duplicate prevention /
-  connection testing (#101)
-modern HA pattern checks — async_setup_entry, runtime_data,
-  unique_id, has_entity_name, device_info (#107)
+fix(action) — badge step .venv/bin/python bug (#128) [shipped]
+docs(readme) — sync Current status to v0.12.0 reality (#129)
+feat(schema) — optional report.provenance block, schema 0.3.0 → 0.4.0 (#130)
+feat(cli) — hasscheck publish --dry-run (#131)
+docs — Upgrade Radar v1.0 positioning + ADR 0010 status taxonomy (#132)
+PyPI trusted publishing (#15) — depends on repo public flip
 ```
 
-Stretch (v0.10.x — pick by signal once public):
-
-```text
-more README content rules (#102, #103)
-auto-generate per-rule docs from RuleDefinition metadata (#104)
-demo terminal recording (#105)
-imports_async_redact PASS resolution decision (#106)
-integration test detection rules (#108)
-maintenance signal rules (#109)
-```
-
-## Month 8+ — Opt-in hub (v1.0) [planned]
+## Month 9+ — Opt-in hub with verified Upgrade Radar (v1.0) [planned]
 
 Goal:
 
-> Discovery only from voluntarily published reports. No public scoring.
+> Discovery from voluntarily published reports. Verified by GitHub OIDC.
+> No public scoring.
+
+The v1.0 narrative is **HassCheck Upgrade Radar — verified upgrade-readiness
+signals for Home Assistant custom integrations.** The hub answers the user
+question: *"Can I trust this integration enough before I install or upgrade?"*
 
 Deliverables:
 
 ```text
-hub-verified badges — server-side rule re-execution (#67) replaces
-  self-reported committed badge JSON
+Upgrade Radar status taxonomy — Fresh / Warnings / Failing / Stale /
+  Unverified, computed server-side from latest verified report
+OIDC verified provenance display on every report page (commit SHA,
+  ref, run id, ruleset, tool version)
+hub-verified badges — server-generated from latest verified report,
+  replacing self-reported committed badge JSON (#67)
 project profiles + report directory (read-only)
-search and filters
-no default ranking by score
+search, sorted by published_at DESC, no score ranking
 schema bump policy enforced via ADR 0009 (lockstep with hasscheck-web)
 ```
 
 The hub becomes useful only after enough voluntary publish events from
-real maintainers. Distribution (Month 7) gates this — v1.0 cannot start
-without v0.10 community signal.
+real maintainers. Distribution (PyPI #15 + repo public flip) gates this —
+v1.0 cannot start without community signal.
 
 ---
 


### PR DESCRIPTION
## Summary

Pre-launch P0 docs fix surfaced by the v1.0 review. README's "Current status" block was three minor releases behind reality (said v0.9.0 latest / v0.10 in-progress; package is v0.12.0). Same drift on \`idea.md\` ladder + roadmap.

Closes #129.

## Changes

### \`README.md\`

- **Current status** block rewritten to reflect v0.12.0 reality: 52 rules, per-rule settings, auto-generated rule docs, hub at hasscheck.io operational.
- **GitHub Action @v0.9.0 pins** bumped to **@v0.12.0** (active examples on lines 85 and 127). Historical "v0.x.0 includes:" prose, if any, preserved.
- **emit-publish callout** rewritten — was "hasscheck.io launches alongside the public release" (no longer true; hub is live), now states the hub is operational, OIDC repository-claim validation happens at ingest, and the local CLI without \`emit-publish\` is still the recommended starting point.

### \`idea.md\`

- **Implementation status note** refreshed: latest \`v0.12.0\`, in-progress pre-v1.0 polish (#128–#132), hasscheck.io live.
- **Section 3 (Product ladder)** gains rungs for v0.10, v0.11, v0.12 (all \`[shipped]\`), an explicit v0.13.x \`[in progress]\` for the v1.0 review punch list, and a sharpened v1.0 entry referencing Upgrade Radar positioning + verified provenance display + OIDC validation.
- **Section 15 (Roadmap)** adds Month 7 (v0.10), Month 7.5 (v0.11), Month 7.6 (v0.12), Month 8 (v0.13.x), and rewrites the original Month 6+ hub entry as Month 9+ with the Upgrade Radar narrative locked in.

## Test plan

- [x] \`uv run pytest -q\` — **824 passing**, zero changes (docs-only PR)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run hasscheck docs-render --check\` — "OK: all rule docs are up to date"
- [x] \`rg "@v0\\.[0-9]+\\.0" README.md\` — only \`@v0.12.0\` appears in active examples
- [x] No "certify / approved / safe / quality tier" language introduced

## Notes

- This PR doesn't change strategy. It documents the strategy that already happened.
- Sister PR **#133** (#128 fix) shipped the action.yml \`.venv\` fix that this status bump now correctly references.
- The remaining v1.0 review issues (#130 schema provenance, #131 publish --dry-run, #132 Upgrade Radar positioning + ADR 0010) are P1 and live as separate issues for v0.13.x sequencing.

## What's next post-merge

Both P0 launch blockers cleared (#128 + #129). Next sequence:

1. v0.13 cycle — pick from #130, #131, #132 in any order (they don't block each other)
2. **Repo public flip** (user action) — README + action.yml + LICENSE + COC + CONTRIBUTING + demo all in coherent state for first-time visitors
3. **#15 PyPI publish** — depends on flip
4. **v1.0.0 tag** — after PyPI + Upgrade Radar pieces land or with explicit "self-reported badges, hub-verified coming" framing