### PR TITLE
chore(release): bump version to 0.15.1 (#146)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.15.0"
+version = "0.15.1"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Issue

Closes #146

## Summary

- Bumps `hasscheck` version `0.15.0` → `0.15.1`
- Regenerates `uv.lock`
- Marks v0.15.1: quality profiles (#146)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `version = "0.15.1"` |
| `src/hasscheck/__init__.py` | `__version__ = "0.15.1"` |
| `uv.lock` | Regenerated |

## Test plan

- [ ] Not run (explain why):
- [x] Ran unit tests: 1041 passed (no new code)
- [ ] Ran pre-commit:
- [x] Manual verification: pre-commit hooks passed on commit

## Checklist

- [x] Linked the required issue above using `Closes #<issue>`.
- [x] Added or updated tests, or explained why tests are not needed.
- [ ] Ran pre-commit locally, or explained why it was not run.
- [x] Updated docs or examples when behavior changed.
- [x] Confirmed this PR has no `Co-Authored-By` or AI attribution trailers.