### PR TITLE
feat(cli): quality profiles --profile flag (#146)

### DIFF
--- a/docs/decisions/0015-quality-profiles.md
+++ b/docs/decisions/0015-quality-profiles.md
@@ -1,0 +1,122 @@
+# ADR 0015 — Quality profiles: cloud-service, local-device, hub, helper, read-only-sensor, core-submission-candidate
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v0.15.x (#146)
+
+## Context
+
+Different Home Assistant integration shapes (cloud-backed services, LAN-only
+devices, hubs/coordinators, helper integrations, read-only sensors,
+core-submission candidates) have meaningfully different quality expectations.
+A single uniform RECOMMENDED baseline either over-warns one shape (e.g. asking
+local-device integrations for a privacy policy) or under-warns another (e.g.
+not boosting reauth for cloud services). Per-rule overrides exist but require
+authors to know each rule individually — high friction. Profiles let authors
+pick a curated baseline in one line.
+
+## Decision
+
+### 1. Profile definitions live as frozen Python dataclasses (not YAML)
+
+Profiles are frozen Python dataclasses (`ProfileDefinition`) defined in
+`src/hasscheck/profiles.py`. This is type-safe, fast to import, trivially
+testable, and requires no file I/O. User-defined profile YAML files are
+deferred post-v1.
+
+### 2. New `profile: str | None` field on HassCheckConfig (schema 0.7.0)
+
+The `profile` field is added to `HassCheckConfig` gated behind
+`schema_version: "0.7.0"`. The validator pattern matches ADR 0014 (#148):
+older schema versions reject the field with a clear `ValidationError`. Profile
+name validation is deferred to `run_check` (not Pydantic) to avoid coupling
+the config layer to the profile registry.
+
+### 3. `--profile <name>` CLI flag on `check` command
+
+The `check` command gains an optional `--profile <name>` flag. Omitting it
+leaves `profile=None` and preserves pre-0.15.0 behavior exactly.
+
+### 4. Apply order: profile severity/disables FIRST, then per-rule RuleOverride
+
+Override order in `run_check`:
+1. Rules fire → raw findings.
+2. `apply_profile_overrides` applies profile severity boosts and disables.
+3. `apply_overrides` applies per-rule `RuleOverride` entries from
+   `hasscheck.yaml` — user intent always wins over profile.
+
+This ensures profiles are curated recommendations, not mandates. A user can
+always silence a rule that the profile boosted to REQUIRED.
+
+### 5. CLI `--profile` wins over `profile:` in hasscheck.yaml
+
+When both the CLI `--profile` flag and `profile:` in `hasscheck.yaml` are
+present, the CLI value takes precedence. This matches `--no-config` precedence
+semantics: the most-recent explicit intent wins.
+
+### 6. Non-overridable rules are silently skipped by profiles
+
+Profiles cannot mutate rules with `overridable=False`. Any rule_id from
+`profile.severity_overrides` or `profile.disabled_rules` whose rule has
+`overridable=False` is silently passed through unchanged at apply time. This
+keeps locked rules truly locked — profiles are recommendations, not bypasses.
+
+### 7. RuleDefinition.profiles stays empty in v1; PROFILES owns the mapping
+
+The `RuleDefinition.profiles` field (issue #147) is intentionally left empty
+in v1. The `PROFILES` mapping in `src/hasscheck/profiles.py` is the single
+source of truth for which profiles a rule belongs to. This avoids churn across
+52+ rule definitions when adjusting profiles. A future `RuleDefinition.profiles`
+backfill can be done as a separate, mechanical PR once the profile set
+stabilises.
+
+## Consequences
+
+- **schema_version bumps 0.6.0 → 0.7.0.** Older configs (0.2.0–0.6.0) still
+  parse; the `profile` field is rejected on versions below 0.7.0 with a clear
+  validation error.
+- **`ApplicabilitySource` Literal extends to include `"profile"`.** This is
+  schema-visible (findings JSON `applicability.source`) but additive; existing
+  consumers that read this field treat it as opaque text and continue to work.
+- **`hasscheck init` and the scaffold template** produce
+  `schema_version: "0.7.0"` as the new default. Existing `hasscheck.yaml`
+  files at lower versions continue to parse without modification.
+- **`core-submission-candidate` is intentionally aggressive** (~43 boosts —
+  every overridable RECOMMENDED rule). Authors should only use this profile
+  when actively preparing for upstream Core contribution.
+- **A parity test** (`test_core_submission_candidate_covers_every_overridable_recommended_rule`)
+  enforces that `_CORE_SUBMISSION_RULE_IDS` in `profiles.py` stays in sync with
+  the rule registry. When a new overridable RECOMMENDED rule lands, the test
+  fails, forcing the author to decide whether it belongs in core-submission.
+- **A future `--profile auto`** (shape detection) is non-breaking — the design
+  leaves room for it without schema changes.
+
+## Alternatives considered
+
+- **YAML profile files at v1** — deferred; adds I/O and parser surface for no
+  v1 benefit. Python dataclasses are simpler and more testable.
+
+- **Backfill `RuleDefinition.profiles` on all 52 rules** — rejected per D7;
+  the profile→rule mapping lives in `profiles.py` to avoid per-rule churn.
+
+- **Profile wins over per-rule `RuleOverride`** — rejected; user explicit
+  intent must always win.
+
+- **Profile name validated at Pydantic load time** — rejected; would couple
+  the config layer to the profile registry and require importing `profiles.py`
+  from `config.py`. Validation deferred to `run_check` is cleaner.
+
+- **Empty `--profile ""` raising a `BadParameter`** — rejected; short-circuits
+  naturally to the config value or `None` via `profile or ...`. Acceptable
+  behavior.
+
+- **`core-submission-candidate` derived from registry at import time** —
+  rejected; silent semantics drift when adding new RECOMMENDED rules. The
+  explicit literal list plus the parity test is intentional.
+
+## Related
+
+- ADR 0014 — Quality gate modes (parallel feature; gate is independent of profile)
+- Issue #146 — Source issue
+- Issue #147 — Added `RuleDefinition.profiles` field (now intentionally unused in v1)
+- Proposal: `sdd/146-quality-profiles/proposal` (engram)

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -8,14 +8,18 @@ from pathlib import Path
 from hasscheck.config import HassCheckConfig, apply_overrides, discover_config
 from hasscheck.detect import detect_project
 from hasscheck.models import (
+    Applicability,
     ApplicabilityApplied,
+    ApplicabilityStatus,
     CategorySignal,
     HassCheckReport,
     ProjectInfo,
     ReportSummary,
     RuleStatus,
 )
+from hasscheck.profiles import PROFILES, ProfileDefinition
 from hasscheck.provenance import detect_provenance
+from hasscheck.rules.base import RuleDefinition
 from hasscheck.rules.registry import RULES
 from hasscheck.slug import detect_repo_slug
 from hasscheck.target import build_validity, detect_target
@@ -46,12 +50,89 @@ CATEGORY_LABELS = {
 }
 
 
+def apply_profile_overrides(
+    findings: list,
+    profile: ProfileDefinition | None,
+    rules: list[RuleDefinition],
+) -> list:
+    """Apply profile severity boosts and disables to findings.
+
+    Returns a new list. Findings whose rule_id is in profile.disabled_rules
+    become NOT_APPLICABLE with applicability.source='profile'. Findings whose
+    rule_id is in profile.severity_overrides AND whose rule is overridable
+    receive the boosted severity. Non-overridable rules are silently passed
+    through unchanged (D6 — profiles cannot mutate locked rules).
+
+    profile=None is the no-op case: findings are returned as a new list,
+    unchanged in content.
+
+    Override order documented here: (1) rules fire, (2) profile overrides,
+    (3) per-rule config overrides.
+    """
+    if profile is None:
+        return list(findings)
+
+    rule_by_id = {r.id: r for r in rules}
+    result = []
+
+    for finding in findings:
+        rule = rule_by_id.get(finding.rule_id)
+
+        # Disabled by profile → mark not_applicable, source='profile'
+        if finding.rule_id in profile.disabled_rules:
+            if rule is None or not rule.overridable:
+                # D6 — silently skip non-overridable rules
+                result.append(finding)
+                continue
+            result.append(
+                finding.model_copy(
+                    update={
+                        "status": RuleStatus.NOT_APPLICABLE,
+                        "applicability": Applicability(
+                            status=ApplicabilityStatus.NOT_APPLICABLE,
+                            reason=f"Disabled by profile '{profile.id}'.",
+                            source="profile",
+                        ),
+                    }
+                )
+            )
+            continue
+
+        # Severity boost — only when rule is overridable
+        if (
+            finding.rule_id in profile.severity_overrides
+            and rule is not None
+            and rule.overridable
+        ):
+            result.append(
+                finding.model_copy(
+                    update={"severity": profile.severity_overrides[finding.rule_id]}
+                )
+            )
+            continue
+
+        # Pass through unchanged
+        result.append(finding)
+
+    return result
+
+
 def run_check(
     path: Path | str,
     *,
     config: HassCheckConfig | None = None,
     no_config: bool = False,
+    profile_name: str | None = None,
 ) -> HassCheckReport:
+    """Run a full HassCheck report for the given repository path.
+
+    Override order:
+      1. Rules fire and produce raw findings.
+      2. Profile severity_overrides and disabled_rules are applied
+         (apply_profile_overrides). Only overridable rules are affected.
+      3. Per-rule RuleOverride entries from hasscheck.yaml are applied last
+         (apply_overrides). User intent always wins over profile.
+    """
     if config is not None and no_config:
         raise ValueError("Cannot pass both config= and no_config=True; pick one.")
 
@@ -89,6 +170,18 @@ def run_check(
         )
 
     findings = [rule.check(context) for rule in RULES]
+
+    # --- profile resolution: CLI argument wins over config (D5) ---
+    effective_profile_name = profile_name or (config.profile if config else None)
+    if effective_profile_name is not None:
+        if effective_profile_name not in PROFILES:
+            raise ValueError(
+                f"Unknown profile: {effective_profile_name!r}. "
+                f"Known profiles: {sorted(PROFILES)}."
+            )
+        findings = apply_profile_overrides(
+            findings, PROFILES[effective_profile_name], RULES
+        )
 
     config_applicability_rule_ids = sorted(
         finding.rule_id

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from enum import StrEnum
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -119,6 +120,18 @@ def check(
         "--no-config",
         help="Ignore hasscheck.yaml even if present (useful for CI debugging).",
     ),
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            "-P",
+            help=(
+                "Apply a built-in quality profile: cloud-service, local-device, "
+                "hub, helper, read-only-sensor, core-submission-candidate. "
+                "Wins over `profile:` in hasscheck.yaml."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Check a custom integration repository and print actionable findings.
 
@@ -130,6 +143,7 @@ def check(
       hasscheck check --path . --format json
       hasscheck check --path . --format md
       hasscheck check --path . --no-config
+      hasscheck check --path . --profile cloud-service
     """
     if not path.exists():
         console.print(f"[red]Error:[/] Path '{path}' does not exist.")
@@ -138,9 +152,24 @@ def check(
         )
         raise typer.Exit(code=1)
 
+    # Hoist discover_config to resolve effective_profile before run_check.
+    # D5: CLI --profile wins over config profile:.
     try:
-        report = run_check(path, no_config=no_config)
+        cfg = discover_config(path.resolve()) if not no_config else None
     except ConfigError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    effective_profile = profile or (cfg.profile if cfg else None)
+
+    try:
+        report = run_check(
+            path,
+            config=cfg,
+            no_config=no_config,
+            profile_name=effective_profile,
+        )
+    except (ConfigError, ValueError) as exc:
         typer.echo(f"hasscheck: error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
@@ -151,12 +180,6 @@ def check(
     else:
         print_terminal_report(report, console)
 
-    # intentional: gate evaluated separately from run_check for clean separation
-    # between the report-production logic and the exit-code policy.
-    try:
-        cfg = discover_config(path.resolve()) if not no_config else None
-    except ConfigError:
-        cfg = None
     _gate = cfg.gate if cfg else None
     if should_exit_nonzero(report.findings, _gate):
         raise typer.Exit(code=1)

--- a/src/hasscheck/config.py
+++ b/src/hasscheck/config.py
@@ -84,16 +84,22 @@ class PublishConfig(BaseModel):
 _GATE_SUPPORTED_FROM = "0.6.0"
 _PRE_GATE_VERSIONS = {"0.2.0", "0.3.0", "0.4.0", "0.5.0"}
 
+_PROFILE_SUPPORTED_FROM = "0.7.0"
+_PRE_PROFILE_VERSIONS = {"0.2.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0"}
+
 
 class HassCheckConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0"] = "0.6.0"
+    schema_version: Literal["0.2.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0", "0.7.0"] = (
+        "0.7.0"
+    )
     project: ProjectConfig | None = None
     applicability: ProjectApplicability | None = None
     rules: dict[str, RuleOverride] = Field(default_factory=dict)
     publish: PublishConfig | None = None
     gate: GateConfig | None = None
+    profile: str | None = None
 
     @model_validator(mode="after")
     def _schema_version_matches_fields(self) -> HassCheckConfig:
@@ -105,6 +111,11 @@ class HassCheckConfig(BaseModel):
             raise ValueError(
                 f"schema_version {self.schema_version!r} does not support the "
                 f"'gate' field; upgrade to {_GATE_SUPPORTED_FROM!r}"
+            )
+        if self.profile is not None and self.schema_version in _PRE_PROFILE_VERSIONS:
+            raise ValueError(
+                f"schema_version {self.schema_version!r} does not support the "
+                f"'profile' field; upgrade to {_PROFILE_SUPPORTED_FROM!r}"
             )
         return self
 

--- a/src/hasscheck/models.py
+++ b/src/hasscheck/models.py
@@ -35,7 +35,7 @@ class RuleSeverity(StrEnum):
     INFORMATIONAL = "informational"
 
 
-ApplicabilitySource = Literal["default", "detected", "config"]
+ApplicabilitySource = Literal["default", "detected", "config", "profile"]
 
 IntegrationVersionSource = Literal[
     "manifest",

--- a/src/hasscheck/profiles.py
+++ b/src/hasscheck/profiles.py
@@ -1,0 +1,217 @@
+"""Built-in quality profiles (#146 / ADR-0015).
+
+Profiles are curated severity baselines for specific Home Assistant integration
+shapes (cloud-service, local-device, hub, helper, read-only-sensor,
+core-submission-candidate). Each profile may:
+
+  - Boost RECOMMENDED rules to REQUIRED (severity_overrides).
+  - Mark rules as not_applicable for the integration shape (disabled_rules).
+
+Profiles are PURE RECOMMENDATIONS. Per-rule user RuleOverride entries in
+hasscheck.yaml take precedence (D4 in the proposal). Profiles cannot mutate
+non-overridable rules — those entries are silently skipped at apply time (D6).
+
+Profile definitions are standalone maps; RuleDefinition.profiles field is NOT
+populated here (ADR 0015 D7).
+
+Rule IDs in this module MUST exist in hasscheck.rules.registry.RULES_BY_ID
+AND have overridable=True. Both invariants are enforced by tests in
+tests/test_profiles.py (NOT at import time, to avoid circular imports
+between rules.registry and profiles).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from hasscheck.models import RuleSeverity
+
+
+@dataclass(frozen=True)
+class ProfileDefinition:
+    """A named quality profile that adjusts rule severity and applicability.
+
+    Fields:
+        id: Unique profile identifier (kebab-case).
+        title: Short human-readable title.
+        description: Longer description of the integration shape this covers.
+        severity_overrides: Mapping of rule_id → new RuleSeverity.
+            Only rules with overridable=True are affected at apply time.
+        disabled_rules: Rule IDs whose findings are forced to NOT_APPLICABLE.
+            Only rules with overridable=True are affected at apply time.
+    """
+
+    id: str
+    title: str
+    description: str
+    severity_overrides: dict[str, RuleSeverity] = field(default_factory=dict)
+    disabled_rules: frozenset[str] = field(default_factory=frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Built-in profile definitions (ADR-0015 — frozen at v1)
+# ---------------------------------------------------------------------------
+
+CLOUD_SERVICE = ProfileDefinition(
+    id="cloud-service",
+    title="Cloud-backed integration",
+    description=(
+        "Cloud-backed integration: reauth, diagnostics redaction, and privacy "
+        "documentation are critical for credentialed external services."
+    ),
+    severity_overrides={
+        "config_flow.reauth_step.exists": RuleSeverity.REQUIRED,
+        "diagnostics.redaction.used": RuleSeverity.REQUIRED,
+        "docs.privacy.exists": RuleSeverity.REQUIRED,
+    },
+    disabled_rules=frozenset(),
+)
+
+LOCAL_DEVICE = ProfileDefinition(
+    id="local-device",
+    title="LAN-only device integration",
+    description=(
+        "LAN-only device integration: stable device identity and unique IDs "
+        "are critical; privacy-policy documentation rarely applies."
+    ),
+    severity_overrides={
+        "config_flow.unique_id.set": RuleSeverity.REQUIRED,
+        "entity.device_info.set": RuleSeverity.REQUIRED,
+        "entity.unique_id.set": RuleSeverity.REQUIRED,
+    },
+    disabled_rules=frozenset({"docs.privacy.exists"}),
+)
+
+HUB = ProfileDefinition(
+    id="hub",
+    title="Hub / coordinator integration",
+    description=(
+        "Hub or coordinator managing child entities: device registry "
+        "and full setup/unload lifecycle support are critical."
+    ),
+    severity_overrides={
+        "entity.device_info.set": RuleSeverity.REQUIRED,
+        "init.async_setup_entry.defined": RuleSeverity.REQUIRED,
+        "tests.unload.detected": RuleSeverity.REQUIRED,
+    },
+    disabled_rules=frozenset(),
+)
+
+HELPER = ProfileDefinition(
+    id="helper",
+    title="Helper-style integration",
+    description=(
+        "Helper-style integration (template, derivative, computed): "
+        "config flow and tests matter most; device/diagnostics rarely apply."
+    ),
+    severity_overrides={
+        "config_flow.file.exists": RuleSeverity.REQUIRED,
+        "tests.config_flow.detected": RuleSeverity.REQUIRED,
+    },
+    disabled_rules=frozenset(
+        {
+            "entity.device_info.set",
+            "diagnostics.file.exists",
+        }
+    ),
+)
+
+READ_ONLY_SENSOR = ProfileDefinition(
+    id="read-only-sensor",
+    title="Read-only sensor integration",
+    description=(
+        "Read-only sensor integration: tests + README presence matter; "
+        "reauth and repair flows typically do not apply."
+    ),
+    severity_overrides={
+        "tests.folder.exists": RuleSeverity.REQUIRED,
+        "docs.readme.exists": RuleSeverity.REQUIRED,
+    },
+    disabled_rules=frozenset(
+        {
+            "config_flow.reauth_step.exists",
+            "repairs.file.exists",
+        }
+    ),
+)
+
+# Hardcoded enumeration of every overridable RECOMMENDED rule ID at v0.15.x.
+# This is INTENTIONALLY a literal list (not derived from RULES at import time)
+# so that adding a new RECOMMENDED rule does NOT silently change
+# `core-submission-candidate` semantics. A test in tests/test_profiles.py
+# enforces parity — when a new overridable RECOMMENDED rule lands, this
+# list MUST be updated in the same PR (the test fails otherwise).
+# Parity test enforces sync when new RECOMMENDED rules land.
+_CORE_SUBMISSION_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "brand.icon.exists",
+        "ci.github_actions.exists",
+        "config_flow.connection_test",
+        "config_flow.file.exists",
+        "config_flow.reauth_step.exists",
+        "config_flow.reconfigure_step.exists",
+        "config_flow.unique_id.set",
+        "config_flow.user_step.exists",
+        "diagnostics.file.exists",
+        "diagnostics.redaction.used",
+        "docs.configuration.exists",
+        "docs.examples.exists",
+        "docs.hacs_instructions.exists",
+        "docs.installation.exists",
+        "docs.limitations.exists",
+        "docs.privacy.exists",
+        "docs.readme.exists",
+        "docs.removal.exists",
+        "docs.supported_devices.exists",
+        "docs.troubleshooting.exists",
+        "entity.device_info.set",
+        "entity.has_entity_name.set",
+        "entity.unique_id.set",
+        "init.async_setup_entry.defined",
+        "init.runtime_data.used",
+        "maintenance.changelog.exists",
+        "maintenance.recent_commit.detected",
+        "maintenance.recent_release.detected",
+        "manifest.integration_type.exists",
+        "manifest.integration_type.valid",
+        "manifest.iot_class.exists",
+        "manifest.iot_class.valid",
+        "manifest.requirements.entries_well_formed",
+        "manifest.requirements.no_git_or_url_specs",
+        "repairs.file.exists",
+        "repo.license.exists",
+        "tests.config_flow.detected",
+        "tests.folder.exists",
+        "tests.setup_entry.detected",
+        "tests.unload.detected",
+        "version.identity.present",
+        "version.manifest.resolvable",
+        "version.matches.release_tag",
+    }
+)
+
+CORE_SUBMISSION_CANDIDATE = ProfileDefinition(
+    id="core-submission-candidate",
+    title="Targeting Home Assistant core submission",
+    description=(
+        "Targeting Home Assistant core submission: every overridable "
+        "RECOMMENDED rule is boosted to REQUIRED. Use this profile only when "
+        "preparing an integration for upstream contribution."
+    ),
+    severity_overrides={
+        rule_id: RuleSeverity.REQUIRED for rule_id in _CORE_SUBMISSION_RULE_IDS
+    },
+    disabled_rules=frozenset(),
+)
+
+PROFILES: dict[str, ProfileDefinition] = {
+    p.id: p
+    for p in (
+        CLOUD_SERVICE,
+        LOCAL_DEVICE,
+        HUB,
+        HELPER,
+        READ_ONLY_SENSOR,
+        CORE_SUBMISSION_CANDIDATE,
+    )
+}

--- a/src/hasscheck/profiles.py
+++ b/src/hasscheck/profiles.py
@@ -215,3 +215,8 @@ PROFILES: dict[str, ProfileDefinition] = {
         CORE_SUBMISSION_CANDIDATE,
     )
 }
+
+
+def get_profile(name: str) -> ProfileDefinition | None:
+    """Return a built-in profile by name, or None if not found."""
+    return PROFILES.get(name)

--- a/src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl
+++ b/src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl
@@ -2,7 +2,7 @@
 # Docs: https://github.com/Daily-Nerd/hasscheck#configuration
 # ADRs: docs/decisions/0001, 0003, 0004 (in the hasscheck repo)
 
-schema_version: "0.6.0"
+schema_version: "0.7.0"
 
 # Project applicability — declare only facts you are confident about.
 # Uncomment any flag below where you know the answer.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -441,6 +441,22 @@ def test_run_check_cli_profile_name_overrides_config_profile(tmp_path) -> None:
     )
 
 
+def test_run_check_read_only_sensor_disables_reauth_step(tmp_path) -> None:
+    """A4: read-only-sensor profile marks config_flow.reauth_step.exists as not_applicable."""
+    from hasscheck.models import RuleStatus
+
+    report = run_check(tmp_path, no_config=True, profile_name="read-only-sensor")
+    findings_by_id = {f.rule_id: f for f in report.findings}
+    assert (
+        findings_by_id["config_flow.reauth_step.exists"].status
+        == RuleStatus.NOT_APPLICABLE
+    )
+    assert (
+        findings_by_id["config_flow.reauth_step.exists"].applicability.source
+        == "profile"
+    )
+
+
 def test_run_check_user_rule_override_wins_over_profile_boost(tmp_path) -> None:
     """Per-rule config override supersedes profile severity boost."""
     from hasscheck.config import HassCheckConfig, RuleOverride

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import json
 
 import pytest
 
 from hasscheck.checker import run_check
 from hasscheck.config import HassCheckConfig, RuleOverride
-from hasscheck.models import RuleStatus
+from hasscheck.models import Finding, RuleStatus
 
 
 def test_missing_custom_components_and_manifest_are_reported(tmp_path) -> None:
@@ -182,3 +184,282 @@ def test_category_label_version_identity_present() -> None:
     from hasscheck.checker import CATEGORY_LABELS
 
     assert CATEGORY_LABELS["version"] == "Version Identity"
+
+
+# ---------- Phase 3: ApplicabilitySource "profile" + apply_profile_overrides ----------
+
+
+def test_applicability_source_accepts_profile() -> None:
+    """ApplicabilitySource must include 'profile' as a valid literal value."""
+    from hasscheck.models import Applicability, ApplicabilityStatus
+
+    a = Applicability(
+        status=ApplicabilityStatus.NOT_APPLICABLE,
+        reason="Disabled by profile 'test'.",
+        source="profile",
+    )
+    assert a.source == "profile"
+
+
+def _make_finding_for_checker(
+    rule_id: str = "docs.readme.exists",
+    severity: str = "recommended",
+    status: str = "warn",
+) -> Finding:
+    """Build a minimal Finding for apply_profile_overrides tests."""
+    from hasscheck.models import (
+        Applicability,
+        ApplicabilityStatus,
+        RuleSeverity,
+        RuleSource,
+        RuleStatus,
+    )
+
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        category="test",
+        status=RuleStatus(status),
+        severity=RuleSeverity(severity),
+        title=f"{rule_id} title",
+        message=f"{rule_id} message",
+        applicability=Applicability(
+            status=ApplicabilityStatus.APPLICABLE,
+            reason="test reason",
+        ),
+        source=RuleSource(url="https://example.com"),
+    )
+
+
+def test_apply_profile_overrides_none_returns_identical_list() -> None:
+    """apply_profile_overrides(findings, None, rules) returns a new list with same elements."""
+    from hasscheck.checker import apply_profile_overrides
+
+    findings = [_make_finding_for_checker()]
+    result = apply_profile_overrides(findings, None, [])
+    assert result == findings
+    assert result is not findings  # new list object
+
+
+def test_apply_profile_overrides_boosts_overridable_severity() -> None:
+    """Profile severity_override boosts a RECOMMENDED finding to REQUIRED."""
+    from hasscheck.checker import apply_profile_overrides
+    from hasscheck.models import RuleSeverity
+    from hasscheck.profiles import READ_ONLY_SENSOR
+    from hasscheck.rules.registry import RULES
+
+    finding = _make_finding_for_checker(
+        rule_id="docs.readme.exists",
+        severity="recommended",
+        status="warn",
+    )
+    result = apply_profile_overrides([finding], READ_ONLY_SENSOR, RULES)
+    assert len(result) == 1
+    assert result[0].severity == RuleSeverity.REQUIRED
+
+
+def test_apply_profile_overrides_disables_overridable_rule() -> None:
+    """Profile disabled_rules marks finding NOT_APPLICABLE with source='profile'."""
+    from hasscheck.checker import apply_profile_overrides
+    from hasscheck.models import RuleStatus
+    from hasscheck.profiles import LOCAL_DEVICE
+    from hasscheck.rules.registry import RULES
+
+    finding = _make_finding_for_checker(
+        rule_id="docs.privacy.exists",
+        severity="recommended",
+        status="warn",
+    )
+    result = apply_profile_overrides([finding], LOCAL_DEVICE, RULES)
+    assert len(result) == 1
+    assert result[0].status == RuleStatus.NOT_APPLICABLE
+    assert result[0].applicability.source == "profile"
+
+
+def test_apply_profile_overrides_skips_non_overridable_severity_override() -> None:
+    """A profile severity_override on a non-overridable rule is silently skipped."""
+
+    from hasscheck.checker import apply_profile_overrides
+    from hasscheck.models import RuleSeverity
+    from hasscheck.profiles import ProfileDefinition
+
+    # manifest.exists is non-overridable (overridable=False)
+    synthetic_profile = ProfileDefinition(
+        id="test-non-overridable-sev",
+        title="Test",
+        description="Test profile that boosts a locked rule.",
+        severity_overrides={"manifest.exists": RuleSeverity.REQUIRED},
+        disabled_rules=frozenset(),
+    )
+    # manifest.exists is REQUIRED + non-overridable; severity must stay unchanged
+    from hasscheck.models import (
+        Applicability,
+        ApplicabilityStatus,
+        Finding,
+        RuleSource,
+        RuleStatus,
+    )
+
+    finding = Finding(
+        rule_id="manifest.exists",
+        rule_version="1.0.0",
+        category="hacs_structure",
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest exists",
+        message="no manifest",
+        applicability=Applicability(status=ApplicabilityStatus.APPLICABLE, reason="t"),
+        source=RuleSource(url="https://example.com"),
+    )
+    from hasscheck.rules.registry import RULES
+
+    result = apply_profile_overrides([finding], synthetic_profile, RULES)
+    assert result[0].severity == RuleSeverity.REQUIRED  # unchanged
+    # No source change either
+    assert result[0].applicability.source != "profile"
+
+
+def test_apply_profile_overrides_skips_non_overridable_disable() -> None:
+    """A profile disabled_rules on a non-overridable rule is silently skipped."""
+    from hasscheck.checker import apply_profile_overrides
+    from hasscheck.models import (
+        Applicability,
+        ApplicabilityStatus,
+        Finding,
+        RuleSeverity,
+        RuleSource,
+        RuleStatus,
+    )
+    from hasscheck.profiles import ProfileDefinition
+
+    synthetic_profile = ProfileDefinition(
+        id="test-non-overridable-disable",
+        title="Test",
+        description="Test profile that disables a locked rule.",
+        severity_overrides={},
+        disabled_rules=frozenset({"manifest.exists"}),
+    )
+    finding = Finding(
+        rule_id="manifest.exists",
+        rule_version="1.0.0",
+        category="hacs_structure",
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title="manifest exists",
+        message="no manifest",
+        applicability=Applicability(status=ApplicabilityStatus.APPLICABLE, reason="t"),
+        source=RuleSource(url="https://example.com"),
+    )
+    from hasscheck.rules.registry import RULES
+
+    result = apply_profile_overrides([finding], synthetic_profile, RULES)
+    assert result[0].status == RuleStatus.FAIL  # unchanged
+    assert result[0].applicability.source != "profile"
+
+
+def test_apply_profile_overrides_does_not_mutate_original_findings() -> None:
+    """apply_profile_overrides never mutates the input finding objects."""
+    from hasscheck.checker import apply_profile_overrides
+    from hasscheck.profiles import READ_ONLY_SENSOR
+    from hasscheck.rules.registry import RULES
+
+    original = _make_finding_for_checker(
+        rule_id="docs.readme.exists",
+        severity="recommended",
+        status="warn",
+    )
+    original_severity = original.severity
+    original_status = original.status
+
+    apply_profile_overrides([original], READ_ONLY_SENSOR, RULES)
+
+    assert original.severity == original_severity
+    assert original.status == original_status
+
+
+# ---------- Phase 4: run_check profile integration ----------
+
+
+def test_run_check_unknown_profile_name_raises_value_error(tmp_path) -> None:
+    """run_check with an unknown profile name raises ValueError with 'Unknown profile'."""
+    with pytest.raises(ValueError, match="Unknown profile"):
+        run_check(tmp_path, profile_name="bogus-profile-doesnt-exist")
+
+
+def test_run_check_no_profile_identical_to_baseline(tmp_path) -> None:
+    """run_check with no profile produces same findings as without profile kwarg."""
+    report_no_profile = run_check(tmp_path, no_config=True)
+    report_explicit_none = run_check(tmp_path, no_config=True, profile_name=None)
+
+    # severity values should be identical
+    baseline = {f.rule_id: f.severity for f in report_no_profile.findings}
+    with_none = {f.rule_id: f.severity for f in report_explicit_none.findings}
+    assert baseline == with_none
+
+
+def test_run_check_profile_boosts_severity_in_report(tmp_path) -> None:
+    """cloud-service profile boosts config_flow.reauth_step.exists to REQUIRED."""
+    from hasscheck.models import RuleSeverity
+
+    report = run_check(tmp_path, no_config=True, profile_name="cloud-service")
+    findings_by_id = {f.rule_id: f for f in report.findings}
+
+    assert (
+        findings_by_id["config_flow.reauth_step.exists"].severity
+        == RuleSeverity.REQUIRED
+    )
+
+
+def test_run_check_profile_name_resolves_from_config(tmp_path) -> None:
+    """When profile set in config, it is applied during run_check."""
+    from hasscheck.config import HassCheckConfig
+    from hasscheck.models import RuleSeverity
+
+    config = HassCheckConfig(
+        schema_version="0.7.0",
+        profile="read-only-sensor",
+    )
+    report = run_check(tmp_path, config=config)
+    findings_by_id = {f.rule_id: f for f in report.findings}
+    assert findings_by_id["docs.readme.exists"].severity == RuleSeverity.REQUIRED
+
+
+def test_run_check_cli_profile_name_overrides_config_profile(tmp_path) -> None:
+    """CLI profile_name wins over config.profile."""
+    from hasscheck.config import HassCheckConfig
+    from hasscheck.models import RuleSeverity
+
+    config = HassCheckConfig(
+        schema_version="0.7.0",
+        profile="helper",
+    )
+    # cloud-service boosts diagnostics.redaction.used; helper does not
+    report = run_check(tmp_path, config=config, profile_name="cloud-service")
+    findings_by_id = {f.rule_id: f for f in report.findings}
+    assert (
+        findings_by_id["diagnostics.redaction.used"].severity == RuleSeverity.REQUIRED
+    )
+
+
+def test_run_check_user_rule_override_wins_over_profile_boost(tmp_path) -> None:
+    """Per-rule config override supersedes profile severity boost."""
+    from hasscheck.config import HassCheckConfig, RuleOverride
+    from hasscheck.models import RuleStatus
+
+    config = HassCheckConfig(
+        schema_version="0.7.0",
+        rules={
+            "config_flow.reauth_step.exists": RuleOverride(
+                status="not_applicable",
+                reason="read-only integration, no reauth needed",
+            )
+        },
+    )
+    # cloud-service boosts config_flow.reauth_step.exists to REQUIRED,
+    # but user override marks it not_applicable → user wins
+    report = run_check(tmp_path, config=config, profile_name="cloud-service")
+    findings_by_id = {f.rule_id: f for f in report.findings}
+    assert (
+        findings_by_id["config_flow.reauth_step.exists"].status
+        == RuleStatus.NOT_APPLICABLE
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -788,3 +788,71 @@ def test_check_legacy_no_gate_stanza_no_fail_exits_zero(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert all(f["status"] != "fail" for f in payload["findings"])
     assert result.exit_code == 0
+
+
+# ---------- Phase 6: --profile flag (#146) ----------
+
+
+def test_check_profile_flag_accepted(tmp_path: Path) -> None:
+    """--profile cloud-service is accepted and runs without error (exit depends on findings)."""
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--path",
+            str(tmp_path),
+            "--profile",
+            "cloud-service",
+            "--format",
+            "json",
+        ],
+    )
+    # exit code can be 0 or 1 (findings); what matters is not 2 (usage error)
+    assert result.exit_code in (0, 1), (
+        f"Unexpected exit code: {result.exit_code}\n{result.output}"
+    )
+    # output is valid JSON
+    payload = json.loads(result.stdout)
+    findings_by_id = {f["rule_id"]: f for f in payload["findings"]}
+    # cloud-service boosts config_flow.reauth_step.exists to required
+    assert findings_by_id["config_flow.reauth_step.exists"]["severity"] == "required", (
+        "cloud-service profile should boost config_flow.reauth_step.exists to required"
+    )
+
+
+def test_check_profile_flag_wins_over_config(tmp_path: Path) -> None:
+    """CLI --profile overrides profile: in hasscheck.yaml."""
+    (tmp_path / "hasscheck.yaml").write_text(
+        "schema_version: '0.7.0'\nprofile: helper\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--path",
+            str(tmp_path),
+            "--profile",
+            "cloud-service",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code in (0, 1)
+    payload = json.loads(result.stdout)
+    findings_by_id = {f["rule_id"]: f for f in payload["findings"]}
+    # cloud-service boosts diagnostics.redaction.used (helper does not)
+    assert findings_by_id["diagnostics.redaction.used"]["severity"] == "required", (
+        "CLI --profile cloud-service should win over config profile: helper"
+    )
+
+
+def test_check_unknown_profile_exits_nonzero_with_error_message(tmp_path: Path) -> None:
+    """--profile unknown-profile exits 1 and prints 'Unknown profile' to stderr."""
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--profile", "unknown-bogus-profile"],
+    )
+    assert result.exit_code == 1
+    combined_output = (result.output or "") + (result.stderr or "")
+    assert "Unknown profile" in combined_output or "unknown" in combined_output.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,11 +96,12 @@ def test_project_config_rejects_extra_fields() -> None:
 
 def test_hasscheck_config_empty_defaults() -> None:
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.6.0"
+    assert cfg.schema_version == "0.7.0"
     assert cfg.project is None
     assert cfg.applicability is None
     assert cfg.rules == {}
     assert cfg.gate is None
+    assert cfg.profile is None
 
 
 def test_hasscheck_config_with_rules() -> None:
@@ -518,7 +519,7 @@ def test_hasscheck_config_accepts_applicability_block() -> None:
         applicability=ProjectApplicability(supports_diagnostics=False)
     )
 
-    assert cfg.schema_version == "0.6.0"
+    assert cfg.schema_version == "0.7.0"
     assert cfg.applicability is not None
     assert cfg.applicability.supports_diagnostics is False
 
@@ -646,9 +647,9 @@ def test_load_config_file_v03_backward_compat_no_publish(tmp_path: Path) -> None
 
 
 def test_hasscheck_config_default_schema_version_is_0_6_0() -> None:
-    """Default instantiation yields schema_version 0.6.0 (bumped from 0.5.0 in #148)."""
+    """Default instantiation yields schema_version 0.7.0 (bumped from 0.6.0 in #146)."""
     cfg = HassCheckConfig()
-    assert cfg.schema_version == "0.6.0"
+    assert cfg.schema_version == "0.7.0"
 
 
 def test_hasscheck_config_accepts_explicit_0_4_0() -> None:
@@ -744,3 +745,36 @@ def test_no_gate_field_defaults_to_none() -> None:
 def test_unknown_schema_version_rejected() -> None:
     with pytest.raises(ValidationError):
         HassCheckConfig(schema_version="9.9.9")  # type: ignore[arg-type]
+
+
+# ---------- Phase 5: schema 0.7.0 + profile field (#146) ----------
+
+
+def test_hasscheck_config_default_schema_version_is_070() -> None:
+    """Default instantiation yields schema_version 0.7.0 (bumped from 0.6.0 in #146)."""
+    cfg = HassCheckConfig()
+    assert cfg.schema_version == "0.7.0"
+    assert cfg.profile is None
+
+
+def test_hasscheck_config_profile_field_accepts_string_on_070() -> None:
+    cfg = HassCheckConfig(schema_version="0.7.0", profile="cloud-service")
+    assert cfg.profile == "cloud-service"
+
+
+def test_hasscheck_config_profile_rejected_on_060() -> None:
+    """profile field must not be accepted on schema_version 0.6.0."""
+    with pytest.raises(ValidationError, match="profile"):
+        HassCheckConfig(schema_version="0.6.0", profile="cloud-service")
+
+
+def test_hasscheck_config_060_without_profile_still_valid() -> None:
+    """Existing 0.6.0 configs without profile field remain valid."""
+    cfg = HassCheckConfig(schema_version="0.6.0")
+    assert cfg.schema_version == "0.6.0"
+    assert cfg.profile is None
+
+
+def test_hasscheck_config_profile_field_defaults_to_none() -> None:
+    cfg = HassCheckConfig(schema_version="0.7.0")
+    assert cfg.profile is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,7 +21,7 @@ def test_init_yaml_is_valid_hasscheck_config(tmp_path):
     init_project(tmp_path)
     parsed = yaml.safe_load((tmp_path / "hasscheck.yaml").read_text())
     config = HassCheckConfig(**parsed)
-    assert config.schema_version == "0.6.0"
+    assert config.schema_version == "0.7.0"
     assert config.rules == {}
     assert config.gate is None
 
@@ -129,3 +129,15 @@ def test_init_enable_publish_missing_template_raises(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         init_project(tmp_path, enable_publish=True)
+
+
+# ---------- Phase 7: scaffold schema_version bump to 0.7.0 (#146) ----------
+
+
+def test_init_yaml_contains_schema_version_070(tmp_path):
+    """Scaffold output must contain schema_version: '0.7.0' (bumped from 0.6.0 in #146)."""
+    init_project(tmp_path, skip_action=True)
+    content = (tmp_path / "hasscheck.yaml").read_text()
+    assert '"0.7.0"' in content or "'0.7.0'" in content, (
+        f"Expected schema_version '0.7.0' in scaffold output, got:\n{content}"
+    )

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,149 @@
+"""Tests for hasscheck.profiles — ProfileDefinition dataclass and built-in profiles."""
+
+from __future__ import annotations
+
+import pytest
+
+from hasscheck.models import RuleSeverity
+from hasscheck.profiles import (
+    CLOUD_SERVICE,
+    CORE_SUBMISSION_CANDIDATE,
+    HELPER,
+    LOCAL_DEVICE,
+    PROFILES,
+    ProfileDefinition,
+)
+
+EXPECTED_PROFILE_IDS = {
+    "cloud-service",
+    "local-device",
+    "hub",
+    "helper",
+    "read-only-sensor",
+    "core-submission-candidate",
+}
+
+
+# ---------- Phase 1.1: registry size + keying + frozen ----------
+
+
+def test_profiles_registry_contains_exactly_six_built_ins() -> None:
+    assert set(PROFILES) == EXPECTED_PROFILE_IDS
+
+
+def test_each_profile_keyed_by_its_own_id() -> None:
+    for name, profile in PROFILES.items():
+        assert profile.id == name
+
+
+def test_profile_dataclass_is_frozen() -> None:
+    """Mutating any field raises FrozenInstanceError."""
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        CLOUD_SERVICE.id = "x"  # type: ignore[misc]
+
+
+# ---------- Phase 1.3: invariant tests (rule IDs exist + overridable) ----------
+
+
+@pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.id)
+def test_profile_severity_override_rule_ids_exist_in_registry(
+    profile: ProfileDefinition,
+) -> None:
+    from hasscheck.rules.registry import RULES_BY_ID
+
+    for rule_id in profile.severity_overrides:
+        assert rule_id in RULES_BY_ID, (
+            f"Profile {profile.id!r} references unknown rule_id {rule_id!r} "
+            f"in severity_overrides"
+        )
+
+
+@pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.id)
+def test_profile_disabled_rule_ids_exist_in_registry(
+    profile: ProfileDefinition,
+) -> None:
+    from hasscheck.rules.registry import RULES_BY_ID
+
+    for rule_id in profile.disabled_rules:
+        assert rule_id in RULES_BY_ID, (
+            f"Profile {profile.id!r} references unknown rule_id {rule_id!r} "
+            f"in disabled_rules"
+        )
+
+
+@pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.id)
+def test_profile_severity_overrides_target_overridable_rules(
+    profile: ProfileDefinition,
+) -> None:
+    from hasscheck.rules.registry import RULES_BY_ID
+
+    for rule_id in profile.severity_overrides:
+        rule = RULES_BY_ID[rule_id]
+        assert rule.overridable, (
+            f"Profile {profile.id!r} boosts non-overridable rule {rule_id!r}"
+        )
+
+
+@pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.id)
+def test_profile_disabled_rules_target_overridable_rules(
+    profile: ProfileDefinition,
+) -> None:
+    from hasscheck.rules.registry import RULES_BY_ID
+
+    for rule_id in profile.disabled_rules:
+        rule = RULES_BY_ID[rule_id]
+        assert rule.overridable, (
+            f"Profile {profile.id!r} disables non-overridable rule {rule_id!r}"
+        )
+
+
+# ---------- Phase 2.1: core-submission-candidate parity test ----------
+
+
+def test_core_submission_candidate_covers_every_overridable_recommended_rule() -> None:
+    """Parity guard: _CORE_SUBMISSION_RULE_IDS must exactly match the registry.
+
+    Adding a new overridable RECOMMENDED rule MUST be a deliberate decision
+    about core-submission-candidate scope (fails the test, forcing the author
+    to update _CORE_SUBMISSION_RULE_IDS in profiles.py).
+    """
+    from hasscheck.rules.registry import RULES_BY_ID
+
+    expected = frozenset(
+        rid
+        for rid, rule in RULES_BY_ID.items()
+        if rule.overridable and rule.severity is RuleSeverity.RECOMMENDED
+    )
+    actual = frozenset(CORE_SUBMISSION_CANDIDATE.severity_overrides)
+    assert actual == expected, (
+        f"CORE_SUBMISSION_CANDIDATE.severity_overrides does not match "
+        f"the current set of overridable RECOMMENDED rules.\n"
+        f"Missing from profile: {expected - actual}\n"
+        f"Extra in profile: {actual - expected}"
+    )
+
+
+# ---------- Cloud-service profile structure ----------
+
+
+def test_cloud_service_profile_has_three_severity_overrides() -> None:
+    assert len(CLOUD_SERVICE.severity_overrides) == 3
+    for _rule_id, sev in CLOUD_SERVICE.severity_overrides.items():
+        assert sev == RuleSeverity.REQUIRED
+
+
+def test_cloud_service_profile_has_empty_disabled_rules() -> None:
+    assert CLOUD_SERVICE.disabled_rules == frozenset()
+
+
+def test_local_device_profile_disables_privacy_rule() -> None:
+    assert "docs.privacy.exists" in LOCAL_DEVICE.disabled_rules
+
+
+def test_helper_profile_disables_device_info_and_diagnostics() -> None:
+    assert LOCAL_DEVICE.disabled_rules == frozenset({"docs.privacy.exists"})
+    assert HELPER.disabled_rules == frozenset(
+        {"entity.device_info.set", "diagnostics.file.exists"}
+    )


### PR DESCRIPTION
## Issue

Closes #146

## Summary

- Adds `--profile` CLI flag and `profile:` config field — six named integration-type profiles (`cloud-service`, `local-device`, `hub`, `helper`, `read-only-sensor`, `core-submission-candidate`) that adjust rule severities and disable inapplicable rules for the integration shape
- Implements `apply_profile_overrides()` in `checker.py` — runs after rules fire and before per-rule `RuleOverride` entries, so explicit user config always wins; non-overridable REQUIRED rules are never touched by profiles
- Config schema bumps `0.6.0` → `0.7.0`; extends `ApplicabilitySource` with `"profile"` value for provenance; ships ADR 0015

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/profiles.py` | NEW — `ProfileDefinition` frozen dataclass, 6 built-in profiles, `get_profile()` |
| `src/hasscheck/checker.py` | `apply_profile_overrides()` pure function; `run_check(profile_name=...)` |
| `src/hasscheck/config.py` | `profile: str \| None` field; schema `0.7.0`; cross-field validator |
| `src/hasscheck/cli.py` | `--profile`/`-P` flag; `effective_profile` resolution (CLI wins over config) |
| `src/hasscheck/models.py` | `ApplicabilitySource` Literal += `"profile"` |
| `src/hasscheck/scaffold/templates/hasscheck.yaml.tmpl` | Default schema → `0.7.0` |
| `docs/decisions/0015-quality-profiles.md` | ADR 0015 — 7 design decisions |
| `tests/test_profiles.py` | NEW — 32 tests (registry, parity, overridable invariants) |
| `tests/test_checker.py` | 13 new tests (apply_profile_overrides, run_check integration) |
| `tests/test_config.py` | 6 new tests (profile field, schema compat) |
| `tests/test_cli.py` | 3 new tests (--profile flag, precedence, unknown profile error) |

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: 1041 passed / 0 failed (986 → 1041, +55)
- [ ] Ran pre-commit:
- [x] Manual verification: parity test enforces `core-submission-candidate` covers exactly all overridable RECOMMENDED rules; profile→rule mappings verified against live registry; backward compat (no `profile:` + schema 0.6.0) confirmed passing

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [ ] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.