### PR TITLE
feat(147): expand RuleDefinition metadata (tags, profiles, version range, advisory_id, qs link, confidence, lifecycle)

### DIFF
--- a/src/hasscheck/docs_render.py
+++ b/src/hasscheck/docs_render.py
@@ -48,8 +48,52 @@ def render_page(rule: RuleDefinition) -> str:
         f"- {rule.source_url}",
         f"- `source_checked_at`: {rule.source.checked_at}",
         "",
-        _AUTOGEN_MARKER,
     ]
+
+    # --- Optional metadata sections (rendered only when non-default) ---
+    # Order: Tags, Confidence, Deprecated, Replacement
+    # Spec §4 + Design §5: profiles, advisory_id, related_quality_scale_rule deferred.
+
+    if rule.tags:
+        tag_list = ", ".join(f"`{t}`" for t in rule.tags)
+        lines += [
+            "## Tags",
+            "",
+            tag_list,
+            "",
+        ]
+
+    if rule.confidence != "high":
+        lines += [
+            "## Confidence",
+            "",
+            rule.confidence,
+            "",
+        ]
+
+    if rule.deprecated:
+        deprecation_lines = [
+            "## Deprecated",
+            "",
+            "> This rule is deprecated.",
+        ]
+        if rule.deprecated_in_version:
+            deprecation_lines += [
+                ">",
+                f"> Deprecated in version: {rule.deprecated_in_version}",
+            ]
+        deprecation_lines.append("")
+        lines += deprecation_lines
+
+    if rule.replacement_rule is not None:
+        lines += [
+            "## Replacement",
+            "",
+            f"See [{rule.replacement_rule}](./{rule.replacement_rule}.md).",
+            "",
+        ]
+
+    lines.append(_AUTOGEN_MARKER)
 
     return "\n".join(lines)
 

--- a/src/hasscheck/rules/base.py
+++ b/src/hasscheck/rules/base.py
@@ -76,7 +76,7 @@ class RuleDefinition:
     title: str
     why: str
     source_url: str
-    check: Callable[[ProjectContext], Finding]
+    check: Callable[[ProjectContext], Finding] = field(hash=False, compare=False)
     overridable: bool
 
     # --- optional metadata (new — appended AFTER overridable) ---

--- a/src/hasscheck/rules/base.py
+++ b/src/hasscheck/rules/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from hasscheck.config import ProjectApplicability
@@ -33,6 +33,42 @@ def get_rule_setting(
 
 @dataclass(frozen=True)
 class RuleDefinition:
+    """A single hasscheck rule with its check function and metadata.
+
+    Required fields (positional-safe, keyword-only in practice):
+        id, version, category, severity, title, why, source_url, check, overridable
+
+    Optional metadata fields (all have safe defaults; append AFTER overridable):
+        tags             — tuple[str, ...]; MUST be a tuple, not list/set (frozen dataclass).
+                           Raises TypeError in __post_init__ if a list or set is passed.
+        profiles         — tuple[str, ...]; same constraint as tags. Semantics deferred to O6.
+        min_ha_version   — minimum HA version string this rule applies to; None = all versions.
+        max_ha_version   — maximum HA version string this rule applies to; None = all versions.
+        introduced_by    — attribution string (e.g. author email); None = unknown/legacy.
+        introduced_at_version — hasscheck version when this rule was added; None = legacy.
+        advisory_id      — opaque advisory ID string; validation deferred to O4 / #155.
+        related_quality_scale_rule — opaque QS rule ID; validation deferred to O15.
+        confidence       — Literal["high", "medium", "low"]; validated eagerly in __post_init__.
+                           Raises ValueError if an unknown value is passed.
+                           Default "high" preserves semantics for all existing rules.
+        false_positive_notes — prose describing known false-positive scenarios; None = none known.
+        replacement_rule — ID of the rule that supersedes this one; cross-reference validated by
+                           registry-level contract test, NOT at construction time (chicken-and-egg
+                           with registration order).
+        deprecated       — True when this rule is retired; renders a deprecation notice in docs.
+        deprecated_in_version — hasscheck version when deprecated; only meaningful when deprecated=True.
+                               Logical constraint (requires deprecated=True) is deferred.
+
+    Deferred validations (NOT enforced in this PR):
+        - deprecated_in_version implies deprecated=True
+        - min_ha_version <= max_ha_version semver ordering
+        - advisory_id format or existence (O4)
+        - profiles string membership (O6)
+        - related_quality_scale_rule existence (O15)
+        - element types inside tags / profiles tuples
+    """
+
+    # --- required (existing — DO NOT REORDER) ---
     id: str
     version: str
     category: str
@@ -42,6 +78,44 @@ class RuleDefinition:
     source_url: str
     check: Callable[[ProjectContext], Finding]
     overridable: bool
+
+    # --- optional metadata (new — appended AFTER overridable) ---
+    tags: tuple[str, ...] = ()
+    profiles: tuple[str, ...] = ()
+    min_ha_version: str | None = None
+    max_ha_version: str | None = None
+    introduced_by: str | None = None
+    introduced_at_version: str | None = None
+    advisory_id: str | None = None
+    related_quality_scale_rule: str | None = None
+    confidence: Literal["high", "medium", "low"] = "high"
+    false_positive_notes: str | None = None
+    replacement_rule: str | None = None
+    deprecated: bool = False
+    deprecated_in_version: str | None = None
+
+    def __post_init__(self) -> None:
+        """Eager validation of collection types and confidence literal.
+
+        Frozen dataclasses do not validate Literal types natively. We check
+        explicitly here so that misconfigured rule definitions fail loudly at
+        the construction site rather than silently at hash-time or later.
+        """
+        if not isinstance(self.tags, tuple):
+            raise TypeError(
+                f"RuleDefinition.tags must be a tuple, got {type(self.tags).__name__}. "
+                f"Use tags=('x', 'y') not tags=['x', 'y'] (frozen dataclass requires hashable)."
+            )
+        if not isinstance(self.profiles, tuple):
+            raise TypeError(
+                f"RuleDefinition.profiles must be a tuple, got {type(self.profiles).__name__}. "
+                f"Use profiles=('x',) not profiles=['x']."
+            )
+        if self.confidence not in ("high", "medium", "low"):
+            raise ValueError(
+                f"RuleDefinition.confidence must be 'high', 'medium', or 'low'; "
+                f"got {self.confidence!r}."
+            )
 
     @property
     def source(self) -> RuleSource:

--- a/tests/test_docs_render.py
+++ b/tests/test_docs_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 from hasscheck.models import RuleSeverity
 from hasscheck.rules.base import RuleDefinition
@@ -22,6 +23,20 @@ def _make_rule(
     source_url: str = "https://example.com/docs",
     version: str = "1.0.0",
     overridable: bool = False,
+    # --- 13 new optional metadata fields ---
+    tags: tuple[str, ...] = (),
+    profiles: tuple[str, ...] = (),
+    min_ha_version: str | None = None,
+    max_ha_version: str | None = None,
+    introduced_by: str | None = None,
+    introduced_at_version: str | None = None,
+    advisory_id: str | None = None,
+    related_quality_scale_rule: str | None = None,
+    confidence: Literal["high", "medium", "low"] = "high",
+    false_positive_notes: str | None = None,
+    replacement_rule: str | None = None,
+    deprecated: bool = False,
+    deprecated_in_version: str | None = None,
 ) -> RuleDefinition:
     def _noop(ctx):  # pragma: no cover
         raise NotImplementedError
@@ -36,6 +51,19 @@ def _make_rule(
         source_url=source_url,
         check=_noop,
         overridable=overridable,
+        tags=tags,
+        profiles=profiles,
+        min_ha_version=min_ha_version,
+        max_ha_version=max_ha_version,
+        introduced_by=introduced_by,
+        introduced_at_version=introduced_at_version,
+        advisory_id=advisory_id,
+        related_quality_scale_rule=related_quality_scale_rule,
+        confidence=confidence,
+        false_positive_notes=false_positive_notes,
+        replacement_rule=replacement_rule,
+        deprecated=deprecated,
+        deprecated_in_version=deprecated_in_version,
     )
 
 
@@ -311,3 +339,63 @@ class TestCheckDrift:
         drift = check_drift(tmp_path)
 
         assert rule_id in drift
+
+
+# ---------------------------------------------------------------------------
+# Metadata rendering — new sections from #147
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataSectionsSkippedWhenDefault:
+    """Scenario 7 — all new fields at defaults → no metadata section headers emitted."""
+
+    def test_docs_render_skips_empty_metadata_sections(self) -> None:
+        from hasscheck.docs_render import render_page
+
+        rule = _make_rule()  # all new fields at defaults
+        output = render_page(rule)
+
+        assert "## Tags" not in output
+        assert "## Confidence" not in output
+        assert "## Deprecated" not in output
+        assert "## Replacement" not in output
+
+
+class TestMetadataSectionsEmittedWhenPopulated:
+    """Scenario 8 — non-default field values → metadata sections are rendered."""
+
+    def test_docs_render_emits_populated_metadata_sections(self) -> None:
+        from hasscheck.docs_render import render_page
+
+        rule = _make_rule(
+            tags=("ha-2026",),
+            deprecated=True,
+            replacement_rule="new.better.rule",
+            confidence="low",
+        )
+        output = render_page(rule)
+
+        assert "## Tags" in output
+        assert "ha-2026" in output
+        assert "## Confidence" in output
+        assert "low" in output
+        assert "## Deprecated" in output
+        assert "## Replacement" in output
+        assert "new.better.rule" in output
+
+
+class TestDocsRenderCheckPassesAfterFieldAddition:
+    """Scenario 9 — docs-render --check returns no drift after regeneration."""
+
+    def test_docs_render_check_passes_after_field_addition(
+        self, tmp_path: Path
+    ) -> None:
+        from hasscheck.docs_render import check_drift, render_all
+
+        render_all(tmp_path)
+        drift = check_drift(tmp_path)
+
+        assert drift == {}, (
+            f"Drift detected after render_all — renderer and docs are out of sync: "
+            f"{list(drift.keys())}"
+        )

--- a/tests/test_rule_definition_metadata.py
+++ b/tests/test_rule_definition_metadata.py
@@ -1,0 +1,114 @@
+"""Tests for new optional metadata fields on RuleDefinition — #147."""
+
+from __future__ import annotations
+
+import pytest
+
+from hasscheck.models import RuleSeverity
+from hasscheck.rules.base import RuleDefinition
+
+
+def _make_minimal_rule(**kwargs) -> RuleDefinition:
+    """Return a RuleDefinition with only the 9 original required fields."""
+
+    def _noop(ctx):  # pragma: no cover
+        raise NotImplementedError
+
+    defaults = dict(
+        id="test.rule",
+        version="1.0.0",
+        category="test",
+        severity=RuleSeverity.REQUIRED,
+        title="Test rule",
+        why="Because we test.",
+        source_url="https://example.com",
+        check=_noop,
+        overridable=False,
+    )
+    defaults.update(kwargs)
+    return RuleDefinition(**defaults)
+
+
+class TestRuleDefinitionAcceptsAllNewFields:
+    """Scenario 1 — construct with all 13 new fields at non-default values."""
+
+    def test_rule_definition_accepts_all_new_fields(self) -> None:
+        def _noop(ctx):  # pragma: no cover
+            raise NotImplementedError
+
+        rule = RuleDefinition(
+            id="test.full.fields",
+            version="2.0.0",
+            category="meta",
+            severity=RuleSeverity.REQUIRED,
+            title="Full fields rule",
+            why="To test all new metadata fields.",
+            source_url="https://example.com/full",
+            check=_noop,
+            overridable=True,
+            # --- 13 new optional fields ---
+            tags=("ha-2026", "cloud"),
+            profiles=("default", "strict"),
+            min_ha_version="2024.1",
+            max_ha_version="2025.12",
+            introduced_by="dev@example.com",
+            introduced_at_version="1.5.0",
+            advisory_id="GHSA-xxxx-yyyy-zzzz",
+            related_quality_scale_rule="some-quality-rule",
+            confidence="medium",
+            false_positive_notes="May trigger on edge case X.",
+            replacement_rule="new.better.rule",
+            deprecated=True,
+            deprecated_in_version="2.0.0",
+        )
+
+        assert rule.tags == ("ha-2026", "cloud")
+        assert rule.profiles == ("default", "strict")
+        assert rule.min_ha_version == "2024.1"
+        assert rule.max_ha_version == "2025.12"
+        assert rule.introduced_by == "dev@example.com"
+        assert rule.introduced_at_version == "1.5.0"
+        assert rule.advisory_id == "GHSA-xxxx-yyyy-zzzz"
+        assert rule.related_quality_scale_rule == "some-quality-rule"
+        assert rule.confidence == "medium"
+        assert rule.false_positive_notes == "May trigger on edge case X."
+        assert rule.replacement_rule == "new.better.rule"
+        assert rule.deprecated is True
+        assert rule.deprecated_in_version == "2.0.0"
+
+
+class TestRuleDefinitionDefaultsForNewFields:
+    """Scenario 2 — construct with only the 9 existing required fields; assert all 13 new fields equal their defaults."""
+
+    def test_rule_definition_defaults_for_new_fields(self) -> None:
+        rule = _make_minimal_rule()
+
+        assert rule.tags == ()
+        assert rule.profiles == ()
+        assert rule.min_ha_version is None
+        assert rule.max_ha_version is None
+        assert rule.introduced_by is None
+        assert rule.introduced_at_version is None
+        assert rule.advisory_id is None
+        assert rule.related_quality_scale_rule is None
+        assert rule.confidence == "high"
+        assert rule.false_positive_notes is None
+        assert rule.replacement_rule is None
+        assert rule.deprecated is False
+        assert rule.deprecated_in_version is None
+
+
+class TestRuleDefinitionCollectionFieldsRejectList:
+    """Scenario 3 — tags=list raises TypeError (eager D2 validation in __post_init__)."""
+
+    def test_rule_definition_collection_fields_reject_list(self) -> None:
+        with pytest.raises(TypeError):
+            _make_minimal_rule(tags=["x"])  # type: ignore[arg-type]
+
+
+class TestRuleDefinitionConfidenceRejectsInvalidLiteral:
+    """Scenario 4 — confidence='extreme' raises ValueError in __post_init__."""
+
+    def test_rule_definition_confidence_rejects_invalid_literal(self) -> None:
+        with pytest.raises(ValueError):
+            _make_minimal_rule(confidence="extreme")  # type: ignore[arg-type]

--- a/tests/test_rule_registry_contract.py
+++ b/tests/test_rule_registry_contract.py
@@ -1,0 +1,52 @@
+"""Registry-level contract tests for RuleDefinition metadata — #147."""
+
+from __future__ import annotations
+
+from hasscheck.rules.registry import RULES_BY_ID
+
+# ---------------------------------------------------------------------------
+# Task 2.1 — replacement_rule cross-reference contract
+# ---------------------------------------------------------------------------
+
+ANCHOR_ID = sorted(RULES_BY_ID.keys())[0]
+EXPECTED_HASH = 0  # placeholder — replaced in Task 2.3 GREEN phase
+
+
+def test_replacement_rule_must_reference_existing_id() -> None:
+    """Every non-None replacement_rule must point to an existing rule in RULES_BY_ID.
+
+    Passes vacuously when no rule has replacement_rule set (expected baseline
+    in this PR — no existing rule is deprecated yet).
+    """
+    dangling: list[tuple[str, str]] = []
+    for rule_id, rule in RULES_BY_ID.items():
+        if (
+            rule.replacement_rule is not None
+            and rule.replacement_rule not in RULES_BY_ID
+        ):
+            dangling.append((rule_id, rule.replacement_rule))
+    assert not dangling, f"replacement_rule references non-existent rule(s): {dangling}"
+
+
+# ---------------------------------------------------------------------------
+# Task 2.2 → 2.3 — hash-stability snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_existing_rule_hashes_stable() -> None:
+    """Hash of the alphabetically-first registered rule must stay stable post-PR.
+
+    The snapshot is captured once (Task 2.3 GREEN), hard-coded as EXPECTED_HASH,
+    and serves as a canary against future field reorderings or accidental
+    dataclass mutations that would silently break any consumer that interns
+    RuleDefinition in a set or dict.
+
+    If you intentionally change a field that affects the hash, update EXPECTED_HASH
+    and document why in your commit message.
+    """
+    rule = RULES_BY_ID[ANCHOR_ID]
+    assert hash(rule) == EXPECTED_HASH, (
+        f"Hash of {ANCHOR_ID!r} changed from {EXPECTED_HASH} to {hash(rule)}. "
+        f"This breaks any consumer that interns RuleDefinition. "
+        f"If intentional, update EXPECTED_HASH and document why in the commit."
+    )

--- a/tests/test_rule_registry_contract.py
+++ b/tests/test_rule_registry_contract.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
+
+from hasscheck.rules.base import RuleDefinition
 from hasscheck.rules.registry import RULES_BY_ID
 
 # ---------------------------------------------------------------------------
@@ -9,7 +12,34 @@ from hasscheck.rules.registry import RULES_BY_ID
 # ---------------------------------------------------------------------------
 
 ANCHOR_ID = sorted(RULES_BY_ID.keys())[0]
-EXPECTED_HASH = 0  # placeholder — replaced in Task 2.3 GREEN phase
+
+# Locked field ordering: any reorder/add/remove of fields in this sequence
+# changes the hash structure and breaks consumers that intern RuleDefinition.
+# `check` is excluded from hash/compare (field(hash=False, compare=False)).
+EXPECTED_HASHED_FIELD_NAMES: tuple[str, ...] = (
+    "id",
+    "version",
+    "category",
+    "severity",
+    "title",
+    "why",
+    "source_url",
+    # "check" — excluded from hash (callable, non-deterministic across processes)
+    "overridable",
+    "tags",
+    "profiles",
+    "min_ha_version",
+    "max_ha_version",
+    "introduced_by",
+    "introduced_at_version",
+    "advisory_id",
+    "related_quality_scale_rule",
+    "confidence",
+    "false_positive_notes",
+    "replacement_rule",
+    "deprecated",
+    "deprecated_in_version",
+)
 
 
 def test_replacement_rule_must_reference_existing_id() -> None:
@@ -29,24 +59,42 @@ def test_replacement_rule_must_reference_existing_id() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Task 2.2 → 2.3 — hash-stability snapshot
+# Task 2.2 → 2.3 — hash-stability anchor
 # ---------------------------------------------------------------------------
 
 
 def test_existing_rule_hashes_stable() -> None:
-    """Hash of the alphabetically-first registered rule must stay stable post-PR.
+    """Hash structure of RuleDefinition must remain stable post-PR.
 
-    The snapshot is captured once (Task 2.3 GREEN), hard-coded as EXPECTED_HASH,
-    and serves as a canary against future field reorderings or accidental
-    dataclass mutations that would silently break any consumer that interns
-    RuleDefinition in a set or dict.
+    Python's PYTHONHASHSEED randomises per-process hash values for strings and
+    other objects, making cross-process integer pinning unreliable without
+    constraining PYTHONHASHSEED in CI (an invasive change). Instead, we pin the
+    STRUCTURAL invariant: the exact sequence of fields that participate in the
+    hash computation (all fields where hash != False, in declaration order).
 
-    If you intentionally change a field that affects the hash, update EXPECTED_HASH
-    and document why in your commit message.
+    Any reordering, addition, or removal of hashed fields changes the hash
+    structure and would silently break consumers that intern RuleDefinition in
+    a set or dict-key position. This test catches that class of regression.
+
+    If you intentionally change which fields participate in hashing, update
+    EXPECTED_HASHED_FIELD_NAMES and document why in the commit message.
     """
-    rule = RULES_BY_ID[ANCHOR_ID]
-    assert hash(rule) == EXPECTED_HASH, (
-        f"Hash of {ANCHOR_ID!r} changed from {EXPECTED_HASH} to {hash(rule)}. "
-        f"This breaks any consumer that interns RuleDefinition. "
-        f"If intentional, update EXPECTED_HASH and document why in the commit."
+    actual_hashed = tuple(
+        f.name
+        for f in dataclasses.fields(RuleDefinition)
+        if f.hash is not False  # None means "inherit from compare" = True
+    )
+    assert actual_hashed == EXPECTED_HASHED_FIELD_NAMES, (
+        f"Hash-participating fields changed.\n"
+        f"Expected: {EXPECTED_HASHED_FIELD_NAMES}\n"
+        f"Actual:   {actual_hashed}\n"
+        "This breaks any consumer that interns RuleDefinition. "
+        "Update EXPECTED_HASHED_FIELD_NAMES and document why in the commit."
+    )
+
+    # Secondary check: the anchor rule is hashable and hashes consistently
+    # within the same process (verifies __post_init__ doesn't corrupt the object).
+    anchor_rule = RULES_BY_ID[ANCHOR_ID]
+    assert hash(anchor_rule) == hash(anchor_rule), (
+        f"hash({ANCHOR_ID!r}) is not idempotent — frozen dataclass invariant violated."
     )


### PR DESCRIPTION
## Summary

Adds 13 optional metadata fields to `RuleDefinition` so downstream consumers (Upgrade Radar #132, Profiles O6, QS mapping O15, advisories O4, hub filtering, replacement chains) read metadata instead of special-casing rules in code. Internal refactor — no `SCHEMA_VERSION` change, no JSON contract change, no ADR required.

## Fields added (all optional, backward-compatible defaults)

| Group | Fields |
|---|---|
| Categorization | `tags: tuple[str, ...] = ()`, `profiles: tuple[str, ...] = ()` |
| HA version range | `min_ha_version`, `max_ha_version` |
| Provenance / lineage | `introduced_by`, `introduced_at_version` |
| External links | `advisory_id`, `related_quality_scale_rule` |
| Quality / confidence | `confidence: Literal["high","medium","low"] = "high"`, `false_positive_notes` |
| Lifecycle | `replacement_rule`, `deprecated: bool = False`, `deprecated_in_version` |

Collection fields are `tuple[str, ...]` not `list[str]` — frozen dataclass requires hashable types. Eager `__post_init__` validation raises `TypeError` immediately if a `list` is passed (does not defer the failure to first `hash()` call).

## Validation scope

- ✅ `replacement_rule` cross-reference enforced at registry-level via new `tests/test_rule_registry_contract.py`
- ✅ `confidence` enforced by `Literal` + `__post_init__` (raises `ValueError` on invalid values)
- ✅ Hash-stability anchor: structural field-name tuple instead of pinned integer (PYTHONHASHSEED makes integer pinning impossible across processes; structural anchor is a stronger invariant — catches add/remove/reorder)
- ⏳ `advisory_id` validation deferred to O4 (advisories layer ships there)
- ⏳ `related_quality_scale_rule` validation deferred to O15 (QS mapping)
- ⏳ `profiles` runtime semantics deferred to O6 (profile selector)

## Docs renderer

`docs_render.render_page()` extended to surface 4 new sections when populated: `Tags`, `Confidence` (only when not `"high"`), `Deprecated`, `Replacement`. Empty / default values do NOT emit a section header. `docs-render --check` confirms zero drift across all 52 existing rule pages.

## Backward compatibility

- All 50+ existing rule constructors unmodified
- No rule module touched
- 856 → 865 tests (9 new), all passing
- `docs-render --check` exits 0

## SDD trail (engram)

- `sdd/147-rule-definition-metadata/proposal` (#461)
- `sdd/147-rule-definition-metadata/spec` (#462)
- `sdd/147-rule-definition-metadata/design` (#463)
- `sdd/147-rule-definition-metadata/tasks` (#464)
- `sdd/147-rule-definition-metadata/apply-progress` (#465)
- `sdd/147-rule-definition-metadata/verify-report` (#467) — 0 CRITICAL, 1 WARNING (hash-anchor structural-vs-integer, accepted), 1 SUGGESTION
- `sdd/147-rule-definition-metadata/archive-report` (#468)

## Test plan

- [x] `.venv/bin/python -m pytest -q` — 865 passed, exit 0
- [x] `.venv/bin/python -m hasscheck docs-render --check` — exit 0, no drift
- [x] All 6 commits GPG-signed (key `1ABF9EB6AF44A008`)
- [x] `__post_init__` raises `TypeError` on `tags=["x"]`, `ValueError` on `confidence="extreme"`
- [x] `replacement_rule` cross-ref test asserts every populated value resolves to a registered rule ID
- [ ] Reviewer confirms field ordering on `RuleDefinition` (optional-with-defaults appended after the 9 existing required fields)

Closes #147