### PR TITLE
feat(config): quality gate modes in hasscheck.yaml (#148)

### DIFF
--- a/docs/decisions/0014-quality-gate-modes.md
+++ b/docs/decisions/0014-quality-gate-modes.md
@@ -1,0 +1,125 @@
+# ADR 0014 — Quality gate modes: advisory, strict-required, hacs-publish, upgrade-radar
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v0.14.x (#148)
+
+## Context
+
+`hasscheck check` has historically exited non-zero when any finding carries
+`status=fail`. This binary behavior is fine for a first iteration but becomes
+friction in three real use-cases:
+
+1. **Informational dashboards** — a team wants to embed HassCheck in CI and
+   see signals in the report without ever blocking a merge. They need a mode
+   where the check always exits 0 regardless of findings.
+
+2. **HACS submission gates** — HACS evaluates both REQUIRED and RECOMMENDED
+   findings when deciding whether to accept an integration. A CI gate that
+   only blocks on FAIL misses WARN-level signals; a gate that blocks on any
+   FAIL or WARN on any severity is too strict for non-publishing workflows.
+
+3. **Upgrade Radar pipeline** — the hub's per-HA-version pipeline needs to
+   flag regressions in `version.*` rules without blocking unrelated manifest or
+   branding rule work.
+
+The schema_version bump to 0.6.0 provides the right moment to introduce a
+structured `gate:` stanza so users can declare their exit-code policy
+declaratively rather than wrapping the CLI in shell logic.
+
+## Decision
+
+### 1. Gate trigger predicate: `status in {FAIL, WARN}` for named modes
+
+All four named gate modes share the same trigger threshold: a finding is
+"triggered" when its `status` is either `fail` or `warn`. This is deliberate —
+a `warn` in a required rule is still a signal that the gate author cares about,
+and treating `warn` as safe would silently hide regressions. The legacy path
+(no `gate:` stanza) preserves the pre-0.6.0 behavior: only `fail` triggers a
+non-zero exit.
+
+### 2. `hacs-publish` ships covering REQUIRED + RECOMMENDED (HACS tags follow-up)
+
+The HACS review rubric covers both REQUIRED and RECOMMENDED severity rules.
+`hacs-publish` therefore blocks on any finding in those two severity tiers that
+is `fail` or `warn`. A follow-up issue (`TODO(hacs-tags)`) will refine this
+once rules carry explicit `tags=("hacs",)` metadata, allowing the gate to
+target only rules that HACS actually evaluates rather than the whole RECOMMENDED
+tier. Until that metadata exists, REQUIRED + RECOMMENDED is the correct
+conservative approximation.
+
+### 3. `custom` mode deferred — not in the enum
+
+The design considered a `custom` mode (user-supplied predicate). This was
+deferred because it requires either a DSL, a Python callout, or a tag-filter
+syntax — none of which are ready. The four named modes cover all identified
+use-cases at launch. `custom` will follow as a separate ADR when tags land.
+
+### 4. Absent `gate:` stanza = legacy FAIL-only behavior preserved
+
+A `hasscheck.yaml` without a `gate:` key (including all pre-0.6.0 configs)
+continues to exit non-zero only on `fail` findings. This is the zero-migration
+path: existing configs do not need to be updated to get the old behavior.
+`gate: null` is equivalent to omitting `gate:` entirely.
+
+### 5. `gate_mode` in JSON output deferred
+
+The JSON report does not yet include the active gate mode or the gate decision.
+Adding it requires a schema bump decision (what field, what shape, whether it
+belongs under `summary` or `validity`). Deferred to a follow-up issue. The
+current report shape is stable at schema 0.5.0; the `gate:` stanza is a
+CLI-only exit-code policy and does not affect the report payload.
+
+## Consequences
+
+- **schema_version 0.6.0 is introduced.** All existing versions (0.2.0–0.5.0)
+  remain valid. The `gate:` field is rejected on any schema version below 0.6.0
+  with a clear validation error.
+- **`hasscheck init` and the scaffold template** produce `schema_version: "0.6.0"`
+  as the new default. Existing `hasscheck.yaml` files at lower versions continue
+  to parse without modification.
+- **Four gate modes are frozen.** Adding a fifth mode requires a follow-up ADR
+  and a `GateMode` enum member. Removing a mode is a breaking change.
+- **`should_exit_nonzero` is a pure function.** It takes findings and an
+  optional `GateConfig` and is unit-testable without CLI setup. The CLI wires
+  it in via a second `discover_config` call (intentional duplication for
+  separation of concerns between report production and exit-code policy).
+- **No `case _` in the match statement** — a missing branch for a new enum
+  member is a loud bug (Python raises `ValueError`) rather than a silent
+  passthrough. This is intentional and documented in code.
+
+## Alternatives considered
+
+- **Single `strict` flag instead of named modes.** A boolean `strict: true`
+  covering all severities was simpler but would not address the advisory
+  (always-exit-0) or upgrade-radar (version-scoped) use-cases. Named modes
+  are more expressive and self-documenting in CI configuration.
+
+- **Shell-wrapping the exit code.** Teams could `|| true` or `|| exit 0` around
+  the CLI invocation. Rejected: this hides the policy from the config file,
+  makes it invisible to tooling, and duplicates the logic in every consuming
+  repo. A declarative `gate:` stanza is a single source of truth.
+
+- **Tag-based gate filter from the start.** A `gate: {tags: [hacs]}` syntax
+  would be more composable than named modes. Rejected at launch: rules do not
+  carry tags yet. Named modes are a stable interim solution that will remain
+  valid after tags land (they will simply have more precise semantics).
+
+- **Include `gate_mode` in the JSON report immediately.** Rejected: the gate
+  decision is a CLI exit-code policy, not a quality signal. Adding it to the
+  report before the schema field is designed would risk a breaking schema
+  change. Deferred cleanly.
+
+- **Block `warn` findings in legacy mode.** The pre-0.6.0 behavior exits
+  non-zero only on `fail`. Changing that default would break every repo that
+  currently runs without a `gate:` stanza and has `warn` findings. The legacy
+  path is preserved exactly.
+
+## Related
+
+- ADR 0009 — Schema versioning policy (additive bump rule)
+- ADR 0011 — Upgrade Radar status taxonomy
+- ADR 0012 — Compatibility claim policy
+- ADR 0013 — Integration version identity
+- Issue #148 — This ADR's source issue
+- TODO(hacs-tags) — Follow-up to add `tags=("hacs",)` to rule definitions

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -11,10 +11,10 @@ from hasscheck import __version__
 from hasscheck.badges import generate_badges
 from hasscheck.badges.policy import BadgePolicyError
 from hasscheck.checker import run_check
-from hasscheck.config import ConfigError, discover_config
+from hasscheck.config import ConfigError, GateConfig, GateMode, discover_config
 from hasscheck.docs_render import check_drift, render_all
 from hasscheck.init import init_project
-from hasscheck.models import HassCheckReport, RuleStatus
+from hasscheck.models import Finding, HassCheckReport, RuleSeverity, RuleStatus
 from hasscheck.output import print_terminal_report, report_to_json, report_to_md
 from hasscheck.publish import (
     PublishError,
@@ -46,6 +46,42 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+
+
+def should_exit_nonzero(findings: list[Finding], gate: GateConfig | None) -> bool:
+    """Determine whether the CLI should exit non-zero based on findings and gate config.
+
+    When gate is None, uses legacy behavior: exits non-zero on any FAIL finding.
+    When gate is set, applies the gate mode policy to decide the exit signal.
+    The gate trigger threshold is ``status in {FAIL, WARN}`` for all named modes.
+
+    There is no ``case _`` in the match — a missing branch would be a bug, not a
+    runtime fallback. Python will raise ``ValueError`` on an unhandled StrEnum value.
+    """
+    if gate is None:
+        return any(f.status == RuleStatus.FAIL for f in findings)
+
+    triggered = {RuleStatus.FAIL, RuleStatus.WARN}
+    match gate.mode:
+        case GateMode.ADVISORY:
+            return False
+        case GateMode.STRICT_REQUIRED:
+            return any(
+                f.severity == RuleSeverity.REQUIRED and f.status in triggered
+                for f in findings
+            )
+        case GateMode.HACS_PUBLISH:
+            # TODO(hacs-tags): refine once rules carry tags=("hacs",)
+            return any(
+                f.severity in {RuleSeverity.REQUIRED, RuleSeverity.RECOMMENDED}
+                and f.status in triggered
+                for f in findings
+            )
+        case GateMode.UPGRADE_RADAR:
+            return any(
+                f.rule_id.startswith("version.") and f.status in triggered
+                for f in findings
+            )
 
 
 def version_callback(value: bool) -> None:
@@ -115,7 +151,14 @@ def check(
     else:
         print_terminal_report(report, console)
 
-    if any(f.status == RuleStatus.FAIL for f in report.findings):
+    # intentional: gate evaluated separately from run_check for clean separation
+    # between the report-production logic and the exit-code policy.
+    try:
+        cfg = discover_config(path.resolve()) if not no_config else None
+    except ConfigError:
+        cfg = None
+    _gate = cfg.gate if cfg else None
+    if should_exit_nonzero(report.findings, _gate):
         raise typer.Exit(code=1)
 
 

--- a/src/hasscheck/config.py
+++ b/src/hasscheck/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TextIO
 
@@ -16,6 +17,40 @@ if TYPE_CHECKING:
 
 class ConfigError(Exception):
     """Raised when hasscheck.yaml is malformed or contains an invalid override."""
+
+
+class GateMode(StrEnum):
+    """Quality gate exit-code policy.
+
+    Controls which finding states cause `hasscheck check` to exit non-zero.
+    Each mode targets a different use-case audience:
+
+    - ADVISORY: Never exits non-zero; all findings are informational only.
+    - STRICT_REQUIRED: Exits non-zero when any REQUIRED-severity finding is
+      FAIL or WARN.
+    - HACS_PUBLISH: Exits non-zero when any REQUIRED or RECOMMENDED finding is
+      FAIL or WARN (suitable for HACS submission gates).
+    - UPGRADE_RADAR: Exits non-zero when any version.* rule finding is FAIL or
+      WARN (suitable for per-HA-version upgrade pipeline gates).
+    """
+
+    ADVISORY = "advisory"
+    STRICT_REQUIRED = "strict-required"
+    HACS_PUBLISH = "hacs-publish"
+    UPGRADE_RADAR = "upgrade-radar"
+
+
+class GateConfig(BaseModel):
+    """Configuration for the quality gate exit-code policy.
+
+    Specifies which :class:`GateMode` governs whether `hasscheck check` exits
+    non-zero. Absent from a config means the legacy FAIL-only behavior applies.
+    Extra fields are forbidden to catch typos early.
+    """
+
+    model_config = ConfigDict(extra="forbid", use_enum_values=False)
+
+    mode: GateMode
 
 
 class RuleOverride(BaseModel):
@@ -46,20 +81,30 @@ class PublishConfig(BaseModel):
     endpoint: str | None = None
 
 
+_GATE_SUPPORTED_FROM = "0.6.0"
+_PRE_GATE_VERSIONS = {"0.2.0", "0.3.0", "0.4.0", "0.5.0"}
+
+
 class HassCheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0", "0.3.0", "0.4.0", "0.5.0"] = "0.5.0"
+    schema_version: Literal["0.2.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0"] = "0.6.0"
     project: ProjectConfig | None = None
     applicability: ProjectApplicability | None = None
     rules: dict[str, RuleOverride] = Field(default_factory=dict)
     publish: PublishConfig | None = None
+    gate: GateConfig | None = None
 
     @model_validator(mode="after")
     def _schema_version_matches_fields(self) -> HassCheckConfig:
         if self.schema_version == "0.2.0" and self.applicability is not None:
             raise ValueError(
                 "schema_version 0.2.0 does not support applicability; use 0.3.0"
+            )
+        if self.gate is not None and self.schema_version in _PRE_GATE_VERSIONS:
+            raise ValueError(
+                f"schema_version {self.schema_version!r} does not support the "
+                f"'gate' field; upgrade to {_GATE_SUPPORTED_FROM!r}"
             )
         return self
 

--- a/src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl
+++ b/src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl
@@ -2,7 +2,7 @@
 # Docs: https://github.com/Daily-Nerd/hasscheck#configuration
 # ADRs: docs/decisions/0001, 0003, 0004 (in the hasscheck repo)
 
-schema_version: "0.3.0"
+schema_version: "0.6.0"
 
 # Project applicability — declare only facts you are confident about.
 # Uncomment any flag below where you know the answer.
@@ -13,6 +13,17 @@ schema_version: "0.3.0"
 #   supports_diagnostics: false
 #   has_user_fixable_repairs: false
 #   uses_config_flow: true
+
+# Quality gate — controls when `hasscheck check` exits non-zero.
+# Uncomment one mode below and remove the others.
+#
+# gate:
+#   mode: advisory        # Never blocks CI; all findings are informational.
+#   mode: strict-required # Blocks on REQUIRED findings that are FAIL or WARN.
+#   mode: hacs-publish    # Blocks on REQUIRED or RECOMMENDED findings (FAIL/WARN).
+#   mode: upgrade-radar   # Blocks on version.* findings that are FAIL or WARN.
+#
+# Without this stanza the legacy behaviour applies: any FAIL exits non-zero.
 
 # Per-rule overrides — softens specific RECOMMENDED rules.
 # Cannot force a finding to "pass". Cannot soften REQUIRED rules.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,20 @@
 import json
 from pathlib import Path
 
+import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
 
-from hasscheck.cli import app
+from hasscheck.cli import app, should_exit_nonzero
+from hasscheck.config import GateConfig, GateMode
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
 
 runner = CliRunner()
 
@@ -558,3 +568,164 @@ def test_publish_dry_run_flag_registered() -> None:
     publish_cmd = cmd.commands["publish"]
     dry_run_param = next((p for p in publish_cmd.params if p.name == "dry_run"), None)
     assert dry_run_param is not None, "publish must declare a --dry-run option"
+
+
+# ---------- Gate modes — pure function ----------
+
+
+def make_finding(
+    *,
+    rule_id: str = "manifest.domain.exists",
+    severity: RuleSeverity = RuleSeverity.REQUIRED,
+    status: RuleStatus = RuleStatus.FAIL,
+) -> Finding:
+    """Build a minimal Finding for gate-mode unit tests."""
+    app_status = (
+        ApplicabilityStatus.APPLICABLE
+        if status not in (RuleStatus.NOT_APPLICABLE, RuleStatus.MANUAL_REVIEW)
+        else ApplicabilityStatus.NOT_APPLICABLE
+    )
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category="test",
+        status=status,
+        severity=severity,
+        title="Test finding",
+        message="Test message",
+        applicability=Applicability(status=app_status, reason="test"),
+        source=RuleSource(url="https://example.com"),
+    )
+
+
+# Legacy behavior (gate=None)
+
+
+def test_should_exit_nonzero_legacy_fail_returns_true() -> None:
+    findings = [make_finding(status=RuleStatus.FAIL)]
+    assert should_exit_nonzero(findings, gate=None) is True
+
+
+def test_should_exit_nonzero_legacy_warn_returns_false() -> None:
+    findings = [make_finding(status=RuleStatus.WARN)]
+    assert should_exit_nonzero(findings, gate=None) is False
+
+
+def test_should_exit_nonzero_legacy_multiple_findings_any_fail() -> None:
+    findings = [
+        make_finding(status=RuleStatus.WARN),
+        make_finding(rule_id="other.rule", status=RuleStatus.FAIL),
+    ]
+    assert should_exit_nonzero(findings, gate=None) is True
+
+
+# Advisory mode
+
+
+@pytest.mark.parametrize("status", [RuleStatus.FAIL, RuleStatus.WARN])
+def test_should_exit_nonzero_advisory_always_false(status: RuleStatus) -> None:
+    gate = GateConfig(mode=GateMode.ADVISORY)
+    findings = [make_finding(status=status)]
+    assert should_exit_nonzero(findings, gate=gate) is False
+
+
+# Strict-required mode
+
+
+@pytest.mark.parametrize(
+    "severity,status,expected",
+    [
+        (RuleSeverity.REQUIRED, RuleStatus.FAIL, True),
+        (RuleSeverity.REQUIRED, RuleStatus.WARN, True),
+        (RuleSeverity.REQUIRED, RuleStatus.PASS, False),
+        (RuleSeverity.RECOMMENDED, RuleStatus.FAIL, False),
+        (RuleSeverity.INFORMATIONAL, RuleStatus.FAIL, False),
+    ],
+)
+def test_should_exit_nonzero_strict_required(
+    severity: RuleSeverity, status: RuleStatus, expected: bool
+) -> None:
+    gate = GateConfig(mode=GateMode.STRICT_REQUIRED)
+    findings = [make_finding(severity=severity, status=status)]
+    assert should_exit_nonzero(findings, gate=gate) is expected
+
+
+# HACS-publish mode
+
+
+@pytest.mark.parametrize(
+    "severity,status,expected",
+    [
+        (RuleSeverity.REQUIRED, RuleStatus.FAIL, True),
+        (RuleSeverity.REQUIRED, RuleStatus.WARN, True),
+        (RuleSeverity.RECOMMENDED, RuleStatus.FAIL, True),
+        (RuleSeverity.RECOMMENDED, RuleStatus.WARN, True),
+        (RuleSeverity.INFORMATIONAL, RuleStatus.FAIL, False),
+    ],
+)
+def test_should_exit_nonzero_hacs_publish(
+    severity: RuleSeverity, status: RuleStatus, expected: bool
+) -> None:
+    gate = GateConfig(mode=GateMode.HACS_PUBLISH)
+    findings = [make_finding(severity=severity, status=status)]
+    assert should_exit_nonzero(findings, gate=gate) is expected
+
+
+# Upgrade-radar mode
+
+
+@pytest.mark.parametrize(
+    "rule_id,status,expected",
+    [
+        ("version.foo", RuleStatus.WARN, True),
+        ("version.bar", RuleStatus.FAIL, True),
+        ("manifest.domain", RuleStatus.FAIL, False),
+    ],
+)
+def test_should_exit_nonzero_upgrade_radar(
+    rule_id: str, status: RuleStatus, expected: bool
+) -> None:
+    gate = GateConfig(mode=GateMode.UPGRADE_RADAR)
+    findings = [make_finding(rule_id=rule_id, status=status)]
+    assert should_exit_nonzero(findings, gate=gate) is expected
+
+
+# Boundary cases
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        None,
+        GateConfig(mode=GateMode.ADVISORY),
+        GateConfig(mode=GateMode.STRICT_REQUIRED),
+        GateConfig(mode=GateMode.HACS_PUBLISH),
+        GateConfig(mode=GateMode.UPGRADE_RADAR),
+    ],
+)
+def test_should_exit_nonzero_empty_findings_all_modes(
+    gate: GateConfig | None,
+) -> None:
+    assert should_exit_nonzero([], gate=gate) is False
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        None,
+        GateConfig(mode=GateMode.ADVISORY),
+        GateConfig(mode=GateMode.STRICT_REQUIRED),
+        GateConfig(mode=GateMode.HACS_PUBLISH),
+        GateConfig(mode=GateMode.UPGRADE_RADAR),
+    ],
+)
+def test_should_exit_nonzero_all_pass_findings(gate: GateConfig | None) -> None:
+    findings = [
+        make_finding(severity=RuleSeverity.REQUIRED, status=RuleStatus.PASS),
+        make_finding(
+            rule_id="other.rule",
+            severity=RuleSeverity.RECOMMENDED,
+            status=RuleStatus.PASS,
+        ),
+    ]
+    assert should_exit_nonzero(findings, gate=gate) is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -729,3 +729,62 @@ def test_should_exit_nonzero_all_pass_findings(gate: GateConfig | None) -> None:
         ),
     ]
     assert should_exit_nonzero(findings, gate=gate) is False
+
+
+# ---------- Gate modes — CliRunner ----------
+
+
+def write_config_with_gate(tmp_path: Path, mode: str, schema: str = "0.6.0") -> None:
+    """Write a hasscheck.yaml with a gate stanza to tmp_path."""
+    (tmp_path / "hasscheck.yaml").write_text(
+        f"schema_version: '{schema}'\ngate:\n  mode: {mode}\n",
+        encoding="utf-8",
+    )
+
+
+def test_check_exit_code_advisory_no_exit_on_fail(tmp_path: Path) -> None:
+    """Advisory gate: FAIL findings present but exit code must be 0."""
+    write_config_with_gate(tmp_path, "advisory")
+    # Empty tmp_path → manifest.exists FAIL (REQUIRED) → gate=advisory → exit 0
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
+    payload = json.loads(result.stdout)
+    assert any(f["status"] == "fail" for f in payload["findings"]), (
+        "Expected FAIL findings to confirm gate suppression is being tested"
+    )
+    assert result.exit_code == 0
+
+
+def test_check_exit_code_strict_required_exits_on_required_fail(
+    tmp_path: Path,
+) -> None:
+    """Strict-required gate: REQUIRED FAIL → exit 1."""
+    write_config_with_gate(tmp_path, "strict-required")
+    # Empty tmp_path → manifest.exists FAIL (REQUIRED) → exit 1
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
+    payload = json.loads(result.stdout)
+    assert any(
+        f["status"] == "fail" and f["severity"] == "required"
+        for f in payload["findings"]
+    ), "Expected a REQUIRED FAIL finding for strict-required test"
+    assert result.exit_code == 1
+
+
+def test_check_legacy_no_gate_stanza_fail_exits_nonzero(tmp_path: Path) -> None:
+    """Legacy (no gate): any FAIL → exit 1 (backward-compat regression guard)."""
+    (tmp_path / "hasscheck.yaml").write_text(
+        "schema_version: '0.5.0'\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
+    payload = json.loads(result.stdout)
+    assert any(f["status"] == "fail" for f in payload["findings"])
+    assert result.exit_code == 1
+
+
+def test_check_legacy_no_gate_stanza_no_fail_exits_zero(tmp_path: Path) -> None:
+    """Legacy (no gate): no FAIL findings → exit 0."""
+    examples = Path(__file__).parent.parent / "examples" / "good_integration"
+    result = runner.invoke(app, ["check", "--path", str(examples), "--format", "json"])
+    payload = json.loads(result.stdout)
+    assert all(f["status"] != "fail" for f in payload["findings"])
+    assert result.exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,8 @@ from pydantic import ValidationError
 
 from hasscheck.config import (
     ConfigError,
+    GateConfig,
+    GateMode,
     HassCheckConfig,
     ProjectConfig,
     RuleOverride,
@@ -94,10 +96,11 @@ def test_project_config_rejects_extra_fields() -> None:
 
 def test_hasscheck_config_empty_defaults() -> None:
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.5.0"
+    assert cfg.schema_version == "0.6.0"
     assert cfg.project is None
     assert cfg.applicability is None
     assert cfg.rules == {}
+    assert cfg.gate is None
 
 
 def test_hasscheck_config_with_rules() -> None:
@@ -515,7 +518,7 @@ def test_hasscheck_config_accepts_applicability_block() -> None:
         applicability=ProjectApplicability(supports_diagnostics=False)
     )
 
-    assert cfg.schema_version == "0.5.0"
+    assert cfg.schema_version == "0.6.0"
     assert cfg.applicability is not None
     assert cfg.applicability.supports_diagnostics is False
 
@@ -642,10 +645,10 @@ def test_load_config_file_v03_backward_compat_no_publish(tmp_path: Path) -> None
 # ---------- v0.14: Schema version 0.5.0 (#141) — default bumped ----------
 
 
-def test_hasscheck_config_default_schema_version_is_0_5_0() -> None:
-    """Default instantiation yields schema_version 0.5.0 (bumped from 0.4.0 in #141)."""
+def test_hasscheck_config_default_schema_version_is_0_6_0() -> None:
+    """Default instantiation yields schema_version 0.6.0 (bumped from 0.5.0 in #148)."""
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.5.0"
+    assert cfg.schema_version == "0.6.0"
 
 
 def test_hasscheck_config_accepts_explicit_0_4_0() -> None:
@@ -671,3 +674,73 @@ def test_load_config_file_v04_schema_version(tmp_path: Path) -> None:
     (tmp_path / "hasscheck.yaml").write_text("schema_version: '0.4.0'\n")
     cfg = load_config_file(tmp_path / "hasscheck.yaml")
     assert cfg.schema_version == "0.4.0"
+
+
+# ---------- GateMode + GateConfig ----------
+
+
+@pytest.mark.parametrize(
+    "value,expected_member",
+    [
+        ("advisory", GateMode.ADVISORY),
+        ("strict-required", GateMode.STRICT_REQUIRED),
+        ("hacs-publish", GateMode.HACS_PUBLISH),
+        ("upgrade-radar", GateMode.UPGRADE_RADAR),
+    ],
+)
+def test_gate_mode_valid_values(value: str, expected_member: GateMode) -> None:
+    cfg = GateConfig(mode=value)
+    assert cfg.mode == expected_member
+
+
+def test_gate_mode_rejects_unknown() -> None:
+    with pytest.raises(ValidationError):
+        GateConfig(mode="banana")
+
+
+def test_gate_mode_rejects_underscore_form() -> None:
+    with pytest.raises(ValidationError):
+        GateConfig(mode="strict_required")
+
+
+def test_gate_config_requires_mode() -> None:
+    with pytest.raises(ValidationError):
+        GateConfig()  # type: ignore[call-arg]
+
+
+def test_gate_config_rejects_extra_field() -> None:
+    with pytest.raises(ValidationError):
+        GateConfig(mode="advisory", severities=["required"])  # type: ignore[call-arg]
+
+
+def test_gate_accepted_on_schema_0_6_0() -> None:
+    cfg = HassCheckConfig(schema_version="0.6.0", gate=GateConfig(mode="advisory"))
+    assert cfg.gate is not None
+    assert cfg.gate.mode == GateMode.ADVISORY
+
+
+def test_gate_rejected_on_schema_0_5_0() -> None:
+    with pytest.raises(ValidationError):
+        HassCheckConfig(schema_version="0.5.0", gate=GateConfig(mode="advisory"))
+
+
+def test_schema_0_6_0_accepted_without_gate() -> None:
+    cfg = HassCheckConfig(schema_version="0.6.0")
+    assert cfg.schema_version == "0.6.0"
+    assert cfg.gate is None
+
+
+def test_schema_0_5_0_still_accepted() -> None:
+    cfg = HassCheckConfig(schema_version="0.5.0")
+    assert cfg.schema_version == "0.5.0"
+    assert cfg.gate is None
+
+
+def test_no_gate_field_defaults_to_none() -> None:
+    cfg = HassCheckConfig()
+    assert cfg.gate is None
+
+
+def test_unknown_schema_version_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HassCheckConfig(schema_version="9.9.9")  # type: ignore[arg-type]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,8 +21,9 @@ def test_init_yaml_is_valid_hasscheck_config(tmp_path):
     init_project(tmp_path)
     parsed = yaml.safe_load((tmp_path / "hasscheck.yaml").read_text())
     config = HassCheckConfig(**parsed)
-    assert config.schema_version == "0.3.0"
+    assert config.schema_version == "0.6.0"
     assert config.rules == {}
+    assert config.gate is None
 
 
 def test_init_dry_run_does_not_write(tmp_path, capsys):

--- a/tests/test_scaffold_engine.py
+++ b/tests/test_scaffold_engine.py
@@ -271,3 +271,41 @@ class TestCheckApplicabilityGate:
         result = check_applicability_gate(config, "repairs")
         assert result is not None
         assert "has_user_fixable_repairs" in result
+
+
+# ---------------------------------------------------------------------------
+# hasscheck.yaml template — gate block and schema version (#148)
+# ---------------------------------------------------------------------------
+
+
+class TestHasscheckYamlTemplate:
+    """Verify the scaffold template produces valid YAML and mentions all gate modes."""
+
+    def _load_raw_template(self) -> str:
+        from importlib.resources import files
+
+        return (
+            files("hasscheck.scaffold.templates")
+            .joinpath("hasscheck.yaml.tmpl")
+            .read_text(encoding="utf-8")
+        )
+
+    def test_scaffold_template_valid_yaml_without_gate_comment(self) -> None:
+        """Template with gate comment block stripped still parses as valid HassCheckConfig."""
+        import yaml
+
+        raw = self._load_raw_template()
+        # Strip comment-only lines to get pure YAML
+        lines = [ln for ln in raw.splitlines() if not ln.strip().startswith("#")]
+        stripped = "\n".join(lines)
+        parsed = yaml.safe_load(stripped)
+        if parsed is None:
+            parsed = {}
+        cfg = HassCheckConfig(**parsed)
+        assert cfg.gate is None
+
+    def test_scaffold_template_contains_all_four_modes(self) -> None:
+        """Raw template text must mention all four gate modes."""
+        raw = self._load_raw_template()
+        for mode in ("advisory", "strict-required", "hacs-publish", "upgrade-radar"):
+            assert mode in raw, f"Template missing gate mode: {mode}"


### PR DESCRIPTION
## Issue

Closes #148

## Summary

- Adds `gate:` stanza to `hasscheck.yaml` with four named exit-code policy modes: `advisory`, `strict-required`, `hacs-publish`, `upgrade-radar`
- Replaces the hardcoded 2-line FAIL predicate in `cli.py` with a pure `should_exit_nonzero(findings, gate)` function; absence of `gate:` preserves v0.14.2 behavior exactly
- Bumps config schema from `0.5.0` → `0.6.0` (local only, no web coordination); ships ADR 0014

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/config.py` | `GateMode` StrEnum (4 values), `GateConfig` Pydantic model, `gate: GateConfig \| None` on `HassCheckConfig`, schema `0.6.0` added to Literal, model_validator blocks `gate:` on schema < 0.6.0 |
| `src/hasscheck/cli.py` | `should_exit_nonzero(findings, gate)` pure function with exhaustive `match`; replaces inline predicate |
| `src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl` | Bumped default schema to `0.6.0`; added commented `gate:` block with all 4 modes |
| `docs/decisions/0014-quality-gate-modes.md` | ADR 0014 — 5 design decisions, consequences, alternatives |
| `tests/test_config.py` | 11 gate config tests (model validation, schema compat, cross-field validator) |
| `tests/test_cli.py` | 28 unit tests for `should_exit_nonzero` + 4 CliRunner integration tests; `make_finding` helper |
| `tests/test_scaffold_engine.py` | 2 template verification tests |

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: 986 passed / 0 failed (938 → 986, +48)
- [ ] Ran pre-commit:
- [x] Manual verification: all 4 gate modes covered by parametrized unit tests + CliRunner integration tests; backward compat verified (no `gate:` stanza = legacy FAIL-only behavior)

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [ ] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.