### PR TITLE
docs(154): Compatibility Claim Policy + ADR 0012

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ See [`docs/demo.md`](docs/demo.md) for the full walkthrough or
 
 HassCheck is intentionally not a replacement for hassfest and does not assign Home Assistant quality tiers. It provides maintainer-facing, sourced findings that help custom integration authors improve their repositories.
 
+HassCheck reports are **exact-build signals**, not blanket compatibility claims. Before consuming, summarising, or surfacing a HassCheck report anywhere downstream, read the [Compatibility Claim Policy](docs/compatibility-claim-policy.md) — it is the public wording contract that defines what a HassCheck verdict means and what inferences are forbidden. The rationale is recorded in [ADR 0012](docs/decisions/0012-compatibility-claim-policy.md).
+
 ## Current status
 
 **Current package version**: v0.13.0 — beta.

--- a/docs/compatibility-claim-policy.md
+++ b/docs/compatibility-claim-policy.md
@@ -1,0 +1,148 @@
+# Compatibility Claim Policy
+
+> **HassCheck compatibility reports are exact-build signals.**
+>
+> A report applies only to the integration version, commit SHA, Home Assistant
+> version, Python version, check mode, HassCheck version, and ruleset shown in
+> the report.
+>
+> Reports for older integration versions or older Home Assistant versions are
+> historical signals only. They do not imply compatibility for newer integration
+> or Home Assistant releases.
+
+This document is the public wording contract for every consumer of HassCheck
+output — the CLI, the GitHub Action, the hosted hub at
+[hasscheck.io](https://hasscheck.io), badges, dashboards, and any downstream
+tool that surfaces a HassCheck report. If you display, summarise, or link to a
+HassCheck report, follow the rules below.
+
+The rationale is recorded in
+[ADR 0012 — Compatibility claim policy](decisions/0012-compatibility-claim-policy.md).
+
+---
+
+## 1. The exact-build claim
+
+A HassCheck report is a **point-in-time signal about a specific build**. It is
+not a general statement about an integration. Every report carries the exact
+identity of what was checked:
+
+- The integration version (manifest `version`, git tag, or release identity)
+- The commit SHA
+- The Home Assistant version it was checked against (when populated by the
+  caller — see [Status taxonomy](#3-status-taxonomy))
+- The Python version of the runner
+- The HassCheck version and ruleset ID
+- The check mode (`local`, `ci-published`, or `server-verified` — see
+  [Trust levels](#5-trust-levels))
+
+A new commit, a new HA release, a new HassCheck version, or a different ruleset
+produces a **different report**. Older reports do not transfer.
+
+## 2. Wording rules
+
+When you talk about a report, use the language below. The bad examples are
+forbidden in HassCheck-owned surfaces (CLI output, hub UI, badges, official
+docs) and discouraged everywhere else.
+
+| | Phrase |
+|---|---|
+| Never | "Integration X is compatible with HA 2026.5" |
+| Never | "X works with HA 2026.5" |
+| Never | "X is HA 2026.5 ready" |
+| Always | "Version 2.5.0 was checked against HA 2026.5.1" |
+| Always | "Latest verified report for version 2.5.0 against HA 2026.5.1 has warnings" |
+| Always | "No verified report exists for version 1.3.0 against HA 2026.5.1" |
+| Always | "Version 2.5.0 last passed against HA 2026.5.1 on 2026-05-02" |
+
+The pattern is: **<integration version> was checked against <HA version> at
+<time> with <result>**. Never collapse it to "X is compatible with Y".
+
+## 3. Status taxonomy
+
+Every HassCheck consumer that surfaces a verdict for an `(integration version,
+HA version)` pair MUST use one of the labels below. No new labels, no
+synonyms.
+
+| Status | Meaning |
+|---|---|
+| `PASS` | Exact integration version checked against exact HA version recently. No failures, no warnings. |
+| `WARN` | Exact integration version checked against exact HA version, recommended-rule warnings found. |
+| `FAIL` | Exact integration version checked against exact HA version, required-rule failures found. |
+| `STALE` | Exact integration version checked against exact HA version, but report is older than 90 days. |
+| `SUPERSEDED` | This integration version passed, but newer integration versions exist. Latest version may differ. |
+| `NOT_CHECKED` | No report exists for this `(integration version, HA version)` pair. |
+| `UNKNOWN_VERSION` | Report exists but the integration version could not be determined from the report. |
+| `VERSION_MISMATCH` | Manifest `version`, git tag, or release identity do not agree for the same report. |
+
+`PASS`, `WARN`, and `FAIL` are produced directly by the HassCheck rules engine.
+The remaining statuses (`STALE`, `SUPERSEDED`, `NOT_CHECKED`, `UNKNOWN_VERSION`,
+`VERSION_MISMATCH`) are produced by the consumer (typically the hub) when it
+indexes reports across versions and time.
+
+## 4. Confidence levels
+
+When a consumer looks up the "best" report for an `(integration version, HA
+version)` pair and the exact match is missing, it MAY surface the nearest
+verified report — but only with an explicit confidence label.
+
+| Confidence | Meaning |
+|---|---|
+| `exact` | Same integration version, same HA version. |
+| `patch-nearby` | Same integration version, nearby HA patch version (same minor). |
+| `version-stale` | Same integration version, older HA version (different minor or major). |
+| `integration-superseded` | Older integration version checked, newer integration release exists. |
+| `unknown` | No useful verified report. |
+
+Anything below `exact` is a **navigation aid**, not a compatibility claim.
+Display the exact identity of what was actually checked — never paper over the
+mismatch.
+
+## 5. Trust levels
+
+HassCheck reports come from three execution contexts. Consumers MUST display
+the trust level prominently and MUST NOT treat lower levels as equivalent to
+higher levels.
+
+| Level | Meaning |
+|---|---|
+| `local` | Maintainer ran HassCheck locally. Self-reported. The publisher controls everything in the report. |
+| `ci-published` | GitHub Actions ran HassCheck and the hub verified repository identity via OIDC at publish time. The repo identity is attested; the report contents are not re-executed by the hub. |
+| `server-verified` | HassCheck Hub cloned the commit and re-ran the checks itself. The report contents are independently produced by the hub. |
+
+This matches the Three-Trust-Levels model. See ADR 0012 for the rationale and
+ADR 0010 for the OIDC verification mechanics that distinguish `local` from
+`ci-published`.
+
+## 6. Anti-inference rules
+
+The following inferences are **forbidden** in any HassCheck-owned surface and
+discouraged everywhere else. Each one is a wording trap that produces a false
+compatibility claim.
+
+> If version 2.5.0 passes HA 2026.5.1, you cannot conclude version 2.4.1
+> passes.
+
+> If version 1.3.0 passed HA 2025.4, you cannot conclude it passes HA 2026.5.
+
+> If version 2.4.1 passed HA 2026.5, you cannot conclude version 2.5.0
+> passes — even for tiny diffs — unless the diff is documented as
+> docs/metadata-only.
+
+> "Nearest verified report" is a navigation aid, not a compatibility claim.
+
+If you find yourself wanting to bridge two reports, stop. Surface both reports
+with their exact identities and let the reader make the call.
+
+---
+
+## Why this exists
+
+A HassCheck report that is summarised as "X is compatible with HA Y" is worse
+than no report at all: users trust it, integrations break under it, and the
+trust collapses across every report HassCheck has ever emitted. The wording
+rules above protect users from that failure mode by making the exact-build
+nature of every report inescapable in language.
+
+For the strategic and historical context, see
+[ADR 0012 — Compatibility claim policy](decisions/0012-compatibility-claim-policy.md).

--- a/docs/decisions/0012-compatibility-claim-policy.md
+++ b/docs/decisions/0012-compatibility-claim-policy.md
@@ -1,0 +1,156 @@
+# ADR 0012 — Compatibility claim policy: exact-build wording, status taxonomy, trust levels
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v0.13.x (#154)
+
+## Context
+
+HassCheck is about to start emitting compatibility claims tied to specific
+Home Assistant versions. The schema work in #141 (O1) introduces a `target`
+block carrying `ha_version` and related identity fields, and the smoke harness
+in O3 will exercise integrations against tagged HA versions to produce those
+reports at scale. Once those land, every consumer — the CLI, the hosted hub at
+[hasscheck.io](https://hasscheck.io), badges, the Upgrade Radar card, and any
+downstream dashboard — starts surfacing version-tagged verdicts.
+
+Without an explicit, public policy on what those verdicts mean, two failure
+modes are guaranteed:
+
+1. **Overclaiming**: a maintainer or automation reads "PASS for HA 2025.4" and
+   tells users their integration is "compatible with HA 2025.4" — when actually
+   the report applies only to one specific commit, integration version, Python
+   version, check mode, HassCheck version, and ruleset.
+2. **Underclaiming**: users dismiss valid signals because they don't understand
+   a `STALE` or `SUPERSEDED` label, or because a consumer invented its own
+   labels with different semantics.
+
+The external pre-launch agent review (May 2026) flagged the wording rule as
+the single most important contract HassCheck must publish before the first
+version-tagged report ships. Once a single downstream surface uses the words
+"compatible with HA X", that wording leaks across the ecosystem and is almost
+impossible to recall.
+
+The wording rule must precede emission. Not after. Not alongside.
+
+## Decision
+
+1. **HassCheck reports are exact-build signals.** A report applies only to the
+   integration version, commit SHA, HA version, Python version, check mode,
+   HassCheck version, and ruleset shown in the report. Reports for older
+   integration versions or older HA versions are historical signals only. They
+   do not imply compatibility for newer releases.
+
+2. **The wording contract is published as a top-level docs page**:
+   `docs/compatibility-claim-policy.md`. It is linked from the README's
+   "How HassCheck relates to other tools" section so that anyone evaluating
+   HassCheck encounters the wording rule before they encounter their first
+   report.
+
+3. **A canonical status taxonomy** is defined and frozen. Every consumer that
+   surfaces an `(integration version, HA version)` verdict MUST use one of:
+
+   `PASS`, `WARN`, `FAIL`, `STALE`, `SUPERSEDED`, `NOT_CHECKED`,
+   `UNKNOWN_VERSION`, `VERSION_MISMATCH`.
+
+   No synonyms, no new labels. Producer split:
+   - `PASS`, `WARN`, `FAIL` are produced by the rules engine.
+   - `STALE`, `SUPERSEDED`, `NOT_CHECKED`, `UNKNOWN_VERSION`,
+     `VERSION_MISMATCH` are produced by the consumer (typically the hub) when
+     it indexes reports across versions and time.
+
+   This taxonomy is **distinct from** the Upgrade Radar taxonomy in ADR 0011
+   (`fresh`, `warnings`, `failing`, `stale`, `unverified`). ADR 0011 governs
+   the hub's per-integration aggregate signal computed from the latest
+   hub-verified report. This ADR governs the per-`(integration version, HA
+   version)` verdict displayed alongside an exact-build report. Both
+   taxonomies coexist; the casing difference (UPPERCASE here vs. lowercase in
+   ADR 0011) is intentional and contractual — it makes the surface
+   unambiguous in code, in JSON, and in UI copy.
+
+4. **A canonical confidence taxonomy** is defined for fallback lookups:
+   `exact`, `patch-nearby`, `version-stale`, `integration-superseded`,
+   `unknown`. Anything below `exact` is a navigation aid, not a compatibility
+   claim. The exact identity of what was actually checked must always be
+   displayed alongside the fallback.
+
+5. **A canonical trust taxonomy** is adopted: `local`, `ci-published`,
+   `server-verified`. This is the Three-Trust-Levels model. It is a separate
+   axis from status and confidence. Lower trust levels MUST NOT be displayed
+   as equivalent to higher trust levels. The trust level distinction is
+   anchored in the OIDC mechanics from ADR 0010 (the hub's `verified_by`
+   write-right is what separates `local` from `ci-published`).
+
+6. **Anti-inference rules are part of the contract**, not a footnote. Forbidden
+   inferences include:
+   - "Version A passes HA X" → "Version A−1 passes HA X"
+   - "Version A passes HA X" → "Version A passes HA X+1"
+   - "Version A passes HA X" → "Version A+1 passes HA X" (even for tiny diffs)
+   - "Nearest verified report" → "compatibility claim"
+
+7. **The CLI report footer** SHOULD reference
+   `docs/compatibility-claim-policy.md` whenever the report carries a
+   populated `report.target.ha_version`. The footer is wired up in the same
+   change that introduces `report.target` (#141). Adding a dead-coded footer
+   in this ADR's change would either gate on a non-existent field or emit an
+   unconditional footer that exceeds what the schema currently supports —
+   neither is acceptable.
+
+8. **Hub UI surfaces** (Upgrade Radar card, badge endpoints, project pages)
+   MUST display a prominent banner or footer linking to this policy whenever
+   they show a version-tagged verdict. This is enforced by the hub side issue
+   tracked separately as W11.
+
+## Consequences
+
+- **Wording is locked before the first version-tagged report ships.** Any PR
+  that introduces "compatible with HA X" wording on a HassCheck-owned surface
+  MUST be rejected against this ADR.
+- **#141 (O1) inherits the CLI footer task.** The schema PR that introduces
+  `report.target.ha_version` is also responsible for emitting the policy-doc
+  footer. This ADR's change does not modify CLI rendering.
+- **Status taxonomy is frozen.** Adding a new status (e.g., `DEPRECATED`,
+  `UNVERIFIED`) requires a follow-up ADR. Consumers may not invent local
+  variants.
+- **Trust levels are frozen.** Adding a fourth trust level (e.g., a
+  third-party verifier) requires a follow-up ADR and almost certainly a
+  schema bump in the same vein as ADR 0010's `verified_by`.
+- **Hub coupling is loosened, not tightened.** The hub is free to evolve its
+  internal indexing and presentation, but the labels it surfaces are
+  contractual. A hub UI change that drops `STALE` or renames it to `OLD`
+  violates the contract.
+- **Translation guidance**: localised hub UIs MUST keep the canonical English
+  label visible alongside any translation, since the labels are part of the
+  contract and downstream tools may parse them.
+
+## Alternatives considered
+
+- **Wait until the first matrix ships before publishing the policy.** Rejected.
+  Wording rules must precede emission. Once the first "compatible with HA X"
+  phrase escapes into a release blog or social post, the contract is poisoned.
+- **Bury the policy in CHANGELOG or a release note.** Rejected. A release-note
+  contract is not a contract. It must be a top-level docs page linked from the
+  README.
+- **Skip the status taxonomy and define it later, alongside the matrix.**
+  Rejected. The taxonomy IS the wording rule. Without it, every consumer
+  invents its own labels and the contract fragments before it ships.
+- **Add an unconditional CLI footer now**, regardless of whether the report
+  has a target HA version. Rejected. Schema 0.4.0 has no `target` block;
+  emitting a "see compatibility-claim-policy.md" footer on reports that carry
+  no version-tagged verdict is misleading. The footer follows the schema
+  field that justifies it, which lands in #141.
+- **Add a dead-coded gated footer now** so #141 only has to flip a flag.
+  Rejected. Dead code rots, gates drift, and the wiring is small enough that
+  doing it in #141 is cleaner than splitting it across two PRs.
+
+## Related
+
+- ADR 0009 — Schema versioning policy (additive bump rule)
+- ADR 0010 — Provenance block (`verified_by` is the OIDC trust boundary that
+  separates `local` from `ci-published`)
+- ADR 0011 — Upgrade Radar status taxonomy (the per-integration aggregate
+  signal; distinct surface, distinct casing, distinct semantics)
+- Issue #141 — `report.target.ha_version` schema work (O1) and the CLI footer
+  that consumes this policy
+- Issue #154 — This ADR's source issue
+- Hub-side issue W11 — Hub UI banner referencing this policy


### PR DESCRIPTION
## Summary

Locks the public wording contract before #141 (O1 schema) emits version-tagged reports. Without this, "PASS for HA 2026.5" leaks downstream as "compatible with HA 2026.5" — exactly the failure mode HassCheck must avoid.

- `docs/compatibility-claim-policy.md` — exact-build claim, wording rules, status taxonomy (`PASS`/`WARN`/`FAIL`/`STALE`/`SUPERSEDED`/`NOT_CHECKED`/`UNKNOWN_VERSION`/`VERSION_MISMATCH`), confidence levels, three trust levels (`local`/`ci-published`/`server-verified`), anti-inference rules
- `docs/decisions/0012-compatibility-claim-policy.md` — rationale, alternatives considered, distinct from ADR 0011 (Upgrade Radar) by surface and casing
- `README.md` — link added in "How HassCheck relates to other tools" section

## Deviations from issue body

- **ADR numbered 0012, not 0011.** Collision: `0011-upgrade-radar-status-taxonomy.md` already exists (#132). ADR 0012 §3 documents the casing reconciliation (UPPERCASE here vs. lowercase in 0011 — different surfaces, both contractually frozen).
- **CLI report-footer wiring deferred to #141.** `report.target.ha_version` field doesn't exist yet (lands in #141 O1 schema). Adding a gated footer now would either be dead code or unconditional emission exceeding schema. ADR 0012 §7 documents the deferral; #141 inherits the wiring.
- **ADR path is `docs/decisions/`, not `docs/architecture/decisions/`.** Followed actual project layout.

## Test plan

- [x] `docs/compatibility-claim-policy.md` renders cleanly (markdown lint via pre-commit hooks)
- [x] `docs/decisions/0012-compatibility-claim-policy.md` matches the format of ADR 0009 / ADR 0010
- [x] README link points to the policy doc and ADR 0012
- [x] Cross-references inside the policy doc and ADR resolve to existing files
- [x] No collision with existing ADR 0011 (Upgrade Radar) — both files coexist, distinct scope
- [x] `pytest --collect-only` still collects 856 tests (no Python regression — pure docs change)
- [ ] Reviewer confirms wording on the "Never / Always" examples table

Closes #154