### PR TITLE
ci(smoke-publish): fix verify step — 405 on stale endpoint

### DIFF
--- a/.github/workflows/smoke-publish.yml
+++ b/.github/workflows/smoke-publish.yml
@@ -44,16 +44,24 @@ jobs:
         run: |
           set -euo pipefail
           ENDPOINT="${{ inputs.endpoint }}"
+          SLUG="Daily-Nerd/hasscheck"
+          SUMMARY_URL="${ENDPOINT}/api/projects/${SLUG}/summary"
           # Cloud Run + Cloudflare can take a few seconds to propagate cache
           # on the first publish for a slug. Retry briefly.
           for i in 1 2 3 4 5; do
-            BODY=$(curl -fsSL --max-time 10 "${ENDPOINT}/api/projects/Daily-Nerd/hasscheck" || true)
+            BODY=$(curl -fsSL --max-time 10 "${SUMMARY_URL}" || true)
             if [ -n "$BODY" ]; then
-              echo "$BODY" | head -c 1000
+              echo "${BODY}" | head -c 1000
               echo
+              # Assert response shape: slug matches and at least one report
+              # exists. Schema-version validation is implicit — the hub
+              # rejects mismatched schema_version with HTTP 422 at publish
+              # time, so a successful publish + non-empty summary together
+              # prove the lockstep is cleared.
+              echo "${BODY}" | jq -e --arg slug "${SLUG}" '.slug == $slug and .report_count >= 1' >/dev/null
               exit 0
             fi
             sleep 3
           done
-          echo "::error::Report did not appear at ${ENDPOINT}/api/projects/Daily-Nerd/hasscheck after retries"
+          echo "::error::Report did not appear at ${SUMMARY_URL} after retries"
           exit 1


### PR DESCRIPTION
## Summary

\`smoke-publish.yml\` verify step hit \`GET /api/projects/Daily-Nerd/hasscheck\`, which is **DELETE-only** on the hub (withdraw flow at \`hasscheck-web/src/hasscheck_web/withdraw.py:58\`). Hub returns **HTTP 405 Method Not Allowed** on GET → 5 retries → workflow fails.

The publish itself succeeded — schema 0.5.0 report rendered live at [hasscheck.io/Daily-Nerd/hasscheck](https://hasscheck.io/Daily-Nerd/hasscheck) per the post-merge smoke run. Lockstep cleared. Only the verify step was broken.

## Fix

- Use \`GET /api/projects/{owner}/{repo}/summary\` — registered for GET in \`hasscheck-web/src/hasscheck_web/hub.py:116\`. Returns \`slug\`, \`report_count\`, \`latest\`, \`trend\`.
- Assert \`.slug == "Daily-Nerd/hasscheck"\` and \`.report_count >= 1\` via \`jq -e\` so the verify step actually validates response shape, not just non-empty body.
- Schema-version validation is implicit: hub rejects mismatched \`schema_version\` with HTTP 422 at publish time per ADR 0008 / ADR 0009. A successful publish + non-empty summary together prove the lockstep is cleared.

## Failed run reference

[Run 25260669244](https://github.com/Daily-Nerd/hasscheck/actions/runs/25260669244/job/74067303501) — verify step retried 5× with \`curl: (22) The requested URL returned error: 405\`.

## Test plan

- [x] Diff against \`hasscheck-web\` confirms \`/api/projects/{owner}/{repo}/summary\` exists for GET (hub.py:116) and \`/api/projects/{owner}/{repo}\` is DELETE-only (withdraw.py:58)
- [x] \`jq -e\` exits non-zero if \`.slug\` mismatches or \`.report_count < 1\` — verified locally on a sample summary payload
- [ ] After merge: re-trigger \`smoke-publish.yml\` from main; expect green
- [ ] After smoke green: tag v0.14.0