### PR TITLE
feat(schema): add optional report.provenance block; bump schema 0.3.0 → 0.4.0 (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`report.provenance` block** in JSON report schema (#130). New optional `Provenance` model carries GitHub Actions context (`source`, `repository`, `commit_sha`, `ref`, `workflow`, `run_id`, `run_attempt`, `actor`, `published_at`, `verified_by`). CLI populates from `GITHUB_*` env vars when running in GitHub Actions; sets `source: "local"` otherwise. `verified_by` is always `null` from the CLI — only the hosted hub sets this after OIDC validation.
+- **Schema bump**: `schema_version` `0.3.0` → `0.4.0` (additive per ADR 0009). Reports without a `provenance` key remain valid (field defaults to `null`).
+
 ## [0.12.0] — 2026-05-02
 
 ### Added

--- a/docs/decisions/0010-provenance-block.md
+++ b/docs/decisions/0010-provenance-block.md
@@ -1,0 +1,93 @@
+# ADR 0010 — Provenance block: `report.provenance`, `verified_by` convention, schema 0.4.0
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Tag**: v0.13.x (#130)
+
+## Context
+
+The hosted hub (`hasscheck-web`) will display a public "OIDC-verified provenance"
+badge in v1.0. Before launch, the report shape must distinguish between:
+
+- A **self-claimed** provenance (set by the CLI from `GITHUB_*` env vars — anyone
+  can fabricate these)
+- A **verified** provenance (attested by `hasscheck-web` after validating the
+  GitHub OIDC token presented at publish time)
+
+Without this distinction, users cannot tell whether a published report's
+provenance was independently verified or simply self-reported by the publisher.
+
+Additionally, CI users want to correlate a report back to the exact run
+(repository, SHA, ref, workflow, run ID, attempt) that produced it. This is
+useful for debugging and auditing purposes, even without OIDC verification.
+
+## Decision
+
+1. **Schema 0.4.0** introduces an optional `report.provenance` block. The field
+   defaults to `null`, so all pre-v0.4.0 reports remain valid (additive per
+   ADR 0009).
+
+2. **The `Provenance` model** carries the following fields, all optional
+   (`T | None = None`):
+
+   | Field | Type | Set by CLI | Source |
+   |---|---|---|---|
+   | `source` | `"github_actions" \| "local" \| None` | yes | `GITHUB_ACTIONS` env var |
+   | `repository` | `str \| None` | yes | `GITHUB_REPOSITORY` |
+   | `commit_sha` | `str \| None` | yes | `GITHUB_SHA` |
+   | `ref` | `str \| None` | yes | `GITHUB_REF` |
+   | `workflow` | `str \| None` | yes | `GITHUB_WORKFLOW` |
+   | `run_id` | `str \| None` | yes | `GITHUB_RUN_ID` |
+   | `run_attempt` | `int \| None` | yes | `GITHUB_RUN_ATTEMPT` (coerced) |
+   | `actor` | `str \| None` | yes | `GITHUB_ACTOR` |
+   | `published_at` | `str \| None` | yes | UTC ISO-8601, set at report-build time |
+   | `verified_by` | `str \| None` | **NEVER** | hub-only writer |
+
+3. **The CLI MUST NOT set `verified_by`**. It is the exclusive writer right of
+   `hasscheck-web`, set only after validating the GitHub OIDC JWT presented at
+   publish time. The CLI leaves this field `null` always.
+
+   - `provenance` is the *claim* — any publisher can fill it in.
+   - `verified_by` is the *attestation* — only the hub can set it, and only after
+     OIDC validation succeeds.
+
+4. **`detect_provenance()`** in `src/hasscheck/provenance.py` reads env vars:
+   - If `GITHUB_ACTIONS == "true"` → `source="github_actions"`, best-effort
+     population of all `GITHUB_*` fields; missing vars yield `None` (no error).
+   - Otherwise → `source="local"`, all env-derived fields `None`,
+     `published_at` set to current UTC time.
+   - `GITHUB_RUN_ATTEMPT` is coerced via `int(value)`; `ValueError` yields `None`
+     (forgiving boundary, strict model).
+
+5. **JSON serialization** keeps all fields including `null`-valued ones
+   (no `exclude_none=True`). A stable, predictable shape is preferred over a
+   sparse representation. "Field present, value unknown" ≠ "field never existed".
+   Aligns with ADR 0009 (additive versioning).
+
+6. **`verified_by` type is `str | None`**, not `Literal["hasscheck-web-oidc"] | None`.
+   Future hub versions may introduce new verifier identifiers (e.g.,
+   `"hasscheck-web-oidc-v2"`); the CLI should not gate the hub's vocabulary.
+   Trust boundary is enforced by *writer identity*, not by the type system.
+
+## Consequences
+
+- **SCHEMA_VERSION bump**: `0.3.0` → `0.4.0` in `src/hasscheck/models.py`.
+- **`config.py` Literal** widened to `"0.2.0" | "0.3.0" | "0.4.0"`. Default
+  changed to `"0.4.0"`.
+- **Lockstep release gate**: `hasscheck-web` MUST accept schema `0.4.0`
+  (with optional `provenance`) BEFORE the OSS v0.13.x tag ships. Shipping OSS
+  first risks rejecting publishes from early upgraders.
+- **Branch-name leakage via `ref`**: already public in GitHub Actions logs;
+  `hasscheck.yaml`-based publish is opt-in. Accepted risk.
+- **Future CI providers** (GitLab CI, CircleCI, etc.) will be added in future
+  minor schema bumps (additive per ADR 0009). `source` stays
+  `"github_actions" | "local" | None` in v0.4.0.
+- Non-GH-Actions runs always produce `source="local"` with `published_at` set.
+
+## Related
+
+- ADR 0008 — Hosted reports publish contract (transport + auth)
+- ADR 0009 — Schema versioning policy (additive bump rule)
+- Issue #130 — Provenance block implementation
+- Issue #131 — `publish --dry-run` (references this ADR)
+- Issue #132 — Upgrade Radar (references this ADR)

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -13,6 +13,7 @@ from hasscheck.models import (
     ReportSummary,
     RuleStatus,
 )
+from hasscheck.provenance import detect_provenance
 from hasscheck.rules.registry import RULES
 from hasscheck.slug import detect_repo_slug
 
@@ -128,4 +129,5 @@ def run_check(
             applicability_applied=applicability_applied,
         ),
         findings=findings,
+        provenance=detect_provenance(),
     )

--- a/src/hasscheck/config.py
+++ b/src/hasscheck/config.py
@@ -49,7 +49,7 @@ class PublishConfig(BaseModel):
 class HassCheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0", "0.3.0"] = "0.3.0"
+    schema_version: Literal["0.2.0", "0.3.0", "0.4.0"] = "0.4.0"
     project: ProjectConfig | None = None
     applicability: ProjectApplicability | None = None
     rules: dict[str, RuleOverride] = Field(default_factory=dict)

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from hasscheck import __version__
 
-SCHEMA_VERSION = "0.3.0"
+SCHEMA_VERSION = "0.4.0"
 # See docs/decisions/0006-ruleset-versioning.md for bump policy.
 DEFAULT_RULESET_ID = "hasscheck-ha-2026.5"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
@@ -147,6 +147,19 @@ class RulesetInfo(BaseModel):
     source_checked_at: str = DEFAULT_SOURCE_CHECKED_AT
 
 
+class Provenance(BaseModel):
+    source: Literal["github_actions", "local"] | None = None
+    repository: str | None = None
+    commit_sha: str | None = None
+    ref: str | None = None
+    workflow: str | None = None
+    run_id: str | None = None
+    run_attempt: int | None = None
+    actor: str | None = None
+    published_at: str | None = None  # ISO-8601 UTC
+    verified_by: str | None = None  # ALWAYS None from CLI; hub sets this after OIDC
+
+
 class HassCheckReport(BaseModel):
     schema_version: str = SCHEMA_VERSION
     tool: ToolInfo = Field(default_factory=ToolInfo)
@@ -154,6 +167,7 @@ class HassCheckReport(BaseModel):
     ruleset: RulesetInfo = Field(default_factory=RulesetInfo)
     summary: ReportSummary
     findings: list[Finding]
+    provenance: Provenance | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         return self.model_dump(mode="json")

--- a/src/hasscheck/provenance.py
+++ b/src/hasscheck/provenance.py
@@ -1,0 +1,53 @@
+"""Provenance detection for hasscheck reports.
+
+Reads GitHub Actions environment variables (or falls back to "local") and
+returns a populated :class:`~hasscheck.models.Provenance` instance.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+from hasscheck.models import Provenance
+
+
+def detect_provenance(now: datetime | None = None) -> Provenance:
+    """Detect the execution context and return a :class:`Provenance` instance.
+
+    Args:
+        now: Optional datetime to use as ``published_at``. Defaults to
+             ``datetime.now(timezone.utc)``. Inject a fixed value in tests for
+             deterministic assertions.
+
+    Returns:
+        A :class:`Provenance` populated from environment variables.
+        ``verified_by`` is always ``None`` — only the hosted hub sets that field
+        after OIDC validation.
+    """
+    _now = now or datetime.now(UTC)
+    published_at = _now.isoformat()
+
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return Provenance(source="local", published_at=published_at)
+
+    run_attempt: int | None = None
+    raw = os.environ.get("GITHUB_RUN_ATTEMPT")
+    if raw is not None:
+        try:
+            run_attempt = int(raw)
+        except ValueError:
+            pass
+
+    return Provenance(
+        source="github_actions",
+        repository=os.environ.get("GITHUB_REPOSITORY"),
+        commit_sha=os.environ.get("GITHUB_SHA"),
+        ref=os.environ.get("GITHUB_REF"),
+        workflow=os.environ.get("GITHUB_WORKFLOW"),
+        run_id=os.environ.get("GITHUB_RUN_ID"),
+        run_attempt=run_attempt,
+        actor=os.environ.get("GITHUB_ACTOR"),
+        published_at=published_at,
+        verified_by=None,
+    )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -94,9 +94,9 @@ def test_run_check_no_yaml_overrides_applied_is_empty(tmp_path) -> None:
     assert report.summary.overrides_applied.rule_ids == []
 
 
-def test_run_check_schema_version_is_0_3_0(tmp_path) -> None:
+def test_run_check_schema_version_is_0_4_0(tmp_path) -> None:
     report = run_check(tmp_path)
-    assert report.schema_version == "0.3.0"
+    assert report.schema_version == "0.4.0"
 
 
 # ---------- v0.8: Ruleset ID bump ----------
@@ -106,3 +106,24 @@ def test_default_ruleset_id_is_hasscheck_ha_2026_5() -> None:
     from hasscheck.models import DEFAULT_RULESET_ID
 
     assert DEFAULT_RULESET_ID == "hasscheck-ha-2026.5"
+
+
+# ---------- v0.13: Provenance block (#130) ----------
+
+
+def test_run_check_report_provenance_key_present(tmp_path) -> None:
+    """Round-trip: run_check → to_json_dict → parse → 'provenance' key present."""
+    import json
+
+    report = run_check(tmp_path)
+    raw = report.to_json_dict()
+    reparsed = json.loads(json.dumps(raw))
+
+    assert "provenance" in reparsed
+    assert reparsed["schema_version"] == "0.4.0"
+
+
+def test_run_check_report_provenance_is_not_none(tmp_path) -> None:
+    """run_check() populates provenance on the returned report."""
+    report = run_check(tmp_path)
+    assert report.provenance is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_check_json_outputs_report(tmp_path) -> None:
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "0.3.0"
+    assert payload["schema_version"] == "0.4.0"
     assert payload["summary"]["security_review"] == "not_performed"
     assert payload["summary"]["official_ha_tier"] == "not_assigned"
     assert payload["summary"]["hacs_acceptance"] == "not_guaranteed"
@@ -243,7 +243,7 @@ def test_format_json_shortflag_outputs_json(tmp_path) -> None:
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "0.3.0"
+    assert payload["schema_version"] == "0.4.0"
 
 
 # ---------- Exit code behaviour ----------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ def test_project_config_rejects_extra_fields() -> None:
 
 def test_hasscheck_config_empty_defaults() -> None:
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.3.0"
+    assert cfg.schema_version == "0.4.0"
     assert cfg.project is None
     assert cfg.applicability is None
     assert cfg.rules == {}
@@ -515,7 +515,7 @@ def test_hasscheck_config_accepts_applicability_block() -> None:
         applicability=ProjectApplicability(supports_diagnostics=False)
     )
 
-    assert cfg.schema_version == "0.3.0"
+    assert cfg.schema_version == "0.4.0"
     assert cfg.applicability is not None
     assert cfg.applicability.supports_diagnostics is False
 
@@ -636,3 +636,37 @@ def test_load_config_file_v03_backward_compat_no_publish(tmp_path: Path) -> None
     cfg = load_config_file(tmp_path / "hasscheck.yaml")
     assert cfg.schema_version == "0.3.0"
     assert cfg.publish is None
+
+
+# ---------- v0.13: Schema version 0.4.0 (#130) ----------
+
+
+def test_hasscheck_config_default_schema_version_is_0_4_0() -> None:
+    """Default instantiation yields schema_version 0.4.0."""
+    cfg = HassCheckConfig()
+    assert cfg.schema_version == "0.4.0"
+
+
+def test_hasscheck_config_accepts_explicit_0_4_0() -> None:
+    """Explicit schema_version='0.4.0' parses without error."""
+    cfg = HassCheckConfig(schema_version="0.4.0")
+    assert cfg.schema_version == "0.4.0"
+
+
+def test_hasscheck_config_0_3_0_still_accepted() -> None:
+    """Legacy schema_version='0.3.0' is still accepted (Literal widened, not narrowed)."""
+    cfg = HassCheckConfig(schema_version="0.3.0")
+    assert cfg.schema_version == "0.3.0"
+
+
+def test_hasscheck_config_0_2_0_still_accepted() -> None:
+    """Legacy schema_version='0.2.0' is still accepted."""
+    cfg = HassCheckConfig(schema_version="0.2.0")
+    assert cfg.schema_version == "0.2.0"
+
+
+def test_load_config_file_v04_schema_version(tmp_path: Path) -> None:
+    """Load a file with schema_version 0.4.0 succeeds."""
+    (tmp_path / "hasscheck.yaml").write_text("schema_version: '0.4.0'\n")
+    cfg = load_config_file(tmp_path / "hasscheck.yaml")
+    assert cfg.schema_version == "0.4.0"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,164 @@
+"""Tests for hasscheck.provenance — detect_provenance() detection logic.
+
+TDD order: all tests written RED before provenance.py exists.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from hasscheck.provenance import detect_provenance
+
+# ---------- 2.1 GitHub Actions: full context ----------
+
+
+def test_github_actions_full_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITHUB_ACTIONS=true + all GITHUB_* vars → source="github_actions", all fields set, verified_by None."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_SHA", "abc123def456")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "CI")
+    monkeypatch.setenv("GITHUB_RUN_ID", "9876543210")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
+    monkeypatch.setenv("GITHUB_ACTOR", "octocat")
+
+    result = detect_provenance()
+
+    assert result.source == "github_actions"
+    assert result.repository == "owner/repo"
+    assert result.commit_sha == "abc123def456"
+    assert result.ref == "refs/heads/main"
+    assert result.workflow == "CI"
+    assert result.run_id == "9876543210"
+    assert result.run_attempt == 1
+    assert result.actor == "octocat"
+    assert result.published_at is not None
+    assert result.verified_by is None
+
+
+# ---------- 2.2 Local context: no env vars ----------
+
+
+def test_local_context_no_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No GITHUB_ACTIONS → source="local", env fields None, published_at not None."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.delenv("GITHUB_WORKFLOW", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ATTEMPT", raising=False)
+    monkeypatch.delenv("GITHUB_ACTOR", raising=False)
+
+    result = detect_provenance()
+
+    assert result.source == "local"
+    assert result.repository is None
+    assert result.commit_sha is None
+    assert result.ref is None
+    assert result.workflow is None
+    assert result.run_id is None
+    assert result.run_attempt is None
+    assert result.actor is None
+    assert result.published_at is not None
+
+
+# ---------- 2.3 run_attempt coercion: string "2" → int 2 ----------
+
+
+def test_run_attempt_coercion_to_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITHUB_RUN_ATTEMPT="2" → run_attempt == 2 (int)."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+
+    result = detect_provenance()
+
+    assert result.run_attempt == 2
+    assert isinstance(result.run_attempt, int)
+
+
+# ---------- 2.4 run_attempt coercion: bad string → None, no exception ----------
+
+
+def test_run_attempt_bad_string_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITHUB_RUN_ATTEMPT="bad" → run_attempt is None, no exception raised."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "bad")
+
+    result = detect_provenance()
+
+    assert result.run_attempt is None
+
+
+# ---------- 2.5 Partial GitHub Actions context ----------
+
+
+def test_github_actions_partial_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITHUB_ACTIONS=true but some vars missing → best-effort, missing = None, no exception."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.delenv("GITHUB_WORKFLOW", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ATTEMPT", raising=False)
+    monkeypatch.delenv("GITHUB_ACTOR", raising=False)
+
+    result = detect_provenance()
+
+    assert result.source == "github_actions"
+    assert result.repository == "owner/repo"
+    assert result.commit_sha is None
+    assert result.ref is None
+    assert result.workflow is None
+    assert result.run_id is None
+    assert result.run_attempt is None
+    assert result.actor is None
+
+
+# ---------- 2.6 Injectable now parameter ----------
+
+
+def test_now_param_injectable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """inject explicit now → published_at matches injected datetime."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+    fixed_dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+    result = detect_provenance(now=fixed_dt)
+
+    assert result.published_at == fixed_dt.isoformat()
+
+
+def test_now_param_injectable_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """inject now in GitHub Actions context → published_at matches injected datetime."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
+
+    fixed_dt = datetime(2025, 6, 20, 8, 30, 0, tzinfo=UTC)
+    result = detect_provenance(now=fixed_dt)
+
+    assert result.published_at == fixed_dt.isoformat()
+
+
+# ---------- 2.7 verified_by always None ----------
+
+
+def test_verified_by_is_none_in_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """verified_by is None in GitHub Actions context."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    result = detect_provenance()
+
+    assert result.verified_by is None
+
+
+def test_verified_by_is_none_in_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """verified_by is None in local context."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+    result = detect_provenance()
+
+    assert result.verified_by is None

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -185,7 +185,7 @@ def test_publish_report_success(tmp_path, monkeypatch):
     assert captured["url"] == "https://hasscheck.io/api/reports"
     assert captured["auth"] == "Bearer tok-abc"
     assert captured["ua"].startswith("hasscheck/")
-    assert captured["body"]["schema_version"] == "0.3.0"
+    assert captured["body"]["schema_version"] == "0.4.0"
     assert captured["body"]["tool"]["name"] == "hasscheck"
 
 


### PR DESCRIPTION
## Summary

- Adds optional `provenance` block to `HassCheckReport` JSON schema — distinguishes CLI-generated from GitHub Actions OIDC-verified reports
- Bumps `SCHEMA_VERSION` `0.3.0` → `0.4.0` (additive per ADR 0009); reports without `provenance` key remain valid
- New `src/hasscheck/provenance.py`: `detect_provenance()` reads `GITHUB_*` env vars; sets `source="github_actions"` or `"local"`; `verified_by` is always `null` from CLI (hub sets it post-OIDC)
- ADR 0010 documents the CLI/hub trust boundary contract

## Test plan

- [ ] 840/840 tests pass (`pytest`)
- [ ] `test_provenance.py` — 9 tests: GH Actions context, local context, `run_attempt` coercion, malformed env, partial env, `published_at` injectable, `verified_by` always null
- [ ] Round-trip: `to_json_dict()` preserves `provenance` key with nulls (no `exclude_none`)
- [ ] Legacy compat: report without `provenance` key parses as `HassCheckReport` with `provenance=None`
- [ ] `"0.4.0"` accepted as valid `schema_version` in `hasscheck.yaml`

## Release gate

`hasscheck-web` must accept `schema_version: "0.4.0"` before this branch is tagged. See ADR 0010.

Closes #130