### PR TITLE
feat(141): integration version identity + report.target + report.validity (schema 0.5.0)

### DIFF
--- a/docs/decisions/0013-integration-version-identity.md
+++ b/docs/decisions/0013-integration-version-identity.md
@@ -1,0 +1,164 @@
+# ADR 0013 — Integration version identity + ReportTarget + ReportValidity (schema 0.5.0)
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v0.14.x (#141)
+
+## Context
+
+HassCheck schema 0.4.0 (ADR 0009) captures the environment of a check run via
+the `provenance` block — CI context, commit SHA, repository — but carries no
+identity for the integration itself. A report today cannot answer: "Which
+version of this integration was checked?" or "Is this report still current?".
+That gap makes it impossible to build the hub's compatibility matrix, which
+requires pairing an integration version with a HA version and a check result.
+
+ADR 0012 locked the wording contract: HassCheck reports are exact-build
+signals, not general compatibility claims. To surface even the first version-
+tagged verdict, the hub needs the integration version, its source (how we
+detected it), and a validity window so stale reports can be identified without
+re-running the check. Currently, that data is not emitted.
+
+The integration version may come from several sources — the canonical
+`manifest.json["version"]` field, a git annotated tag when the manifest carries
+no version, a GitHub Actions `GITHUB_REF` pointing to a release tag, or HACS
+metadata in environments where HACS is installed. These sources have a natural
+priority order and must be collapsed into a single `(integration_version,
+integration_version_source)` pair with a frozen, deterministic tie-breaking
+rule.
+
+ADR 0012 §7 mandated a CLI footer referencing the compatibility claim policy
+whenever a report carries a populated `report.target.ha_version`. That
+requirement cannot be satisfied until a `target` block exists in the schema.
+This ADR delivers the block and wires the footer simultaneously so the
+obligation never splits across two PRs.
+
+The hub's publish endpoint (ADR 0008) uses strict schema-version matching: an
+HTTP 422 is returned for any payload whose `schema_version` does not match
+the server's expected version. Shipping this schema bump requires hub-side
+acceptance to land before the OSS tag — the same three-step lockstep used for
+schema 0.4.0.
+
+## Decision
+
+1. **MINOR bump 0.4.0 → 0.5.0** per the additive-only policy in ADR 0009. No
+   existing field becomes required; new fields default to `None` or a safe
+   literal so that all 0.4.0 consumers continue to parse 0.5.0 payloads without
+   changes.
+
+2. **`ProjectInfo` gains four optional fields**: `integration_version`,
+   `integration_version_source` (Literal, default `"unknown"`),
+   `manifest_hash`, and `requirements_hash`. These duplicate the identity
+   information at the project level for consumers that do not process the
+   `target` envelope.
+
+3. **New `ReportTarget` model** — 8 fields, all optional — identifies the exact
+   build: `integration_domain`, `integration_version`,
+   `integration_version_source`, `integration_release_tag`, `commit_sha`,
+   `ha_version`, `python_version`, and `check_mode`. All default to `None` or a
+   safe literal. Added to `HassCheckReport` as `target: ReportTarget | None = None`.
+
+4. **New `ReportValidity` model** — 4 fields — describes the freshness
+   contract: `claim_scope` (frozen as `"exact_build_only"`), `checked_at`
+   (ISO-8601 UTC with Z suffix), `expires_after_days` (default 90), and
+   `superseded_by_integration_version`. Added to `HassCheckReport` as
+   `validity: ReportValidity | None = None`.
+
+5. **Hub-only writer contract for `superseded_by_integration_version`**: the
+   CLI always writes `None`. The hub sets this field after indexing, using the
+   same trust boundary as `Provenance.verified_by`. Enforced by a pytest
+   contract test (`test_cli_never_sets_superseded_by_integration_version`)
+   rather than a Pydantic validator, so hub round-trips are not broken.
+
+6. **Detection priority frozen**: `manifest.json["version"]` → `git_tag` (via
+   `git describe --tags --exact-match HEAD`, D6 exact invocation) →
+   `github_release` (GITHUB_REF env matches `refs/tags/*`) → `hacs_metadata`
+   (deferred stub, always returns None in this PR) → `unknown`. First match wins
+   for `integration_version` and `integration_version_source`. Other fields
+   (`commit_sha`, `python_version`, `integration_domain`) populate
+   independently from their own sources.
+
+7. **CLI footer wired in text and markdown output**, gated on
+   `report.target and report.target.ha_version`, per ADR 0012 §7. Footer text
+   is frozen: "Compatibility claims policy:
+   https://github.com/Daily-Nerd/hasscheck/blob/main/docs/compatibility-claim-policy.md
+   — HassCheck reports are exact-build signals." JSON output is unchanged. The
+   footer is dormant in this PR because `ha_version` is always `None` from
+   `detect_target()` until the smoke harness (#150) lands.
+
+8. **Lockstep gate with hasscheck-web**: the OSS tag is blocked until the hub
+   deploys 0.5.0 acceptance and a smoke test passes. See Consequences.
+
+## Consequences
+
+### Hub-side dependency (3-step lockstep)
+
+1. **hasscheck-web** deploys schema 0.5.0 acceptance — `target` and `validity`
+   are optional in the payload validator; the endpoint returns 200 for 0.5.0
+   payloads with or without those fields. This is a separate hub PR deployed
+   first.
+2. **Hub smoke test** confirms a 0.5.0 publish succeeds: a manual or scripted
+   `hasscheck publish` from the feature branch hits the production hub and
+   returns 200, not 422.
+3. **OSS v0.14.x tagged + released**. Step 3 is BLOCKED until step 2 returns
+   green.
+
+### Deferred items
+
+- **HACS metadata detection**: `_hacs_metadata_version()` is a stub that always
+  returns `None`. The "hacs_metadata" Literal value is reserved but never
+  emitted in this PR. Detection is deferred because HACS metadata is only
+  accessible in environments with an HA install fixture, making it untestable
+  in CI. See ADR 0013 §Consequences.
+- **`expires_after_days` configuration support**: hardcoded to 90. Plumbing
+  into `hasscheck.yaml` is a follow-up.
+- **PEP 508 normalization for `requirements_hash`**: the hash uses lexicographic
+  sort of raw PEP 508 strings only. Normalization (canonicalization of package
+  names and extras) is deferred per the proposal risk analysis.
+- **Per-rule min/max HA version backfill**: a separate PR (#147 follow-up).
+- **`is_current` field**: not in this PR. The hub can derive freshness from
+  `checked_at + expires_after_days`. This field is a potential schema 0.6.0
+  addition if hub freshness logic requires it.
+- **`ha_version` population**: always `None` in this PR. The footer code ships
+  dormant and lights up automatically when the smoke harness (#150) populates
+  `ha_version`.
+
+### ADR 0012 wording inheritance
+
+This ADR delivers the CLI footer required by ADR 0012 §7. The footer wording
+is frozen in this ADR. Any modification to the footer text requires an ADR
+amendment.
+
+## Alternatives considered
+
+- **Commit-SHA-only identity**: a `commit_sha`-only signal is insufficient for
+  human-readable compatibility queries. Users need to correlate a check result
+  with an integration version that appears on GitHub Releases and in HACS —
+  not with a 40-character hash.
+- **Flat schema (no `ReportTarget` envelope)**: placing identity fields
+  directly on `ProjectInfo` couples version identity to project structure,
+  makes hub deduplication harder, and pollutes the top-level report namespace.
+  An envelope is cleaner and mirrors `provenance` precedent.
+- **Opt-in `--with-target` CLI flag**: the hub needs identity on every report
+  it indexes; an opt-in flag defeats the always-on requirement and makes the
+  footer inconsistent.
+- **Defer footer to #150**: splitting the ADR 0012 §7 obligation across two PRs
+  risks wording drift. Shipping the footer code in this PR — dormant but
+  correct — is lower risk and avoids a second ADR.
+
+## Related
+
+- ADR 0008 — Hub lockstep (strict schema-version matching on publish)
+- ADR 0009 — Schema versioning policy (additive bump rule, backwards
+  compatibility guarantee)
+- ADR 0010 — Provenance block (`verified_by` trust boundary; pattern mirrored
+  by `superseded_by_integration_version`)
+- ADR 0012 — Compatibility claim policy (exact-build wording; §7 mandates the
+  footer wired in this ADR)
+- Issue #141 — This ADR's source issue
+- Issue #147 — Rule definition metadata (parallel schema work)
+- Issue #150 — Smoke harness (populates `ha_version`; footer lights up when
+  this lands)
+- Issue #154 — ADR 0012 source issue
+- Issue #155 — Related schema work
+- hasscheck-web companion issue — Hub 0.5.0 acceptance (step 1 of lockstep)

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import UTC, datetime
 from pathlib import Path
 
 from hasscheck.config import HassCheckConfig, apply_overrides, discover_config
@@ -16,6 +17,7 @@ from hasscheck.models import (
 from hasscheck.provenance import detect_provenance
 from hasscheck.rules.registry import RULES
 from hasscheck.slug import detect_repo_slug
+from hasscheck.target import _read_manifest_version, build_validity, detect_target
 
 APPLICABILITY_FLAGS_BY_RULE = {
     "diagnostics.file.exists": "supports_diagnostics",
@@ -69,6 +71,11 @@ def run_check(
         applicability=config.applicability if config else None,
         rule_settings=rule_settings,
     )
+
+    now = datetime.now(UTC)
+    target = detect_target(root, context.integration_path, context.domain)
+    validity = build_validity(checked_at=now)
+
     findings = [rule.check(context) for rule in RULES]
 
     config_applicability_rule_ids = sorted(
@@ -113,6 +120,14 @@ def run_check(
         for category, points_possible in sorted(possible.items())
     ]
 
+    # Populate manifest_hash and requirements_hash for ProjectInfo
+    _manifest_hash: str | None = None
+    _requirements_hash: str | None = None
+    if context.integration_path is not None:
+        _, _manifest_hash, _requirements_hash = _read_manifest_version(
+            context.integration_path
+        )
+
     return HassCheckReport(
         project=ProjectInfo(
             path=str(root),
@@ -122,6 +137,12 @@ def run_check(
             if context.integration_path
             else None,
             repo_slug=detect_repo_slug(root, context.integration_path),
+            integration_version=target.integration_version if target else None,
+            integration_version_source=target.integration_version_source
+            if target
+            else "unknown",
+            manifest_hash=_manifest_hash,
+            requirements_hash=_requirements_hash,
         ),
         summary=ReportSummary(
             categories=categories,
@@ -129,5 +150,7 @@ def run_check(
             applicability_applied=applicability_applied,
         ),
         findings=findings,
-        provenance=detect_provenance(),
+        provenance=detect_provenance(now=now),
+        target=target,
+        validity=validity,
     )

--- a/src/hasscheck/config.py
+++ b/src/hasscheck/config.py
@@ -49,7 +49,7 @@ class PublishConfig(BaseModel):
 class HassCheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0", "0.3.0", "0.4.0"] = "0.4.0"
+    schema_version: Literal["0.2.0", "0.3.0", "0.4.0", "0.5.0"] = "0.5.0"
     project: ProjectConfig | None = None
     applicability: ProjectApplicability | None = None
     rules: dict[str, RuleOverride] = Field(default_factory=dict)

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 from hasscheck import __version__
 
-SCHEMA_VERSION = "0.4.0"
+SCHEMA_VERSION = "0.5.0"
 # See docs/decisions/0006-ruleset-versioning.md for bump policy.
 DEFAULT_RULESET_ID = "hasscheck-ha-2026.5"
 DEFAULT_SOURCE_CHECKED_AT = "2026-05-01"
@@ -35,6 +36,16 @@ class RuleSeverity(StrEnum):
 
 
 ApplicabilitySource = Literal["default", "detected", "config"]
+
+IntegrationVersionSource = Literal[
+    "manifest",
+    "git_tag",
+    "github_release",
+    "hacs_metadata",
+    "unknown",
+]
+CheckMode = Literal["static", "import-smoke", "test-matrix"]
+ClaimScope = Literal["exact_build_only"]
 
 
 class RuleSource(BaseModel):
@@ -135,6 +146,34 @@ class ProjectInfo(BaseModel):
     domain: str | None = None
     integration_path: str | None = None
     repo_slug: str | None = None
+    # NEW (0.5.0)
+    integration_version: str | None = None
+    integration_version_source: IntegrationVersionSource = "unknown"
+    manifest_hash: str | None = None
+    requirements_hash: str | None = None
+
+
+class ReportTarget(BaseModel):
+    integration_domain: str | None = None
+    integration_version: str | None = None
+    integration_version_source: IntegrationVersionSource = "unknown"
+    integration_release_tag: str | None = None
+    commit_sha: str | None = None
+    ha_version: str | None = None
+    python_version: str | None = None
+    check_mode: CheckMode = "static"
+
+
+class ReportValidity(BaseModel):
+    claim_scope: ClaimScope = "exact_build_only"
+    checked_at: datetime  # required, ISO-8601 UTC Z
+    expires_after_days: int | None = 90
+    superseded_by_integration_version: str | None = None
+    # ALWAYS None from CLI; hub sets this after indexing
+
+    @field_serializer("checked_at")
+    def _serialize_checked_at(self, v: datetime) -> str:
+        return v.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
 
 
 class ToolInfo(BaseModel):
@@ -168,6 +207,9 @@ class HassCheckReport(BaseModel):
     summary: ReportSummary
     findings: list[Finding]
     provenance: Provenance | None = None
+    # NEW (0.5.0)
+    target: ReportTarget | None = None
+    validity: ReportValidity | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         return self.model_dump(mode="json")

--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -7,6 +7,12 @@ from rich.table import Table
 
 from hasscheck.models import Finding, HassCheckReport, RuleStatus
 
+_COMPAT_POLICY_FOOTER = (
+    "Compatibility claims policy: "
+    "https://github.com/Daily-Nerd/hasscheck/blob/main/docs/compatibility-claim-policy.md"
+    " — HassCheck reports are exact-build signals."
+)
+
 _NON_PASS_STATUSES = {
     RuleStatus.WARN,
     RuleStatus.FAIL,
@@ -68,6 +74,10 @@ def print_terminal_report(
     console.print(table)
 
     _print_fix_suggestions(report.findings, console)
+
+    if report.target and report.target.ha_version:
+        console.print()
+        console.print(_COMPAT_POLICY_FOOTER)
 
 
 def report_to_md(report: HassCheckReport) -> str:
@@ -133,6 +143,10 @@ def report_to_md(report: HassCheckReport) -> str:
     lines.append(
         "> Security Review: Not performed. Official HA Tier: Not assigned. HACS Acceptance: Not guaranteed."
     )
+
+    if report.target and report.target.ha_version:
+        lines.append("")
+        lines.append(_COMPAT_POLICY_FOOTER)
 
     return "\n".join(lines) + "\n"
 

--- a/src/hasscheck/target.py
+++ b/src/hasscheck/target.py
@@ -1,0 +1,189 @@
+"""Target identity detection for hasscheck reports.
+
+Reads integration manifest, git tags, and GitHub Actions environment variables
+to detect the exact-build identity of the integration under check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from hasscheck.models import ReportTarget, ReportValidity
+
+
+def detect_target(
+    root: Path,
+    integration_path: Path | None,
+    domain: str | None,
+) -> ReportTarget | None:
+    """Detect exact-build identity for the integration under check.
+
+    Reads env vars (GITHUB_REF, GITHUB_SHA) internally. Never raises.
+    Returns a ReportTarget with whichever fields detection could fill
+    (others left as defaults).
+
+    Detection priority for ``integration_version`` (first-match-wins):
+        1. manifest.json["version"]             → source = "manifest"
+        2. git describe --tags --exact-match HEAD → source = "git_tag"
+        3. GITHUB_REF matches refs/tags/*        → source = "github_release"
+        4. HACS metadata (deferred; always None this PR) → "hacs_metadata"
+        5. None                                  → source = "unknown"
+
+    Other fields populate independently:
+        - commit_sha     ← os.environ["GITHUB_SHA"] (None outside CI)
+        - python_version ← sys.version_info major.minor.patch (D11)
+        - ha_version     ← None this PR (D12)
+        - check_mode     ← "static"
+        - integration_domain ← domain parameter
+    """
+    try:
+        integration_version: str | None = None
+        integration_version_source = "unknown"
+        integration_release_tag: str | None = None
+
+        # --- Step 1: manifest.json ---
+        if integration_path is not None:
+            version, _m_hash, _r_hash = _read_manifest_version(integration_path)
+            if version is not None:
+                integration_version = version
+                integration_version_source = "manifest"
+
+        # --- Step 2: git describe (only if manifest didn't win) ---
+        if integration_version is None:
+            git_tag = _git_describe_tag(root)
+            if git_tag is not None:
+                integration_version = git_tag
+                integration_version_source = "git_tag"
+
+        # --- Step 3: GITHUB_REF env (only if still no winner) ---
+        if integration_version is None:
+            ref_tag = _github_release_tag()
+            if ref_tag is not None:
+                integration_version = ref_tag
+                integration_version_source = "github_release"
+                integration_release_tag = ref_tag
+
+        # --- Step 4: HACS metadata stub (always None in this PR) ---
+        if integration_version is None:
+            _hacs_metadata_version()  # always returns None; reserved for future
+
+        # --- Independent fields ---
+        commit_sha = os.environ.get("GITHUB_SHA")
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+        return ReportTarget(
+            integration_domain=domain,
+            integration_version=integration_version,
+            integration_version_source=integration_version_source,  # type: ignore[arg-type]
+            integration_release_tag=integration_release_tag,
+            commit_sha=commit_sha,
+            ha_version=None,  # D12: always None in this PR
+            python_version=python_version,
+            check_mode="static",
+        )
+    except Exception:  # noqa: BLE001
+        # detect_target MUST NEVER raise
+        return None
+
+
+def build_validity(checked_at: datetime) -> ReportValidity:
+    """Build a ReportValidity with frozen claim_scope and 90-day expiry.
+
+    ``superseded_by_integration_version`` is ALWAYS None from CLI; the hub
+    sets it after indexing (mirrors Provenance.verified_by).
+    """
+    return ReportValidity(
+        claim_scope="exact_build_only",
+        checked_at=checked_at,
+        expires_after_days=90,
+        superseded_by_integration_version=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_manifest_version(
+    integration_path: Path,
+) -> tuple[str | None, str | None, str | None]:
+    """Read version, manifest_hash, and requirements_hash from manifest.json.
+
+    Returns (version, manifest_hash, requirements_hash).
+    Any IO or parse error → returns (None, None, None).
+    """
+    try:
+        manifest_file = integration_path / "manifest.json"
+        raw_bytes = manifest_file.read_bytes()
+        manifest_hash = _compute_manifest_hash(raw_bytes)
+        data = json.loads(raw_bytes)
+        version = data.get("version") or None
+        requirements = data.get("requirements")
+        requirements_hash = _compute_requirements_hash(requirements)
+        return version, manifest_hash, requirements_hash
+    except Exception:  # noqa: BLE001
+        return None, None, None
+
+
+def _compute_manifest_hash(raw_bytes: bytes) -> str:
+    """Return SHA-256 hex digest of the manifest raw bytes."""
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+def _compute_requirements_hash(requirements: list[str] | None) -> str | None:
+    """Compute SHA-256 of LF-joined sorted PEP 508 strings (D1).
+
+    Empty list or None → returns None (NOT a hash of empty string).
+    """
+    if not requirements:
+        return None
+    joined = "\n".join(sorted(requirements))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _git_describe_tag(root: Path) -> str | None:
+    """Run git describe --tags --exact-match HEAD (D6 exact invocation).
+
+    Returns the tag string on success, None on any failure.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "describe", "--tags", "--exact-match", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if result.returncode != 0:
+            return None
+        tag = result.stdout.strip()
+        return tag if tag else None
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+
+
+def _github_release_tag() -> str | None:
+    """Extract release tag from GITHUB_REF env if it points to a tag.
+
+    Returns "v3.0.0" for GITHUB_REF="refs/tags/v3.0.0", else None.
+    """
+    ref = os.environ.get("GITHUB_REF", "")
+    if ref.startswith("refs/tags/"):
+        return ref[len("refs/tags/") :]
+    return None
+
+
+def _hacs_metadata_version() -> None:
+    """HACS metadata version detection stub.
+
+    Detection deferred; falls through to next source. See ADR 0013 §Consequences.
+    Always returns None in this PR. Reserved as Literal value "hacs_metadata".
+    """
+    return None

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -94,9 +94,9 @@ def test_run_check_no_yaml_overrides_applied_is_empty(tmp_path) -> None:
     assert report.summary.overrides_applied.rule_ids == []
 
 
-def test_run_check_schema_version_is_0_4_0(tmp_path) -> None:
+def test_run_check_schema_version_is_0_5_0(tmp_path) -> None:
     report = run_check(tmp_path)
-    assert report.schema_version == "0.4.0"
+    assert report.schema_version == "0.5.0"
 
 
 # ---------- v0.8: Ruleset ID bump ----------
@@ -120,7 +120,7 @@ def test_run_check_report_provenance_key_present(tmp_path) -> None:
     reparsed = json.loads(json.dumps(raw))
 
     assert "provenance" in reparsed
-    assert reparsed["schema_version"] == "0.4.0"
+    assert reparsed["schema_version"] == "0.5.0"
 
 
 def test_run_check_report_provenance_is_not_none(tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_check_json_outputs_report(tmp_path) -> None:
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "0.4.0"
+    assert payload["schema_version"] == "0.5.0"
     assert payload["summary"]["security_review"] == "not_performed"
     assert payload["summary"]["official_ha_tier"] == "not_assigned"
     assert payload["summary"]["hacs_acceptance"] == "not_guaranteed"
@@ -243,7 +243,7 @@ def test_format_json_shortflag_outputs_json(tmp_path) -> None:
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "0.4.0"
+    assert payload["schema_version"] == "0.5.0"
 
 
 # ---------- Exit code behaviour ----------
@@ -517,7 +517,7 @@ def test_publish_dry_run_shows_schema_version(tmp_path, monkeypatch) -> None:
         ["publish", "--path", str(tmp_path), "--dry-run"],
     )
     assert result.exit_code == 0
-    assert "schema_version: 0.4.0" in result.output
+    assert "schema_version: 0.5.0" in result.output
 
 
 def test_publish_dry_run_withdraw_no_network(tmp_path, monkeypatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ def test_project_config_rejects_extra_fields() -> None:
 
 def test_hasscheck_config_empty_defaults() -> None:
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.4.0"
+    assert cfg.schema_version == "0.5.0"
     assert cfg.project is None
     assert cfg.applicability is None
     assert cfg.rules == {}
@@ -515,7 +515,7 @@ def test_hasscheck_config_accepts_applicability_block() -> None:
         applicability=ProjectApplicability(supports_diagnostics=False)
     )
 
-    assert cfg.schema_version == "0.4.0"
+    assert cfg.schema_version == "0.5.0"
     assert cfg.applicability is not None
     assert cfg.applicability.supports_diagnostics is False
 
@@ -639,12 +639,13 @@ def test_load_config_file_v03_backward_compat_no_publish(tmp_path: Path) -> None
 
 
 # ---------- v0.13: Schema version 0.4.0 (#130) ----------
+# ---------- v0.14: Schema version 0.5.0 (#141) — default bumped ----------
 
 
-def test_hasscheck_config_default_schema_version_is_0_4_0() -> None:
-    """Default instantiation yields schema_version 0.4.0."""
+def test_hasscheck_config_default_schema_version_is_0_5_0() -> None:
+    """Default instantiation yields schema_version 0.5.0 (bumped from 0.4.0 in #141)."""
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.4.0"
+    assert cfg.schema_version == "0.5.0"
 
 
 def test_hasscheck_config_accepts_explicit_0_4_0() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import UTC
+
 import pytest
 from pydantic import ValidationError
 
@@ -181,3 +183,121 @@ def test_report_summary_applicability_applied_default_is_empty() -> None:
     summary = ReportSummary()
 
     assert summary.applicability_applied == ApplicabilityApplied()
+
+
+# ---------- Phase 141: Schema 0.5.0 model assertions (RED) ----------
+
+
+def test_schema_version_is_0_5_0() -> None:
+    from hasscheck.models import SCHEMA_VERSION
+
+    assert SCHEMA_VERSION == "0.5.0"
+
+
+def test_project_info_new_fields_default_none_or_unknown() -> None:
+    from hasscheck.models import ProjectInfo
+
+    pi = ProjectInfo(path="/tmp/test")
+    assert pi.integration_version is None
+    assert pi.integration_version_source == "unknown"
+    assert pi.manifest_hash is None
+    assert pi.requirements_hash is None
+
+
+def test_report_target_model_constructs_with_defaults() -> None:
+    from hasscheck.models import ReportTarget
+
+    t = ReportTarget()
+    assert t.integration_domain is None
+    assert t.integration_version is None
+    assert t.integration_version_source == "unknown"
+    assert t.integration_release_tag is None
+    assert t.commit_sha is None
+    assert t.ha_version is None
+    assert t.python_version is None
+    assert t.check_mode == "static"
+
+
+def test_report_target_check_mode_rejects_invalid_literal() -> None:
+    from hasscheck.models import ReportTarget
+
+    with pytest.raises(ValidationError):
+        ReportTarget(check_mode="dynamic")
+
+
+def test_report_validity_claim_scope_frozen() -> None:
+    from datetime import datetime
+
+    from hasscheck.models import ReportValidity
+
+    with pytest.raises(ValidationError):
+        ReportValidity(
+            claim_scope="anything_else", checked_at=datetime(2026, 1, 1, tzinfo=UTC)
+        )
+
+
+def test_hasscheck_report_target_and_validity_optional() -> None:
+    from hasscheck.models import HassCheckReport, ProjectInfo, ReportSummary
+
+    report = HassCheckReport(
+        project=ProjectInfo(path="/tmp"),
+        summary=ReportSummary(),
+        findings=[],
+    )
+    serialized = report.to_json_dict()
+    deserialized = HassCheckReport.model_validate(serialized)
+    assert deserialized.target is None
+    assert deserialized.validity is None
+
+
+def test_hasscheck_report_serializes_target_and_validity_when_set() -> None:
+    from datetime import datetime
+
+    from hasscheck.models import (
+        HassCheckReport,
+        ProjectInfo,
+        ReportSummary,
+        ReportTarget,
+        ReportValidity,
+    )
+
+    target = ReportTarget(integration_version="1.2.3", check_mode="static")
+    validity = ReportValidity(
+        checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    report = HassCheckReport(
+        project=ProjectInfo(path="/tmp"),
+        summary=ReportSummary(),
+        findings=[],
+        target=target,
+        validity=validity,
+    )
+    d = report.to_json_dict()
+    assert "target" in d
+    assert "validity" in d
+    assert d["target"]["integration_version"] == "1.2.3"
+    assert d["validity"]["claim_scope"] == "exact_build_only"
+
+
+def test_old_0_4_0_report_still_parses_into_v0_5_0_model() -> None:
+    from hasscheck.models import HassCheckReport
+
+    old_dict = {
+        "schema_version": "0.4.0",
+        "tool": {"name": "hasscheck", "version": "0.13.0"},
+        "project": {"path": "/old/path"},
+        "ruleset": {"id": "hasscheck-ha-2026.5", "source_checked_at": "2026-05-01"},
+        "summary": {
+            "overall": "informational_only",
+            "security_review": "not_performed",
+            "official_ha_tier": "not_assigned",
+            "hacs_acceptance": "not_guaranteed",
+            "categories": [],
+            "overrides_applied": {"count": 0, "rule_ids": []},
+            "applicability_applied": {"count": 0, "rule_ids": [], "flags": []},
+        },
+        "findings": [],
+    }
+    report = HassCheckReport.model_validate(old_dict)
+    assert report.target is None
+    assert report.validity is None

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,6 +14,7 @@ from hasscheck.models import (
     HassCheckReport,
     ProjectInfo,
     ReportSummary,
+    ReportTarget,
     RuleSeverity,
     RuleSource,
     RuleStatus,
@@ -340,8 +341,6 @@ def test_report_to_md_no_config_marker_for_default_source() -> None:
 
 
 # ---------- Phase 141: Compat policy footer scenarios (RED) ----------
-
-from hasscheck.models import ReportTarget  # noqa: E402
 
 _EXPECTED_FOOTER_FRAGMENT = "compatibility-claim-policy.md"
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -337,3 +337,68 @@ def test_report_to_md_no_config_marker_for_default_source() -> None:
     output = report_to_md(report)
 
     assert "*(config)*" not in output
+
+
+# ---------- Phase 141: Compat policy footer scenarios (RED) ----------
+
+from hasscheck.models import ReportTarget  # noqa: E402
+
+_EXPECTED_FOOTER_FRAGMENT = "compatibility-claim-policy.md"
+
+
+def _make_report_with_target(ha_version: str | None) -> HassCheckReport:
+    return HassCheckReport(
+        project=ProjectInfo(path="."),
+        summary=ReportSummary(),
+        findings=[],
+        target=ReportTarget(ha_version=ha_version),
+    )
+
+
+# Scenario 20 — text report emits footer when ha_version populated
+def test_text_report_emits_compat_policy_footer_when_ha_version_populated() -> None:
+    report = _make_report_with_target(ha_version="2026.5.1")
+    output = capture_output(report)
+    assert _EXPECTED_FOOTER_FRAGMENT in output, (
+        f"Expected footer fragment '{_EXPECTED_FOOTER_FRAGMENT}' not found in terminal output"
+    )
+
+
+# Scenario 21 — text report omits footer when target is None
+def test_text_report_omits_footer_when_target_is_none() -> None:
+    report = HassCheckReport(
+        project=ProjectInfo(path="."),
+        summary=ReportSummary(),
+        findings=[],
+        target=None,
+    )
+    output = capture_output(report)
+    assert _EXPECTED_FOOTER_FRAGMENT not in output
+
+
+# Scenario 22 — text report omits footer when ha_version is None
+def test_text_report_omits_footer_when_ha_version_is_none() -> None:
+    report = _make_report_with_target(ha_version=None)
+    output = capture_output(report)
+    assert _EXPECTED_FOOTER_FRAGMENT not in output
+
+
+# Scenario 23 — markdown report emits footer when ha_version populated
+def test_markdown_report_emits_compat_policy_footer_when_ha_version_populated() -> None:
+    report = _make_report_with_target(ha_version="2026.5.1")
+    output = report_to_md(report)
+    assert _EXPECTED_FOOTER_FRAGMENT in output, (
+        f"Expected footer fragment '{_EXPECTED_FOOTER_FRAGMENT}' not found in markdown output"
+    )
+
+
+# Scenario 24 — JSON report unchanged by footer logic
+def test_json_report_unchanged_by_footer_logic() -> None:
+    from hasscheck.output import report_to_json
+
+    for ha_version in (None, "2026.5.1"):
+        report = _make_report_with_target(ha_version=ha_version)
+        json_bytes = report_to_json(report)
+        assert _EXPECTED_FOOTER_FRAGMENT not in json_bytes, (
+            f"Footer fragment should not appear in JSON output (ha_version={ha_version!r})"
+        )

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -52,7 +52,7 @@ def make_report(findings: list[Finding]) -> HassCheckReport:
 
 def capture_output(report: HassCheckReport) -> str:
     sio = StringIO()
-    console = Console(file=sio, no_color=True, highlight=False)
+    console = Console(file=sio, no_color=True, highlight=False, width=200)
     print_terminal_report(report, console)
     return sio.getvalue()
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -185,7 +185,7 @@ def test_publish_report_success(tmp_path, monkeypatch):
     assert captured["url"] == "https://hasscheck.io/api/reports"
     assert captured["auth"] == "Bearer tok-abc"
     assert captured["ua"].startswith("hasscheck/")
-    assert captured["body"]["schema_version"] == "0.4.0"
+    assert captured["body"]["schema_version"] == "0.5.0"
     assert captured["body"]["tool"]["name"] == "hasscheck"
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -186,9 +186,12 @@ def test_detect_target_never_raises_on_missing_integration_path(
 
     monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
 
-    # integration_path=None must never raise
+    # integration_path=None must never raise; helpers fall through to "unknown"
     target = detect_target(tmp_path, None, None)
-    assert target is not None or target is None  # either is acceptable
+    assert target is not None
+    assert target.integration_domain is None
+    assert target.integration_version is None
+    assert target.integration_version_source == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,213 @@
+"""Tests for hasscheck.target — detect_target and build_validity."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — test_detect_target_reads_manifest_version
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_reads_manifest_version(tmp_path: Path) -> None:
+    from hasscheck.target import detect_target
+
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"domain": "test", "version": "1.2.3", "name": "Test"})
+    )
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+    assert target.integration_version == "1.2.3"
+    assert target.integration_version_source == "manifest"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10 — test_detect_target_falls_through_to_git_tag_when_manifest_missing
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_falls_through_to_git_tag_when_manifest_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    # No manifest.json → fall through to git describe
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="v2.0.0\n", stderr="")
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+    assert target.integration_version == "v2.0.0"
+    assert target.integration_version_source == "git_tag"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 11 — test_detect_target_falls_through_to_github_release_when_ref_is_tag
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_falls_through_to_github_release_when_ref_is_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v3.0.0")
+
+    # No manifest version, git describe fails
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args[0], 128, stdout="", stderr="fatal: no tag"
+        )
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+    assert target.integration_version == "v3.0.0"
+    assert target.integration_version_source == "github_release"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 12 — test_detect_target_returns_unknown_when_all_sources_miss
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_returns_unknown_when_all_sources_miss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 128, stdout="", stderr="fatal")
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+    assert target.integration_version_source == "unknown"
+    assert target.integration_version is None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 13 — test_detect_target_handles_shallow_clone_subprocess_failure
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_handles_shallow_clone_subprocess_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args[0], 128, stdout="", stderr="fatal: no tags"
+        )
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+    # Should not raise
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 14 — test_detect_target_handles_unreadable_manifest
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_handles_unreadable_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    (tmp_path / "manifest.json").write_text("{not valid json")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 128, stdout="", stderr="")
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+
+    # Must not raise; falls through
+    target = detect_target(tmp_path, tmp_path, "test")
+    assert target is not None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 15 — test_build_validity_sets_claim_scope_and_default_expires
+# ---------------------------------------------------------------------------
+
+
+def test_build_validity_sets_claim_scope_and_default_expires() -> None:
+    from hasscheck.target import build_validity
+
+    validity = build_validity(checked_at=datetime(2026, 1, 1, tzinfo=UTC))
+    assert validity.claim_scope == "exact_build_only"
+    assert validity.expires_after_days == 90
+
+
+# ---------------------------------------------------------------------------
+# Scenario 16 — test_build_validity_checked_at_is_utc_iso8601_z
+# ---------------------------------------------------------------------------
+
+
+def test_build_validity_checked_at_is_utc_iso8601_z() -> None:
+    from hasscheck.target import build_validity
+
+    validity = build_validity(checked_at=datetime(2026, 1, 1, tzinfo=UTC))
+    d = validity.model_dump(mode="json")
+    assert d["checked_at"].endswith("Z"), f"Expected Z suffix, got: {d['checked_at']}"
+    # Basic ISO-8601 structure check
+    assert "T" in d["checked_at"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 17 — test_detect_target_never_raises_on_missing_integration_path
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_never_raises_on_missing_integration_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import detect_target
+
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 128, stdout="", stderr="")
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+
+    # integration_path=None must never raise
+    target = detect_target(tmp_path, None, None)
+    assert target is not None or target is None  # either is acceptable
+
+
+# ---------------------------------------------------------------------------
+# Scenario 25 — test_cli_never_sets_superseded_by_integration_version
+# ---------------------------------------------------------------------------
+
+
+def test_cli_never_sets_superseded_by_integration_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hasscheck.target import build_validity, detect_target
+
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 128, stdout="", stderr="")
+
+    monkeypatch.setattr("hasscheck.target.subprocess.run", fake_run)
+
+    detect_target(tmp_path, tmp_path, "test")
+    validity = build_validity(checked_at=datetime(2026, 1, 1, tzinfo=UTC))
+    assert validity.superseded_by_integration_version is None

--- a/tests/test_target_integration.py
+++ b/tests/test_target_integration.py
@@ -1,0 +1,37 @@
+"""Integration test: checker.py populates target and validity on reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Scenario 18 — test_checker_populates_target_and_validity_on_report
+# ---------------------------------------------------------------------------
+
+
+def test_checker_populates_target_and_validity_on_report(tmp_path: Path) -> None:
+    from hasscheck.checker import run_check
+
+    # Write a minimal manifest.json with a version
+    integration_dir = tmp_path / "custom_components" / "my_integration"
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "domain": "my_integration",
+                "name": "My Integration",
+                "version": "1.0.0",
+                "documentation": "https://example.com",
+                "requirements": [],
+                "codeowners": [],
+            }
+        )
+    )
+
+    report = run_check(tmp_path)
+
+    assert report.target is not None, "report.target must not be None after run_check"
+    assert report.validity is not None, (
+        "report.validity must not be None after run_check"
+    )


### PR DESCRIPTION
## Summary

Locks the per-build identity contract that every downstream feature (Compatibility Ledger, Versioned Matrix UI, Installed Integration Radar, version-scoped badges) depends on. Bumps `SCHEMA_VERSION` 0.4.0 → 0.5.0 (MINOR additive per ADR 0009). Old 0.4.0 reports remain parseable.

Closes #141.

## Schema changes (additive, all optional)

**Extended `ProjectInfo`** (4 new fields):
- `integration_version: str | None`
- `integration_version_source: Literal["manifest","git_tag","github_release","hacs_metadata","unknown"] = "unknown"`
- `manifest_hash: str | None` — sha256 of manifest.json bytes
- `requirements_hash: str | None` — sha256 of LF-joined sorted PEP 508 strings; empty list → `None`

**New `ReportTarget`** (8 fields, all optional): `integration_domain`, `integration_version`, `integration_version_source`, `integration_release_tag`, `commit_sha`, `ha_version`, `python_version`, `check_mode: Literal["static","import-smoke","test-matrix"] = "static"`.

**New `ReportValidity`** (4 fields): `claim_scope: Literal["exact_build_only"]`, `checked_at: datetime`, `expires_after_days: int | None = 90`, `superseded_by_integration_version: str | None` (HUB-ONLY writer — never set by CLI; same trust pattern as `provenance.verified_by` per ADR 0010).

**`HassCheckReport`**: `target: ReportTarget | None = None`, `validity: ReportValidity | None = None`.

## Detection module

New `src/hasscheck/target.py` mirrors `detect_provenance()` exactly. Frozen detection priority for `integration_version` (first-match-wins):
1. `manifest.json` `version` → `"manifest"`
2. `git describe --tags --exact-match HEAD` → `"git_tag"` (subprocess uses `check=False, timeout=5.0`; silent fallthrough on shallow clones / non-zero exit)
3. `GITHUB_REF=refs/tags/*` → `"github_release"`
4. HACS metadata stub (always returns None this PR; full detection deferred) → `"hacs_metadata"` reserved
5. None → `"unknown"`

`commit_sha`, `python_version`, `integration_domain` populate independently of the priority chain. `python_version` is `f"{major}.{minor}.{micro}"`, NOT full `sys.version`.

## CLI footer (inherited from ADR 0012 §7)

Text + Markdown reports emit:
> Compatibility claims policy: https://github.com/Daily-Nerd/hasscheck/blob/main/docs/compatibility-claim-policy.md — HassCheck reports are exact-build signals.

Conditional on `report.target.ha_version` being populated. JSON output unaffected.

**Footer is dormant in production this PR**: `static` mode never populates `ha_version`. The footer lights up automatically when #150 (smoke harness) lands `import-smoke` / `test-matrix` modes that emit a real HA version.

## ADR 0013

`docs/decisions/0013-integration-version-identity.md` — 8 numbered decisions covering schema bump, model shape, hub-only writer contract, detection priority, footer wiring, lockstep gate. References ADRs 0008 / 0009 / 0010 / 0012.

## ⚠️ Hub lockstep — release blocker

Per ADR 0008 / ADR 0009, `hasscheck-web` rejects mismatched `schema_version` with HTTP 422. Release sequence (ADR 0013 §Consequences):

1. `hasscheck-web` deploys schema 0.5.0 acceptance (with optional `target` + `validity`)
2. Hub smoke test confirms 0.5.0 publish round-trips successfully
3. OSS v0.14.x tagged + released

**Do NOT merge + tag OSS v0.14.x until step 2 is green.** Merging this PR alone is safe (no release); shipping the tag without hub readiness will break every consumer's `hasscheck publish`.

## Out-of-scope (deferred)

- HACS metadata reading: stub-only this PR; full lookup needs separate issue
- `check_mode` values beyond `"static"`: deferred to #150 (smoke harness)
- `expires_after_days` configurable via `hasscheck.yaml`: hardcoded 90 (matches ADR 0012 STALE threshold)
- `min_ha_version` / `max_ha_version` backfill on rules: progressive PRs (#147 shipped the fields)
- PEP 508 normalization for `requirements_hash`: lexicographic-only; drift-detection acceptable
- `hasscheck schema` CLI subcommand: not introduced

## Verify findings

- 889 / 889 tests pass (865 baseline + 24 new)
- 11 commits, all GPG-signed (key `1ABF9EB6AF44A008`), zero `Co-Authored-By`
- 0 CRITICAL, 1 WARNING (`_read_manifest_version` imported cross-module despite underscore-private convention — defensible; cleanup follow-up suggested), 1 SUGGESTION (stale line refs in spec doc)
- `docs-render --check` exits 0 (no rule docs drift; rules untouched)

## SDD trail (engram)

- `sdd/141-schema-version-identity/explore` (#469)
- `sdd/141-schema-version-identity/proposal` (#470)
- `sdd/141-schema-version-identity/spec` (#471)
- `sdd/141-schema-version-identity/design` (#472)
- `sdd/141-schema-version-identity/tasks` (#473)
- `sdd/141-schema-version-identity/apply-progress` (#474)
- `sdd/141-schema-version-identity/verify-report` (#475)
- `sdd/141-schema-version-identity/archive-report` (#476)

## Test plan

- [x] `.venv/bin/python -m pytest -q` — 889 passed, exit 0
- [x] `.venv/bin/python -m hasscheck docs-render --check` — exit 0
- [x] All 11 commits GPG-signed (`git log --show-signature` reports "Good signature" for each)
- [x] Old 0.4.0 reports parse via `HassCheckReport.model_validate(...)` (test scenario 8)
- [x] Footer fires when `target.ha_version` populated; absent when None (text + markdown)
- [x] Subprocess `git describe` mocked failure paths exercise without raising
- [x] CLI never sets `superseded_by_integration_version` (contract test)
- [ ] Reviewer confirms ADR 0013 §Hub-side dependency has the 3-step lockstep
- [ ] Hub-side companion PR open and tracked before OSS v0.14.x tag