### PR TITLE
docs: Upgrade Radar v1.0 positioning + ADR 0011 status taxonomy (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`report.provenance` block** in JSON report schema (#130). New optional `Provenance` model carries GitHub Actions context (`source`, `repository`, `commit_sha`, `ref`, `workflow`, `run_id`, `run_attempt`, `actor`, `published_at`, `verified_by`). CLI populates from `GITHUB_*` env vars when running in GitHub Actions; sets `source: "local"` otherwise. `verified_by` is always `null` from the CLI — only the hosted hub sets this after OIDC validation.
 - **Schema bump**: `schema_version` `0.3.0` → `0.4.0` (additive per ADR 0009). Reports without a `provenance` key remain valid (field defaults to `null`).
 - **`hasscheck publish --dry-run`** (#131). Validates the publish path — runs the check, resolves the endpoint (showing which source won: `--to` flag / env var / `hasscheck.yaml` / default), detects OIDC token presence — without making any network request. Also works with `--withdraw` and `--withdraw-all` to preview what would be deleted.
+- **Upgrade Radar framing + ADR 0011** (#132). `idea.md` §1 gains a North star section positioning HassCheck as the upgrade-readiness signal for HA custom integrations. §3 v1.0 ladder entry and §15 Month 9+ goal updated accordingly. New `docs/decisions/0011-upgrade-radar-status-taxonomy.md` defines the five-state hub status model: Fresh / Warnings / Failing / Stale / Unverified, with calculation rules, window rationale, display contract, and CLI behaviour notes.
 
 ## [0.12.0] — 2026-05-02
 

--- a/docs/decisions/0011-upgrade-radar-status-taxonomy.md
+++ b/docs/decisions/0011-upgrade-radar-status-taxonomy.md
@@ -1,0 +1,113 @@
+# ADR 0011 — Upgrade Radar status taxonomy
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v1.0 hub positioning
+
+## Context
+
+Home Assistant's documentation explicitly states that custom integrations are
+community-maintained, not officially reviewed, not security-audited, and not
+supported by the Home Assistant project. Users who discover an integration
+through HACS have no standardised signal for "is this integration being
+maintained and does it pass basic quality checks right now?"
+
+HassCheck's hub (via ADR 0008) accepts opt-in published reports from
+maintainers who run the CLI in GitHub Actions with OIDC authentication. Each
+published report carries a `provenance` block (ADR 0010) that records which
+CI context produced it. This gives the hub a verified, time-stamped stream of
+quality snapshots per integration.
+
+Without a defined status model, a hub project page cannot answer the user
+question clearly:
+
+> "Can I trust this integration enough before I install or upgrade?"
+
+A single score invites arguments. A five-state taxonomy aligned to recency and
+finding severity is simpler to interpret and avoids false precision.
+
+## Decision
+
+### Status taxonomy
+
+Five states, computed server-side on the hub from the most recent
+hub-verified report for a given slug:
+
+| State | Label | Calculation rule |
+|-------|-------|-----------------|
+| `fresh` | Fresh | Latest report ≤ 30 days old AND no `fail` findings AND ruleset matches current default |
+| `warnings` | Warnings | Latest report ≤ 90 days old AND no `fail` findings AND ≥ 1 `warn` finding (or ruleset behind current) |
+| `failing` | Failing | Latest report has ≥ 1 `fail` finding (regardless of age) |
+| `stale` | Stale | Latest report > 90 days old AND no `fail` findings |
+| `unverified` | Unverified | No hub-verified report ever published for this slug |
+
+Priority when multiple rules apply: `failing` > `stale` > `warnings` > `fresh`.
+`unverified` applies only when no record exists at all.
+
+### Window rationale
+
+- **30 days** (`fresh` upper bound): one sprint cycle. An integration updated
+  within a month is demonstrably active.
+- **90 days** (`stale` lower bound): one quarter. Beyond this, the signal is
+  "this may be abandoned" regardless of historical pass state. The 30–90 day
+  window surfaces as `warnings` — active but not freshly verified.
+- These thresholds are initial best-guesses and SHOULD be tuned post-launch
+  with real data. They are hub configuration, not OSS constants — no
+  `SCHEMA_VERSION` bump is required to change them.
+
+### Display contract
+
+Hub project pages MUST:
+
+- Show the status label and the date of the latest verified report
+- Show the ruleset ID from that report (`hasscheck-ha-2026.5` etc.)
+- Show finding counts (pass / warn / fail / not_applicable)
+- Link to the full report page
+
+Hub project pages MUST NOT:
+
+- Use language like "certified", "safe", "approved", "official", or
+  "HACS guaranteed"
+- Imply security review was performed
+- Imply compatibility with any specific HA version
+- Display a numeric score as the primary signal
+
+### CLI behaviour
+
+Status is computed server-side only. `hasscheck check` and
+`hasscheck publish --dry-run` do not display a radar status — they display
+raw finding counts. This is intentional: the radar status depends on recency
+(wall-clock time since last publish), which the CLI cannot compute without
+querying the hub.
+
+### `verified_by` contract
+
+Per ADR 0010: the `provenance.verified_by` field is set exclusively by the
+hub after OIDC validation passes. The CLI always emits `verified_by: null`.
+The radar status MUST only be derived from reports where
+`provenance.verified_by` is non-null. Self-reported local reports (uploaded
+without OIDC) result in `unverified`.
+
+## Consequences
+
+**Positive**:
+- Simple five-state model maps cleanly to a hub badge (`radar.json` endpoint
+  consumed by shields.io).
+- Maintainers have a clear action: publish a new report to move from `stale`
+  to `warnings` or `fresh`.
+- Users get a time-anchored signal without false precision.
+
+**Negative**:
+- Thresholds (30d / 90d) are best-guesses; will need tuning post-launch.
+- `stale` may mis-signal stable integrations that haven't needed changes —
+  the display label should clarify "last verified" rather than "abandoned".
+- Status calculation is hub-side only — cannot be reproduced locally from
+  the OSS CLI alone.
+
+## References
+
+- ADR 0008 — hosted reports publish contract
+- ADR 0010 — provenance block and `verified_by` contract
+- Issue #67 — hub-verified badges
+- Issue #132 — Upgrade Radar positioning and this ADR
+- hasscheck-web: radar card on project page (companion implementation issue)

--- a/idea.md
+++ b/idea.md
@@ -48,6 +48,21 @@ before the tool has earned trust.
 
 # 1. Product position
 
+## North star
+
+**HassCheck is the upgrade-readiness signal for Home Assistant custom integrations.**
+
+Not a linter.
+Not a directory.
+Not a score.
+Not certification.
+
+A verified, opt-in answer to:
+
+> "Can I trust this integration enough before I install or upgrade?"
+
+Home Assistant's docs state explicitly: custom integrations are community-maintained, not officially reviewed, not security-audited, and not supported by the Home Assistant project. That gap is real. HassCheck's hub fills it — not by certifying anything, but by surfacing **verified, opt-in, current** signals from maintainers who choose to publish.
+
 ## One-line pitch
 
 > HassCheck is an unofficial CLI that checks Home Assistant custom integration
@@ -176,14 +191,15 @@ v0.11   Test detection + maintenance signals + auto-generated     [shipped]
         per-rule docs + demo recording
 v0.12   Per-rule settings in hasscheck.yaml + four more docs.*    [shipped]
         rules + diagnostics field cleanup
-v0.13.x Pre-v1.0 polish: report.provenance schema field,          [in progress]
-        hasscheck publish --dry-run, action.yml + README
-        consistency, Upgrade Radar positioning + ADR 0010
-v1.0    Opt-in project hub with verified Upgrade Radar — discovery [planned]
-        from voluntarily published reports, OIDC-verified
-        provenance display, hub-generated badges replacing
-        self-reported committed JSON, status taxonomy
-        (Fresh / Warnings / Failing / Stale / Unverified)
+v0.13.x Pre-v1.0 polish: report.provenance schema field (#130),   [shipped]
+        hasscheck publish --dry-run (#131), Upgrade Radar
+        positioning + ADR 0011 status taxonomy (#132)
+v1.0    HassCheck Upgrade Radar — hub-verified upgrade-readiness   [planned]
+        signals for HA custom integrations. Discovery from
+        voluntarily published reports, OIDC-verified provenance
+        display, hub-generated badges, status taxonomy:
+        Fresh / Warnings / Failing / Stale / Unverified
+        (defined in ADR 0011)
 ```
 
 Each rung adds value the previous rung cannot deliver alone. The hub only
@@ -1070,22 +1086,23 @@ Goal:
 Sequenced deliverables:
 
 ```text
-fix(action) — badge step .venv/bin/python bug (#128) [shipped]
-docs(readme) — sync Current status to v0.12.0 reality (#129)
-feat(schema) — optional report.provenance block, schema 0.3.0 → 0.4.0 (#130)
-feat(cli) — hasscheck publish --dry-run (#131)
-docs — Upgrade Radar v1.0 positioning + ADR 0010 status taxonomy (#132)
-PyPI trusted publishing (#15) — depends on repo public flip
+fix(action) — badge step .venv/bin/python bug (#128)            [shipped]
+docs(readme) — sync Current status to v0.12.0 reality (#129)    [shipped]
+feat(schema) — optional report.provenance block, 0.3.0→0.4.0    [shipped]
+              (#130)
+feat(cli) — hasscheck publish --dry-run (#131)                   [shipped]
+docs — Upgrade Radar v1.0 positioning + ADR 0011 taxonomy (#132) [shipped]
+PyPI trusted publishing (#15) — depends on repo public flip      [planned]
 ```
 
-## Month 9+ — Opt-in hub with verified Upgrade Radar (v1.0) [planned]
+## Month 9+ — HassCheck Upgrade Radar hub (v1.0) [planned]
 
 Goal:
 
 > Discovery from voluntarily published reports. Verified by GitHub OIDC.
-> No public scoring.
+> No public scoring. No certification.
 
-The v1.0 narrative is **HassCheck Upgrade Radar — verified upgrade-readiness
+The v1.0 headline is **HassCheck Upgrade Radar — verified upgrade-readiness
 signals for Home Assistant custom integrations.** The hub answers the user
 question: *"Can I trust this integration enough before I install or upgrade?"*
 


### PR DESCRIPTION
## Summary

- `idea.md` §1 gains a **North star** section: HassCheck is the upgrade-readiness signal for HA custom integrations, not a linter/directory/score/certification
- `idea.md` §3 v1.0 ladder entry rewritten around Upgrade Radar headline; v0.13.x marked shipped
- `idea.md` §15 Month 9+ goal rewritten with Upgrade Radar framing
- New `docs/decisions/0011-upgrade-radar-status-taxonomy.md`: five-state hub status model with calculation rules, window rationale (30d/90d), display contract (no certification language), CLI behaviour note, `verified_by` contract

> **Note**: ADR is 0011, not 0010 as cited in the issue — 0010 was taken by the provenance-block ADR from #130.

## Test plan

- [ ] 856/856 tests pass (docs-only change)
- [ ] No "certify / approved / safe / quality tier" language in new content
- [ ] ADR 0011 follows style of ADR 0008/0009 (Status / Date / Tag, Context, Decision, Consequences, References)
- [ ] v1.0 ladder entry references ADR 0011 correctly

Closes #132