### PR TITLE
feat(cli): add hasscheck publish --dry-run (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`report.provenance` block** in JSON report schema (#130). New optional `Provenance` model carries GitHub Actions context (`source`, `repository`, `commit_sha`, `ref`, `workflow`, `run_id`, `run_attempt`, `actor`, `published_at`, `verified_by`). CLI populates from `GITHUB_*` env vars when running in GitHub Actions; sets `source: "local"` otherwise. `verified_by` is always `null` from the CLI — only the hosted hub sets this after OIDC validation.
 - **Schema bump**: `schema_version` `0.3.0` → `0.4.0` (additive per ADR 0009). Reports without a `provenance` key remain valid (field defaults to `null`).
+- **`hasscheck publish --dry-run`** (#131). Validates the publish path — runs the check, resolves the endpoint (showing which source won: `--to` flag / env var / `hasscheck.yaml` / default), detects OIDC token presence — without making any network request. Also works with `--withdraw` and `--withdraw-all` to preview what would be deleted.
 
 ## [0.12.0] — 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ jobs:
 
 > The hosted reports endpoint at `hasscheck.io` is operational. Publishing requires `permissions: id-token: write` on the workflow so HassCheck can mint a GitHub OIDC token; the hub validates the token's repository claim before accepting the report. The local CLI (without `emit-publish`) remains fully functional and is the recommended starting point if you don't want to publish.
 
+Before enabling `emit-publish` in your CI workflow, validate the publish path locally with `--dry-run`:
+
+```bash
+hasscheck publish --path . --dry-run
+# would publish report to: https://hasscheck.io
+#   - repo slug: owner/my-integration (from git remote)
+#   - schema_version: 0.4.0
+#   - ruleset: hasscheck-ha-2026.5
+#   - 52 rules evaluated, 3 findings
+#   - oidc token: not detected
+#   - endpoint resolved from: default
+#   - dry-run: no network request made
+```
+
+`--dry-run` runs the full check, resolves the endpoint and detects OIDC token availability — without making any network request. Use it to confirm your configuration before the first live publish.
+
 **Outputs:** `exit-code` — `0` when no FAIL findings, `1` when one or more FAIL findings.
 
 The action uploads `hasscheck-report.json` as a build artifact on every run.

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -18,8 +18,10 @@ from hasscheck.models import HassCheckReport, RuleStatus
 from hasscheck.output import print_terminal_report, report_to_json, report_to_md
 from hasscheck.publish import (
     PublishError,
+    detect_oidc_token,
     publish_report,
     resolve_endpoint,
+    resolve_endpoint_with_source,
     resolve_oidc_token,
     split_slug,
     withdraw_report,
@@ -257,6 +259,11 @@ def publish(
         "--force",
         help="Skip the withdraw confirmation prompt. Required in CI / non-TTY.",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Validate and preview without making any network request.",
+    ),
 ) -> None:
     """Opt-in upload of a HassCheck report to a hosted service.
 
@@ -269,6 +276,7 @@ def publish(
       hasscheck publish --path . --to https://my-host.example
       hasscheck publish --withdraw --report-id abc123
       hasscheck publish --withdraw-all
+      hasscheck publish --path . --dry-run
     """
     if withdraw and withdraw_all:
         typer.echo(
@@ -290,6 +298,53 @@ def publish(
     except ConfigError as exc:
         typer.echo(f"hasscheck: error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
+
+    if dry_run:
+        endpoint, endpoint_source = resolve_endpoint_with_source(to, config=cfg)
+        _, token_status = detect_oidc_token(oidc_token)
+
+        if withdraw or withdraw_all:
+            resolved_slug = slug or detect_repo_slug(path.resolve())
+            if resolved_slug is None:
+                typer.echo(
+                    "hasscheck: error: could not detect repo slug; pass --slug owner/repo.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            target_desc = (
+                f"report {report_id}"
+                if report_id
+                else f"all reports for {resolved_slug}"
+            )
+            typer.echo(f"would withdraw {target_desc} from: {endpoint}")
+            typer.echo(f"  - endpoint resolved from: {endpoint_source}")
+            typer.echo(f"  - oidc token: {token_status}")
+            typer.echo("  - dry-run: no network request made")
+            return
+
+        try:
+            report = run_check(path, config=cfg, no_config=no_config)
+        except ConfigError as exc:
+            typer.echo(f"hasscheck: error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+        detected_slug = (
+            slug or detect_repo_slug(path.resolve()) or "unknown (pass --slug)"
+        )
+        actionable = sum(
+            1
+            for f in report.findings
+            if f.status not in (RuleStatus.PASS, RuleStatus.NOT_APPLICABLE)
+        )
+        typer.echo(f"would publish report to: {endpoint}")
+        typer.echo(f"  - repo slug: {detected_slug}")
+        typer.echo(f"  - schema_version: {report.schema_version}")
+        typer.echo(f"  - ruleset: {report.ruleset.id}")
+        typer.echo(f"  - {len(report.findings)} rules evaluated, {actionable} findings")
+        typer.echo(f"  - oidc token: {token_status}")
+        typer.echo(f"  - endpoint resolved from: {endpoint_source}")
+        typer.echo("  - dry-run: no network request made")
+        return
 
     try:
         endpoint = resolve_endpoint(to, config=cfg)

--- a/src/hasscheck/publish.py
+++ b/src/hasscheck/publish.py
@@ -58,6 +58,25 @@ class PublishResult:
     schema_version: str
 
 
+def resolve_endpoint_with_source(
+    cli_value: str | None,
+    *,
+    config: HassCheckConfig | None = None,
+) -> tuple[str, str]:
+    """Resolve publish endpoint and return (endpoint, source_label).
+
+    Precedence: CLI flag > $HASSCHECK_PUBLISH_ENDPOINT > config.publish.endpoint > DEFAULT_ENDPOINT.
+    """
+    if cli_value:
+        return cli_value.rstrip("/"), "--to flag"
+    env_value = os.environ.get(ENDPOINT_ENV_VAR)
+    if env_value:
+        return env_value.rstrip("/"), f"${ENDPOINT_ENV_VAR}"
+    if config is not None and config.publish is not None and config.publish.endpoint:
+        return config.publish.endpoint.rstrip("/"), "hasscheck.yaml"
+    return DEFAULT_ENDPOINT, "default"
+
+
 def resolve_endpoint(
     cli_value: str | None,
     *,
@@ -67,14 +86,8 @@ def resolve_endpoint(
 
     Precedence: CLI flag > $HASSCHECK_PUBLISH_ENDPOINT > config.publish.endpoint > DEFAULT_ENDPOINT.
     """
-    if cli_value:
-        return cli_value.rstrip("/")
-    env_value = os.environ.get(ENDPOINT_ENV_VAR)
-    if env_value:
-        return env_value.rstrip("/")
-    if config is not None and config.publish is not None and config.publish.endpoint:
-        return config.publish.endpoint.rstrip("/")
-    return DEFAULT_ENDPOINT
+    endpoint, _ = resolve_endpoint_with_source(cli_value, config=config)
+    return endpoint
 
 
 def resolve_oidc_token(cli_value: str | None) -> str:
@@ -88,6 +101,19 @@ def resolve_oidc_token(cli_value: str | None) -> str:
         "no OIDC token available — pass --oidc-token or set "
         f"{OIDC_TOKEN_ENV_VAR}. Publishing requires GitHub Actions OIDC."
     )
+
+
+def detect_oidc_token(cli_value: str | None) -> tuple[str | None, str]:
+    """Detect OIDC token presence and source without raising.
+
+    Returns (token_or_None, source_label). Safe to call in dry-run contexts.
+    """
+    if cli_value:
+        return cli_value, "--oidc-token flag"
+    env_value = os.environ.get(OIDC_TOKEN_ENV_VAR)
+    if env_value:
+        return env_value, f"${OIDC_TOKEN_ENV_VAR}"
+    return None, "not detected"
 
 
 def _headers(oidc_token: str) -> dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -431,3 +431,130 @@ def test_init_default_cli_does_not_write_publish_workflow(tmp_path) -> None:
     workflow = tmp_path / ".github" / "workflows" / "hasscheck.yml"
     content = workflow.read_text()
     assert "emit-publish" not in content
+
+
+# ---------- publish --dry-run (v0.13) ----------
+
+
+def test_publish_dry_run_no_network_request(tmp_path, monkeypatch) -> None:
+    """--dry-run exits 0 and makes no HTTP requests."""
+    write_minimal_integration(tmp_path)
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+
+    http_called = []
+
+    def mock_post(*args, **kwargs):
+        http_called.append(True)
+
+    monkeypatch.setattr("httpx.Client.post", mock_post)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert not http_called
+    assert "dry-run: no network request made" in result.output
+
+
+def test_publish_dry_run_shows_endpoint(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+    monkeypatch.delenv("HASSCHECK_PUBLISH_ENDPOINT", raising=False)
+    write_minimal_integration(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "https://hasscheck.io" in result.output
+    assert "endpoint resolved from: default" in result.output
+
+
+def test_publish_dry_run_shows_endpoint_from_flag(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+    write_minimal_integration(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run", "--to", "https://my.host"],
+    )
+    assert result.exit_code == 0
+    assert "https://my.host" in result.output
+    assert "endpoint resolved from: --to flag" in result.output
+
+
+def test_publish_dry_run_token_not_detected(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+    write_minimal_integration(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "not detected" in result.output
+
+
+def test_publish_dry_run_token_detected_via_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HASSCHECK_OIDC_TOKEN", "tok123")
+    write_minimal_integration(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "$HASSCHECK_OIDC_TOKEN" in result.output
+
+
+def test_publish_dry_run_shows_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+    write_minimal_integration(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["publish", "--path", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "schema_version: 0.4.0" in result.output
+
+
+def test_publish_dry_run_withdraw_no_network(tmp_path, monkeypatch) -> None:
+    """--dry-run --withdraw shows what would be withdrawn, makes no DELETE."""
+    monkeypatch.delenv("HASSCHECK_OIDC_TOKEN", raising=False)
+    write_minimal_integration(tmp_path)
+
+    http_called = []
+
+    def mock_delete(*args, **kwargs):
+        http_called.append(True)
+
+    monkeypatch.setattr("httpx.Client.delete", mock_delete)
+
+    result = runner.invoke(
+        app,
+        [
+            "publish",
+            "--path",
+            str(tmp_path),
+            "--dry-run",
+            "--withdraw",
+            "--report-id",
+            "rep_abc",
+            "--slug",
+            "owner/repo",
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert not http_called
+    assert "dry-run: no network request made" in result.output
+    assert "rep_abc" in result.output
+
+
+def test_publish_dry_run_flag_registered() -> None:
+    cmd = get_command(app)
+    publish_cmd = cmd.commands["publish"]
+    dry_run_param = next((p for p in publish_cmd.params if p.name == "dry_run"), None)
+    assert dry_run_param is not None, "publish must declare a --dry-run option"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -321,3 +321,78 @@ def test_withdraw_raises_on_403():
                 client=client,
             )
     assert ex.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# resolve_endpoint_with_source + detect_oidc_token (--dry-run helpers)
+
+
+def test_resolve_endpoint_with_source_cli_flag(monkeypatch):
+    from hasscheck.publish import resolve_endpoint_with_source
+
+    monkeypatch.delenv(ENDPOINT_ENV_VAR, raising=False)
+    endpoint, source = resolve_endpoint_with_source("https://cli.example")
+    assert endpoint == "https://cli.example"
+    assert source == "--to flag"
+
+
+def test_resolve_endpoint_with_source_env(monkeypatch):
+    from hasscheck.publish import resolve_endpoint_with_source
+
+    monkeypatch.setenv(ENDPOINT_ENV_VAR, "https://env.example/")
+    endpoint, source = resolve_endpoint_with_source(None)
+    assert endpoint == "https://env.example"
+    assert source == f"${ENDPOINT_ENV_VAR}"
+
+
+def test_resolve_endpoint_with_source_config(monkeypatch):
+    from hasscheck.publish import resolve_endpoint_with_source
+
+    monkeypatch.delenv(ENDPOINT_ENV_VAR, raising=False)
+    cfg = _make_config_with_endpoint("https://cfg.example")
+    endpoint, source = resolve_endpoint_with_source(None, config=cfg)
+    assert endpoint == "https://cfg.example"
+    assert source == "hasscheck.yaml"
+
+
+def test_resolve_endpoint_with_source_default(monkeypatch):
+    from hasscheck.publish import resolve_endpoint_with_source
+
+    monkeypatch.delenv(ENDPOINT_ENV_VAR, raising=False)
+    endpoint, source = resolve_endpoint_with_source(None)
+    assert endpoint == DEFAULT_ENDPOINT
+    assert source == "default"
+
+
+def test_detect_oidc_token_cli_flag():
+    from hasscheck.publish import detect_oidc_token
+
+    token, source = detect_oidc_token("mytoken")
+    assert token == "mytoken"
+    assert source == "--oidc-token flag"
+
+
+def test_detect_oidc_token_env(monkeypatch):
+    from hasscheck.publish import detect_oidc_token
+
+    monkeypatch.setenv(OIDC_TOKEN_ENV_VAR, "envtoken")
+    token, source = detect_oidc_token(None)
+    assert token == "envtoken"
+    assert source == f"${OIDC_TOKEN_ENV_VAR}"
+
+
+def test_detect_oidc_token_not_detected(monkeypatch):
+    from hasscheck.publish import detect_oidc_token
+
+    monkeypatch.delenv(OIDC_TOKEN_ENV_VAR, raising=False)
+    token, source = detect_oidc_token(None)
+    assert token is None
+    assert source == "not detected"
+
+
+def test_detect_oidc_token_does_not_raise_when_missing(monkeypatch):
+    from hasscheck.publish import detect_oidc_token
+
+    monkeypatch.delenv(OIDC_TOKEN_ENV_VAR, raising=False)
+    # Must not raise MissingTokenError
+    detect_oidc_token(None)


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to `hasscheck publish` — validates the publish path without making any network request
- `resolve_endpoint_with_source()` exposes which tier resolved the endpoint (`--to` flag / `$HASSCHECK_PUBLISH_ENDPOINT` / `hasscheck.yaml` / default); `resolve_endpoint()` delegates to it (no behavior change)
- `detect_oidc_token()` returns presence/source without raising `MissingTokenError` — safe in dry-run context
- Works for `--withdraw` / `--withdraw-all` too: shows target, skips DELETE

## Test plan

- [ ] 856/856 tests pass (`pytest`)
- [ ] Dry-run: no HTTP calls made (monkeypatched `httpx.Client.post/delete`)
- [ ] Endpoint source shown correctly for all 4 tiers
- [ ] Token status: detected via env, via flag, not detected
- [ ] Withdraw dry-run: target displayed, no DELETE
- [ ] `--dry-run` flag registered on `publish` command

Closes #131