### PR TITLE
feat(target): normalize requirements_hash with PEP 508 canonical forms (#159)

### DIFF
--- a/src/hasscheck/target.py
+++ b/src/hasscheck/target.py
@@ -14,6 +14,9 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
 from hasscheck.models import ReportTarget, ReportValidity
 
 
@@ -144,13 +147,27 @@ def _compute_manifest_hash(raw_bytes: bytes) -> str:
 
 
 def _compute_requirements_hash(requirements: list[str] | None) -> str | None:
-    """Compute SHA-256 of LF-joined sorted PEP 508 strings (D1).
+    """Compute SHA-256 of LF-joined sorted normalized PEP 508 strings.
 
-    Empty list or None → returns None (NOT a hash of empty string).
+    Normalization:
+    - Package name: lowercased, hyphens/underscores unified via canonicalize_name.
+    - Whitespace around specifiers: stripped by Requirement.__str__.
+    - Extras: normalized to lowercase, sorted (packaging behaviour).
+    - Invalid PEP 508 entries: used as-is (raw string fallback).
+
+    Empty list or None → returns None.
     """
     if not requirements:
         return None
-    joined = "\n".join(sorted(requirements))
+    normalized: list[str] = []
+    for req_str in requirements:
+        try:
+            req = Requirement(req_str)
+            req.name = canonicalize_name(req.name)
+            normalized.append(str(req))
+        except InvalidRequirement:
+            normalized.append(req_str)
+    joined = "\n".join(sorted(normalized))
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from hasscheck.target import _compute_requirements_hash
+
 # ---------------------------------------------------------------------------
 # Scenario 9 — test_detect_target_reads_manifest_version
 # ---------------------------------------------------------------------------
@@ -395,3 +397,62 @@ def test_cli_never_sets_superseded_by_integration_version(
     detect_target(tmp_path, tmp_path, "test")
     validity = build_validity(checked_at=datetime(2026, 1, 1, tzinfo=UTC))
     assert validity.superseded_by_integration_version is None
+
+
+# Phase 4.2 RED — #159 requirements_hash normalization
+
+
+def test_requirements_hash_normalizes_whitespace() -> None:
+    """Extra whitespace around specifiers must not change the hash."""
+    h1 = _compute_requirements_hash(["aiohttp >= 3.0"])
+    h2 = _compute_requirements_hash(["aiohttp>=3.0"])
+    assert h1 == h2
+
+
+def test_requirements_hash_normalizes_name_case() -> None:
+    """Package name case must not change the hash."""
+    h1 = _compute_requirements_hash(["Aiohttp>=3.0"])
+    h2 = _compute_requirements_hash(["aiohttp>=3.0"])
+    assert h1 == h2
+
+
+def test_requirements_hash_normalizes_name_separator() -> None:
+    """Hyphen/underscore in package name must not change the hash."""
+    h1 = _compute_requirements_hash(["aiohttp_client>=1.0"])
+    h2 = _compute_requirements_hash(["aiohttp-client>=1.0"])
+    assert h1 == h2
+
+
+def test_requirements_hash_is_order_independent() -> None:
+    """Input order must not change the hash."""
+    h1 = _compute_requirements_hash(["a>=1", "b>=2"])
+    h2 = _compute_requirements_hash(["b>=2", "a>=1"])
+    assert h1 == h2
+
+
+def test_requirements_hash_handles_invalid_pep508() -> None:
+    """A non-PEP-508 string must not raise; result must be a valid hex string."""
+    result = _compute_requirements_hash(["not-valid-requirement@!#$"])
+    assert result is not None
+    assert isinstance(result, str)
+    assert len(result) == 64  # SHA-256 hex
+
+
+def test_requirements_hash_returns_none_for_empty_list() -> None:
+    """Empty list must return None."""
+    assert _compute_requirements_hash([]) is None
+
+
+def test_requirements_hash_returns_none_for_none_input() -> None:
+    """None input must return None."""
+    assert _compute_requirements_hash(None) is None
+
+
+def test_requirements_hash_handles_mixed_valid_and_invalid() -> None:
+    """A list with both valid and invalid entries must return a hash without raising."""
+    result = _compute_requirements_hash(
+        ["requests>=2.0", "git+https://example.com/pkg.git"]
+    )
+    assert result is not None
+    assert isinstance(result, str)
+    assert len(result) == 64


### PR DESCRIPTION
## Summary

Closes #159 — `requirements_hash` was hashed from raw PEP 508 strings, so `aiohttp >= 3.0` and `aiohttp>=3.0` produced different hashes. Now normalizes via `packaging.requirements.Requirement` + `canonicalize_name` before hashing.

**What changed**: single function `_compute_requirements_hash` in `target.py`:
- Package name: `canonicalize_name` (case + hyphen/underscore unification)
- Specifier whitespace: stripped by `Requirement.__str__`
- Extras: normalized by `packaging` (sorted, lowercased)
- Invalid PEP 508 strings: raw-string fallback, no crash

**No schema changes** — `requirements_hash` stays a string field on `ProjectInfo`. `packaging` was already a direct dependency.

> **Note**: hashes produced by v0.14.2+ will differ from v0.14.0/v0.14.1 for any requirement that was previously hashed without normalization. This is intentional. The hub does not yet index `requirements_hash` so blast radius is zero.

## Tests

| Metric | Count |
|--------|-------|
| Before | 930 |
| After | 938 |
| New tests | +8 |
| Failures | 0 |

All 8 normalization scenarios covered: whitespace, name case, hyphen/underscore, order independence, invalid PEP 508, empty list, None, mixed valid/invalid.

Closes #159