### PR TITLE
chore(release): bump version to 0.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.14.1"
+version = "0.14.2"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bump version to 0.14.2 for release.

## Bundled in v0.14.2
- #159 — `requirements_hash` normalized via PEP 508 canonical forms (`packaging.requirements.Requirement` + `canonicalize_name`)

> **Note**: hashes produced by v0.14.2+ differ from v0.14.0/v0.14.1 for any requirement that was previously hashed without normalization. Intentional — hub does not yet index `requirements_hash`.

**Tests**: 930 → 938 (+8)