### PR TITLE
chore(release): bump version to 0.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.14.0"
+version = "0.14.1"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bump version to 0.14.1 for release.

## Bundled in v0.14.1
- #160 — `read_manifest_version` promoted to public API
- #161 — single manifest read; hashes transported via `ReportTarget(Field(exclude=True))`
- #142 — three new RECOMMENDED rules: `version.identity.present`, `version.manifest.resolvable`, `version.matches.release_tag`

**Tests**: 889 → 930 (+41)