### PR TITLE
feat(baseline): accept existing findings as baseline (#149)

### DIFF
--- a/docs/decisions/0016-baseline-mode.md
+++ b/docs/decisions/0016-baseline-mode.md
@@ -1,0 +1,107 @@
+# ADR 0016 — Baseline mode: file-based suppression of pre-existing findings
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Tag**: v0.16.x (#149)
+
+## Context
+
+Adopting hasscheck on a brownfield repository (one with existing technical debt)
+produces a large number of FAIL/WARN findings on the first run. This makes it
+hard to gate CI on only *new* regressions while allowing the team to address
+existing issues incrementally. Whole-rule suppression (`rules: status: not_applicable`)
+destroys signal permanently and couples suppression to rule IDs rather than
+specific findings. A time-bounded "accept this known debt" mechanism is needed
+that preserves regression detection while surfacing resolved debt as wins.
+
+## Decision
+
+### 1. `baseline update` MERGES, never replaces (D1)
+
+When `hasscheck baseline update` is run on an existing baseline file:
+- Entries whose `finding_hash` still matches a live FAIL/WARN finding **preserve** their `reason` and `accepted_at` fields.
+- Entries whose `finding_hash` no longer matches any live finding are **dropped** (the debt was resolved).
+- Live FAIL/WARN findings with no matching baseline entry are **added** with `reason=""` and today's `accepted_at`.
+
+Header fields (`generated_at`, `hasscheck_version`, `ruleset`) are always refreshed.
+
+### 2. `baseline drop` removes by `--rule`; `--path` narrows (D2)
+
+`hasscheck baseline drop --rule <id>` removes ALL entries matching `rule_id=<id>`.
+`hasscheck baseline drop --rule <id> --path <file_path>` removes only the specific `(rule_id, path)` entry.
+If no entries match, the command exits non-zero with an error (typo guard). There is no `--dry-run` or `--all` in v1.
+
+### 3. JSON output stays clean (D3)
+
+The `--baseline` flag is a CLI-layer concern only. The `HassCheckReport` JSON contract is not modified. `report_to_json` is not touched. No `baseline_status` fields are added to `Finding`. Schema version is not bumped by this feature.
+
+### 4. `[accepted]`/`[new]`/`[fixed]` labels are terminal-only (D4)
+
+Terminal output (`--format terminal`) shows per-finding labels and a "N fixed since baseline" summary line when `--baseline` is passed. Markdown output (`--format md`) and JSON output are not modified. This avoids coupling the report contract to baseline state.
+
+### 5. `baseline create` refuses to overwrite; `--force` overrides (D5)
+
+`hasscheck baseline create` exits non-zero if `hasscheck-baseline.yaml` already exists at the target path, and the error message points the user to `baseline update` as the safe incremental workflow. Passing `--force` bypasses this guard and overwrites the file. This prevents accidental loss of `reason` annotations accumulated over time.
+
+### 6. Only FAIL and WARN findings enter the baseline (D6)
+
+`NOT_APPLICABLE`, `MANUAL_REVIEW`, and `PASS` findings are not eligible for the baseline. These statuses are not regressions and including them would inflate the baseline file with no actionable signal. The `_BASELINE_ELIGIBLE = frozenset({RuleStatus.FAIL, RuleStatus.WARN})` constant governs eligibility throughout the data layer.
+
+### 7. CLI-layer `FindingPartition`; no `Finding` mutation (architecture)
+
+The partition is computed in the CLI `check` command via `partition_findings(report.findings, baseline_file)` and passed to `print_terminal_report` as an optional keyword argument. The `Finding` model is not modified. Gate decisions consume `partition.new` instead of `report.findings` when a baseline is active. This is "Approach C" from the exploration: no schema bump, no public-contract leak, and gate/profile/gate-modes compose via `list[Finding]`.
+
+### 8. Hash policy: `sha256(rule_id|path|normalized_message)[:8]` (architecture)
+
+The finding hash is computed as:
+```
+sha256(f"{rule_id}|{path or ''}|{normalized_message}".encode("utf-8")).hexdigest()[:8]
+```
+where `normalized_message = " ".join(message.lower().split())`.
+
+Fields **excluded** from the hash: `status`, `severity`, `rule_version`, `source.checked_at`.
+
+8 hex characters = 32-bit collision space, ample for HA-integration baselines where the number of distinct findings is typically under 100. The normalization absorbs whitespace and casing rewrites; intentional message changes in rule code MAY require running `baseline update` — this is documented behavior, not a limitation.
+
+### 9. `baseline/` is a package, not a module (architecture)
+
+The data layer (`BaselineEntry`, `BaselineFile`, `FindingPartition`, hashing, partition, YAML I/O, builder helpers) lives in `src/hasscheck/baseline/core.py`. The CLI subapp lives in `src/hasscheck/baseline/cli.py`. The public surface is re-exported from `src/hasscheck/baseline/__init__.py`. Python disallows a same-named module and package on the import path, so `baseline.py` was never an option once the subapp was split out.
+
+### 10. No `HassCheckConfig` schema bump (architecture)
+
+The `--baseline` flag is a pure CLI option. It is not persisted in `hasscheck.yaml`. The `HassCheckConfig` Pydantic model is unchanged. Rollback is `git revert` of this feature branch; no migration path is needed.
+
+## Interactions
+
+### Profile suppression
+
+When a profile (ADR 0015) or per-rule override sets a finding's status to `NOT_APPLICABLE`, that finding exits the `_BASELINE_ELIGIBLE` set and cannot match a baseline entry. If a previously baselined rule is later suppressed by a profile change, its baseline entry will appear as `[fixed]` in terminal output on the next run — a cosmetic artifact, not a real fix. This is conservative behavior: the entry can be cleaned up with `baseline drop --rule <id>`.
+
+### Gate modes (ADR 0014)
+
+Gate modes compose cleanly. `should_exit_nonzero(gate_findings, gate)` receives `partition.new` instead of `report.findings` when a baseline is active. This means gate mode evaluation (advisory, strict-required, hacs-publish, upgrade-radar) applies only to genuinely new findings, not baselined ones.
+
+## Consequences
+
+- The feature is entirely additive. Without `--baseline`, behavior is identical to pre-0.16 hasscheck.
+- `hasscheck baseline` is a new top-level subapp discoverable via `hasscheck baseline --help`.
+- The `hasscheck-baseline.yaml` file should be committed to version control alongside `hasscheck.yaml`.
+- Hash brittleness on rule message rewrites is an accepted cost; `baseline update` is the recovery path.
+- The `accepted_at` date and `reason` fields enable future tooling (age-based reminders, audit reports) without schema changes.
+
+## Alternatives considered
+
+- **Add `baseline_status` to `Finding` model** — rejected per Decision 7; pollutes the public JSON contract and requires a schema version bump.
+- **Auto-discover `hasscheck-baseline.yaml`** — rejected; explicit beats implicit. The file may live in a non-root location in monorepos.
+- **Auto-regenerate baseline on every check** — rejected; silent debt growth defeats the purpose.
+- **`baseline drop --all`** — deferred; destructive shortcut. Want explicit per-rule UX first to understand usage patterns.
+- **`ruamel.yaml` for comment preservation** — deferred; PyYAML is sufficient for v1. `ruamel.yaml` adds a dependency and complexity.
+- **`schema_version` field on `BaselineFile`** — deferred; the format is trivial and a version field can be added without breaking existing files when needed.
+- **Store baseline entries in `hasscheck.yaml`** — rejected; separates concerns and avoids inflating the config file used by the gate.
+
+## Related
+
+- ADR 0014 — Quality gate modes (#148)
+- ADR 0015 — Quality profiles (#146)
+- Issue #149 — Source issue
+- Proposal: `sdd/149-baseline-mode/proposal` (engram)

--- a/src/hasscheck/baseline/__init__.py
+++ b/src/hasscheck/baseline/__init__.py
@@ -3,3 +3,31 @@
 Imports here are the stable contract for the rest of the codebase
 (cli.py, output.py, tests). Subapp wiring is exposed under `cli`.
 """
+
+from hasscheck.baseline.core import (
+    BaselineEntry,
+    BaselineError,
+    BaselineFile,
+    FindingPartition,
+    baseline_from_findings,
+    compute_finding_hash,
+    drop_from_baseline,
+    load_baseline,
+    merge_baseline,
+    partition_findings,
+    write_baseline,
+)
+
+__all__ = [
+    "BaselineEntry",
+    "BaselineError",
+    "BaselineFile",
+    "FindingPartition",
+    "baseline_from_findings",
+    "compute_finding_hash",
+    "drop_from_baseline",
+    "load_baseline",
+    "merge_baseline",
+    "partition_findings",
+    "write_baseline",
+]

--- a/src/hasscheck/baseline/__init__.py
+++ b/src/hasscheck/baseline/__init__.py
@@ -1,0 +1,5 @@
+"""Baseline mode public surface.
+
+Imports here are the stable contract for the rest of the codebase
+(cli.py, output.py, tests). Subapp wiring is exposed under `cli`.
+"""

--- a/src/hasscheck/baseline/cli.py
+++ b/src/hasscheck/baseline/cli.py
@@ -1,0 +1,1 @@
+"""`hasscheck baseline` subapp — create, update, drop."""

--- a/src/hasscheck/baseline/cli.py
+++ b/src/hasscheck/baseline/cli.py
@@ -1,1 +1,180 @@
 """`hasscheck baseline` subapp — create, update, drop."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from hasscheck import __version__
+from hasscheck.baseline.core import (
+    BaselineError,
+    baseline_from_findings,
+    drop_from_baseline,
+    load_baseline,
+    merge_baseline,
+    write_baseline,
+)
+from hasscheck.checker import run_check
+from hasscheck.config import ConfigError, discover_config
+
+baseline_app = typer.Typer(
+    name="baseline",
+    help="Manage the baseline file (accepted pre-existing findings).",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+_DEFAULT_BASELINE_PATH = Path("hasscheck-baseline.yaml")
+
+
+def _now_today() -> tuple[datetime, date]:
+    now = datetime.now(UTC)
+    return now, now.date()
+
+
+def _run_check_or_exit(project_path: Path) -> object:  # returns HassCheckReport
+    try:
+        cfg = discover_config(project_path.resolve())
+    except ConfigError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    try:
+        return run_check(project_path, config=cfg)
+    except (ConfigError, ValueError) as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@baseline_app.command("create")
+def create(
+    path: Path = typer.Option(
+        Path("."), "--path", "-p", help="Repository path to inspect."
+    ),
+    out: Path = typer.Option(
+        _DEFAULT_BASELINE_PATH,
+        "--out",
+        "-o",
+        help="Baseline file path (default: hasscheck-baseline.yaml).",
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite an existing baseline file (D5)."
+    ),
+) -> None:
+    """Snapshot current FAIL/WARN findings into a baseline file (D5, D6)."""
+    if out.exists() and not force:
+        typer.echo(
+            f"hasscheck: error: {out} already exists. "
+            f"Use `hasscheck baseline update` to merge new findings, "
+            f"or pass --force to overwrite.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not path.exists():
+        typer.echo(f"hasscheck: error: path '{path}' does not exist.", err=True)
+        raise typer.Exit(code=1)
+
+    report = _run_check_or_exit(path)
+    now, today = _now_today()
+    baseline = baseline_from_findings(
+        report.findings,  # type: ignore[arg-type]
+        hasscheck_version=__version__,
+        ruleset=report.ruleset.id,  # type: ignore[union-attr]
+        now=now,
+        today=today,
+    )
+    write_baseline(baseline, out)
+    console.print(
+        f"[green]Created:[/] {out} ({len(baseline.accepted_findings)} accepted finding(s))"
+    )
+
+
+@baseline_app.command("update")
+def update(
+    path: Path = typer.Option(
+        Path("."), "--path", "-p", help="Repository path to inspect."
+    ),
+    file: Path = typer.Option(
+        _DEFAULT_BASELINE_PATH,
+        "--file",
+        "-f",
+        help="Baseline file path (default: hasscheck-baseline.yaml).",
+    ),
+) -> None:
+    """Merge current findings into an existing baseline (D1).
+
+    Preserves `reason` and `accepted_at` for entries that still match a live
+    FAIL/WARN finding by hash. Drops stale entries. Adds new findings with
+    empty reason and today's date.
+    """
+    if not path.exists():
+        typer.echo(f"hasscheck: error: path '{path}' does not exist.", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        existing = load_baseline(file)
+    except BaselineError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    report = _run_check_or_exit(path)
+    now, today = _now_today()
+    merged = merge_baseline(
+        existing,
+        report.findings,  # type: ignore[arg-type]
+        hasscheck_version=__version__,
+        ruleset=report.ruleset.id,  # type: ignore[union-attr]
+        now=now,
+        today=today,
+    )
+    write_baseline(merged, file)
+    console.print(
+        f"[green]Updated:[/] {file} ({len(merged.accepted_findings)} accepted finding(s))"
+    )
+
+
+@baseline_app.command("drop")
+def drop(
+    rule: str = typer.Option(..., "--rule", help="Rule ID to remove (D2)."),
+    path: str | None = typer.Option(
+        None,
+        "--path",
+        help=(
+            "Optional path to narrow removal to a single (rule_id, path) entry. "
+            "Without --path, ALL entries for --rule are removed."
+        ),
+    ),
+    file: Path = typer.Option(
+        _DEFAULT_BASELINE_PATH,
+        "--file",
+        "-f",
+        help="Baseline file path (default: hasscheck-baseline.yaml).",
+    ),
+) -> None:
+    """Remove baseline entries by rule_id (and optionally path).
+
+    NOTE: The `--path` flag here narrows the deletion within the baseline file.
+    It is NOT the project path; `drop` only edits the file, it does not run checks.
+    """
+    try:
+        existing = load_baseline(file)
+    except BaselineError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    now, _ = _now_today()
+    try:
+        new_baseline, removed = drop_from_baseline(
+            existing, rule_id=rule, path=path, now=now
+        )
+    except BaselineError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    write_baseline(new_baseline, file)
+    scope = f"--rule {rule}" + (f" --path {path}" if path is not None else "")
+    console.print(f"[green]Dropped[/] {removed} entry/ies ({scope}) from {file}")

--- a/src/hasscheck/baseline/core.py
+++ b/src/hasscheck/baseline/core.py
@@ -4,3 +4,318 @@ Pure, no Typer, no Rich. Imported by both the CLI subapp and `cli.check`.
 The hash policy is documented in ADR 0016 — message normalization is the
 only field-stability lever; rule_id and path must match exactly.
 """
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+if TYPE_CHECKING:
+    from hasscheck.models import Finding
+
+from hasscheck.models import RuleStatus
+
+# Public statuses that are eligible to enter the baseline (D6).
+_BASELINE_ELIGIBLE = frozenset({RuleStatus.FAIL, RuleStatus.WARN})
+
+
+class BaselineError(Exception):
+    """Raised when a baseline file is missing, corrupt, or refers to unknown data."""
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class BaselineEntry(BaseModel):
+    """A single accepted finding stored in the baseline file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rule_id: str = Field(min_length=1)
+    path: str | None = None
+    finding_hash: str = Field(min_length=8, max_length=8)
+    accepted_at: date
+    reason: str = ""
+
+
+class BaselineFile(BaseModel):
+    """The full contents of a hasscheck-baseline.yaml file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    generated_at: datetime
+    hasscheck_version: str
+    ruleset: str
+    accepted_findings: list[BaselineEntry] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FindingPartition:
+    """Result of comparing live findings against a baseline.
+
+    - new:      live FAIL/WARN findings that DO NOT match any baseline entry
+    - accepted: live FAIL/WARN findings that DO match a baseline entry
+    - fixed:    baseline entries with NO matching live finding (debt resolved)
+    """
+
+    new: list[Finding]
+    accepted: list[Finding]
+    fixed: list[BaselineEntry]
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def compute_finding_hash(finding: Finding) -> str:
+    """Stable 8-hex-char hash of the identity-bearing fields of a Finding.
+
+    Hash inputs: rule_id, path (or empty string), normalized message.
+    Excluded (intentionally): status, severity, rule_version, source.checked_at.
+    Re-running with the same code on the same repo MUST yield the same hash.
+
+    Message normalization is whitespace-collapse + lowercase to absorb trivial
+    rewording without invalidating the entire baseline. ADR 0016 documents the
+    expectation that message changes in rule code MAY require `baseline update`.
+    """
+    normalized = " ".join((finding.message or "").lower().split())
+    raw = f"{finding.rule_id}|{finding.path or ''}|{normalized}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# Partition
+# ---------------------------------------------------------------------------
+
+
+def partition_findings(
+    findings: list[Finding],
+    baseline: BaselineFile,
+) -> FindingPartition:
+    """Split live findings into (new, accepted, fixed) against a baseline.
+
+    Eligibility: only RuleStatus.FAIL and RuleStatus.WARN are considered for
+    matching against baseline entries (D6). All other statuses (PASS,
+    NOT_APPLICABLE, MANUAL_REVIEW) are NOT placed into any of the three
+    buckets — they are not regressions, not accepted debt, and not "fixed".
+    """
+    by_key: dict[tuple[str, str, str], BaselineEntry] = {
+        (e.rule_id, e.path or "", e.finding_hash): e for e in baseline.accepted_findings
+    }
+    matched_keys: set[tuple[str, str, str]] = set()
+
+    new: list[Finding] = []
+    accepted: list[Finding] = []
+
+    for f in findings:
+        if f.status not in _BASELINE_ELIGIBLE:
+            continue
+        key = (f.rule_id, f.path or "", compute_finding_hash(f))
+        if key in by_key:
+            accepted.append(f)
+            matched_keys.add(key)
+        else:
+            new.append(f)
+
+    fixed = [entry for key, entry in by_key.items() if key not in matched_keys]
+
+    return FindingPartition(new=new, accepted=accepted, fixed=fixed)
+
+
+# ---------------------------------------------------------------------------
+# YAML I/O
+# ---------------------------------------------------------------------------
+
+
+def load_baseline(path: Path) -> BaselineFile:
+    """Load and validate a baseline YAML file.
+
+    Raises BaselineError on missing file, YAML parse error, non-mapping top
+    level, or schema validation failure. Never returns None — callers either
+    have a baseline or they don't pass --baseline at all.
+    """
+    if not path.is_file():
+        raise BaselineError(f"baseline file not found: {path}")
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise BaselineError(f"YAML parse error in {path.name}: {exc}") from exc
+    if raw is None:
+        raise BaselineError(f"{path.name} is empty; expected a baseline mapping")
+    if not isinstance(raw, dict):
+        raise BaselineError(
+            f"{path.name} must be a YAML mapping; got {type(raw).__name__}"
+        )
+    try:
+        return BaselineFile(**raw)
+    except ValidationError as exc:
+        raise BaselineError(f"invalid {path.name}: {exc}") from exc
+
+
+def write_baseline(baseline: BaselineFile, path: Path) -> None:
+    """Write a baseline file with deterministic key ordering.
+
+    Top-level keys are emitted in a fixed order to keep diffs minimal across
+    runs. Entries inside accepted_findings are sorted by (rule_id, path or "",
+    finding_hash) — also deterministic.
+    """
+    sorted_entries = sorted(
+        baseline.accepted_findings,
+        key=lambda e: (e.rule_id, e.path or "", e.finding_hash),
+    )
+    payload = {
+        "generated_at": baseline.generated_at.isoformat(),
+        "hasscheck_version": baseline.hasscheck_version,
+        "ruleset": baseline.ruleset,
+        "accepted_findings": [
+            {
+                "rule_id": e.rule_id,
+                "path": e.path,
+                "finding_hash": e.finding_hash,
+                "accepted_at": e.accepted_at.isoformat(),
+                "reason": e.reason,
+            }
+            for e in sorted_entries
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers used by the CLI subapp
+# ---------------------------------------------------------------------------
+
+
+def baseline_from_findings(
+    findings: list[Finding],
+    *,
+    hasscheck_version: str,
+    ruleset: str,
+    now: datetime,
+    today: date,
+) -> BaselineFile:
+    """Build a fresh BaselineFile from a current findings list.
+
+    Only FAIL/WARN findings are included (D6). Reason is empty by default;
+    users edit the file (or use `baseline update` after editing) to attach
+    rationale. accepted_at is set to `today` for every entry.
+    """
+    entries = [
+        BaselineEntry(
+            rule_id=f.rule_id,
+            path=f.path,
+            finding_hash=compute_finding_hash(f),
+            accepted_at=today,
+            reason="",
+        )
+        for f in findings
+        if f.status in _BASELINE_ELIGIBLE
+    ]
+    return BaselineFile(
+        generated_at=now,
+        hasscheck_version=hasscheck_version,
+        ruleset=ruleset,
+        accepted_findings=entries,
+    )
+
+
+def merge_baseline(
+    existing: BaselineFile,
+    findings: list[Finding],
+    *,
+    hasscheck_version: str,
+    ruleset: str,
+    now: datetime,
+    today: date,
+) -> BaselineFile:
+    """Merge live findings into an existing baseline (D1).
+
+    Preservation rule: when an existing entry's (rule_id, path, finding_hash)
+    matches a live FAIL/WARN finding, KEEP the existing reason and accepted_at.
+    Stale entries (no matching live finding) are dropped. New live FAIL/WARN
+    findings (no matching existing entry) are added with empty reason and
+    today's accepted_at.
+
+    Header fields (generated_at, hasscheck_version, ruleset) are refreshed.
+    """
+    by_key: dict[tuple[str, str, str], BaselineEntry] = {
+        (e.rule_id, e.path or "", e.finding_hash): e for e in existing.accepted_findings
+    }
+    merged: list[BaselineEntry] = []
+
+    for f in findings:
+        if f.status not in _BASELINE_ELIGIBLE:
+            continue
+        key = (f.rule_id, f.path or "", compute_finding_hash(f))
+        if key in by_key:
+            merged.append(by_key[key])  # preserve existing reason + accepted_at
+        else:
+            merged.append(
+                BaselineEntry(
+                    rule_id=f.rule_id,
+                    path=f.path,
+                    finding_hash=key[2],
+                    accepted_at=today,
+                    reason="",
+                )
+            )
+    # Stale entries (in baseline but not in live findings) are simply not
+    # appended — they are dropped, which is the documented merge behavior.
+
+    return BaselineFile(
+        generated_at=now,
+        hasscheck_version=hasscheck_version,
+        ruleset=ruleset,
+        accepted_findings=merged,
+    )
+
+
+def drop_from_baseline(
+    existing: BaselineFile,
+    *,
+    rule_id: str,
+    path: str | None,
+    now: datetime,
+) -> tuple[BaselineFile, int]:
+    """Remove entries matching `rule_id` (D2). Returns (new_baseline, count_removed).
+
+    If `path` is None: removes ALL entries with that rule_id.
+    If `path` is given: removes only the (rule_id, path) entry/entries.
+
+    Raises BaselineError if no entries match (so the user notices typos).
+    """
+
+    def _matches(entry: BaselineEntry) -> bool:
+        if entry.rule_id != rule_id:
+            return False
+        if path is None:
+            return True
+        return (entry.path or "") == path
+
+    kept = [e for e in existing.accepted_findings if not _matches(e)]
+    removed = len(existing.accepted_findings) - len(kept)
+    if removed == 0:
+        scope = f"rule_id={rule_id!r}" + (f" path={path!r}" if path is not None else "")
+        raise BaselineError(f"no baseline entries matched {scope}")
+    return (
+        BaselineFile(
+            generated_at=now,
+            hasscheck_version=existing.hasscheck_version,
+            ruleset=existing.ruleset,
+            accepted_findings=kept,
+        ),
+        removed,
+    )

--- a/src/hasscheck/baseline/core.py
+++ b/src/hasscheck/baseline/core.py
@@ -1,0 +1,6 @@
+"""Baseline data layer: models, hashing, partition, YAML I/O.
+
+Pure, no Typer, no Rich. Imported by both the CLI subapp and `cli.check`.
+The hash policy is documented in ADR 0016 — message normalization is the
+only field-stability lever; rule_id and path must match exactly.
+"""

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -11,6 +11,12 @@ from rich.console import Console
 from hasscheck import __version__
 from hasscheck.badges import generate_badges
 from hasscheck.badges.policy import BadgePolicyError
+from hasscheck.baseline import (
+    BaselineError,
+    FindingPartition,
+    load_baseline,
+    partition_findings,
+)
 from hasscheck.baseline.cli import baseline_app
 from hasscheck.checker import run_check
 from hasscheck.config import ConfigError, GateConfig, GateMode, discover_config
@@ -133,6 +139,19 @@ def check(
             ),
         ),
     ] = None,
+    baseline: Annotated[
+        Path | None,
+        typer.Option(
+            "--baseline",
+            "-b",
+            help=(
+                "Path to a baseline file. Findings matching the baseline are "
+                "labeled [accepted] and excluded from the gate. New findings "
+                "trigger the gate; resolved findings show as [fixed]. "
+                "Generate one with `hasscheck baseline create`."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Check a custom integration repository and print actionable findings.
 
@@ -174,15 +193,27 @@ def check(
         typer.echo(f"hasscheck: error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    if format == OutputFormat.JSON:
-        typer.echo(report_to_json(report), nl=False)
-    elif format == OutputFormat.MD:
-        typer.echo(report_to_md(report), nl=False)
-    else:
-        print_terminal_report(report, console)
+    # Baseline partition (no-op when --baseline omitted).
+    bl_partition: FindingPartition | None = None
+    if baseline is not None:
+        try:
+            baseline_file = load_baseline(baseline)
+        except BaselineError as exc:
+            typer.echo(f"hasscheck: error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        bl_partition = partition_findings(report.findings, baseline_file)
 
+    if format == OutputFormat.JSON:
+        typer.echo(report_to_json(report), nl=False)  # D3 — JSON unchanged
+    elif format == OutputFormat.MD:
+        typer.echo(report_to_md(report), nl=False)  # D4 — MD unchanged
+    else:
+        print_terminal_report(report, console, partition=bl_partition)
+
+    # Gate decision: gate on new findings only when a baseline is active.
+    gate_findings = bl_partition.new if bl_partition is not None else report.findings
     _gate = cfg.gate if cfg else None
-    if should_exit_nonzero(report.findings, _gate):
+    if should_exit_nonzero(gate_findings, _gate):
         raise typer.Exit(code=1)
 
 

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from hasscheck import __version__
 from hasscheck.badges import generate_badges
 from hasscheck.badges.policy import BadgePolicyError
+from hasscheck.baseline.cli import baseline_app
 from hasscheck.checker import run_check
 from hasscheck.config import ConfigError, GateConfig, GateMode, discover_config
 from hasscheck.docs_render import check_drift, render_all
@@ -569,6 +570,7 @@ def docs_render(
 
 
 app.add_typer(scaffold_app, name="scaffold")
+app.add_typer(baseline_app, name="baseline")
 
 
 def main() -> None:

--- a/src/hasscheck/output.py
+++ b/src/hasscheck/output.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from rich.console import Console
+from rich.markup import escape as markup_escape
 from rich.table import Table
 
 from hasscheck.models import Finding, HassCheckReport, RuleStatus
+
+if TYPE_CHECKING:
+    from hasscheck.baseline.core import FindingPartition
 
 _COMPAT_POLICY_FOOTER = (
     "Compatibility claims policy: "
@@ -34,7 +39,10 @@ def report_to_json(report: HassCheckReport) -> str:
 
 
 def print_terminal_report(
-    report: HassCheckReport, console: Console | None = None
+    report: HassCheckReport,
+    console: Console | None = None,
+    *,
+    partition: FindingPartition | None = None,
 ) -> None:
     console = console or Console()
     console.print("[bold]HassCheck Summary[/bold]")
@@ -62,18 +70,34 @@ def print_terminal_report(
         )
         console.print()
 
+    # Build a per-finding label map only when a partition is supplied (D4).
+    # Labels use escaped brackets so Rich renders them as literal text, not markup tags.
+    label_by_id: dict[int, str] = {}
+    if partition is not None:
+        for f in partition.new:
+            label_by_id[id(f)] = markup_escape("[new]")
+        for f in partition.accepted:
+            label_by_id[id(f)] = markup_escape("[accepted]")
+
     table = Table(title="Findings")
     table.add_column("Status", no_wrap=True)
     table.add_column("Rule")
     table.add_column("Message")
     for finding in report.findings:
         marker = " (config)" if finding.applicability.source == "config" else ""
-        table.add_row(
-            STATUS_ICON[finding.status], f"{finding.rule_id}{marker}", finding.message
-        )
+        baseline_label = label_by_id.get(id(finding), "")
+        rule_cell = f"{finding.rule_id}{marker}"
+        if baseline_label:
+            rule_cell = f"{rule_cell} {baseline_label}"
+        table.add_row(STATUS_ICON[finding.status], rule_cell, finding.message)
     console.print(table)
 
     _print_fix_suggestions(report.findings, console)
+
+    # "N fixed since baseline" — terminal only (D4).
+    if partition is not None and partition.fixed:
+        console.print()
+        console.print(f"[green]{len(partition.fixed)} fixed since baseline.[/green]")
 
     if report.target and report.target.ha_version:
         console.print()

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -106,6 +106,12 @@ def test_compute_finding_hash_changes_on_rule_id_change() -> None:
     assert compute_finding_hash(f1) != compute_finding_hash(f2)
 
 
+def test_compute_finding_hash_changes_on_message_change() -> None:
+    f1 = _make_finding(message="message one")
+    f2 = _make_finding(message="message two")
+    assert compute_finding_hash(f1) != compute_finding_hash(f2)
+
+
 def test_compute_finding_hash_changes_on_path_change() -> None:
     f1 = _make_finding(path="file_a.py")
     f2 = _make_finding(path="file_b.py")

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,534 @@
+"""Tests for hasscheck.baseline — strict TDD, slice by slice."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from hasscheck.baseline import (
+    BaselineEntry,
+    BaselineError,
+    BaselineFile,
+    baseline_from_findings,
+    compute_finding_hash,
+    drop_from_baseline,
+    load_baseline,
+    merge_baseline,
+    partition_findings,
+    write_baseline,
+)
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_finding(
+    rule_id: str = "x.y",
+    message: str = "msg",
+    path: str | None = None,
+    status: RuleStatus = RuleStatus.FAIL,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0",
+        category="test",
+        status=status,
+        severity=RuleSeverity.REQUIRED,
+        title="Test Finding",
+        message=message,
+        applicability=Applicability(
+            status=ApplicabilityStatus.APPLICABLE,
+            reason="applicable",
+            source="default",
+        ),
+        source=RuleSource(url="https://example.com"),
+        path=path,
+    )
+
+
+def _make_baseline_file(entries: list[BaselineEntry] | None = None) -> BaselineFile:
+    return BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="hasscheck-ha-2026.5",
+        accepted_findings=entries or [],
+    )
+
+
+_NOW = datetime(2026, 5, 2, 12, 0, 0, tzinfo=UTC)
+_TODAY = date(2026, 5, 2)
+
+
+# ---------------------------------------------------------------------------
+# Slice 1: hash + models
+# ---------------------------------------------------------------------------
+
+
+def test_compute_finding_hash_is_deterministic() -> None:
+    f1 = _make_finding(rule_id="m.d.e", message="domain missing", path="manifest.json")
+    f2 = _make_finding(rule_id="m.d.e", message="domain missing", path="manifest.json")
+    assert compute_finding_hash(f1) == compute_finding_hash(f2)
+
+
+def test_compute_finding_hash_is_8_hex_chars() -> None:
+    h = compute_finding_hash(_make_finding())
+    assert len(h) == 8
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_compute_finding_hash_normalizes_whitespace() -> None:
+    f1 = _make_finding(message="foo  bar  baz")
+    f2 = _make_finding(message="foo bar baz")
+    assert compute_finding_hash(f1) == compute_finding_hash(f2)
+
+
+def test_compute_finding_hash_normalizes_case() -> None:
+    f1 = _make_finding(message="DOMAIN Missing")
+    f2 = _make_finding(message="domain missing")
+    assert compute_finding_hash(f1) == compute_finding_hash(f2)
+
+
+def test_compute_finding_hash_changes_on_rule_id_change() -> None:
+    f1 = _make_finding(rule_id="a.b.c", message="same")
+    f2 = _make_finding(rule_id="x.y.z", message="same")
+    assert compute_finding_hash(f1) != compute_finding_hash(f2)
+
+
+def test_compute_finding_hash_changes_on_path_change() -> None:
+    f1 = _make_finding(path="file_a.py")
+    f2 = _make_finding(path="file_b.py")
+    assert compute_finding_hash(f1) != compute_finding_hash(f2)
+
+
+def test_compute_finding_hash_ignores_status_and_severity() -> None:
+    f_fail = _make_finding(status=RuleStatus.FAIL)
+    f_warn = _make_finding(status=RuleStatus.WARN)
+    assert compute_finding_hash(f_fail) == compute_finding_hash(f_warn)
+
+
+def test_compute_finding_hash_none_path_uses_empty_segment() -> None:
+    f_none = _make_finding(path=None)
+    f_empty = _make_finding(path="")
+    # path=None and path="" should produce the same hash (both use empty string)
+    assert compute_finding_hash(f_none) == compute_finding_hash(f_empty)
+
+
+def test_baseline_entry_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        BaselineEntry.model_validate(
+            {
+                "rule_id": "x.y",
+                "finding_hash": "abcd1234",
+                "accepted_at": "2026-05-01",
+                "extra_field": "oops",
+            }
+        )
+
+
+def test_baseline_entry_requires_8_char_hash() -> None:
+    with pytest.raises(ValidationError):
+        BaselineEntry.model_validate(
+            {
+                "rule_id": "x.y",
+                "finding_hash": "short",  # < 8 chars
+                "accepted_at": "2026-05-01",
+            }
+        )
+
+
+def test_baseline_file_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        BaselineFile.model_validate(
+            {
+                "generated_at": "2026-05-01T00:00:00",
+                "hasscheck_version": "0.14.0",
+                "ruleset": "test",
+                "accepted_findings": [],
+                "unknown_key": True,
+            }
+        )
+
+
+def test_baseline_file_empty_accepted_findings_is_valid() -> None:
+    bf = _make_baseline_file()
+    assert bf.accepted_findings == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: partition_findings
+# ---------------------------------------------------------------------------
+
+
+def test_partition_marks_unmatched_finding_as_new() -> None:
+    f = _make_finding(status=RuleStatus.WARN)
+    bl = _make_baseline_file()
+    partition = partition_findings([f], bl)
+    assert f in partition.new
+    assert f not in partition.accepted
+    assert partition.fixed == []
+
+
+def test_partition_marks_matched_finding_as_accepted() -> None:
+    f = _make_finding(status=RuleStatus.FAIL)
+    h = compute_finding_hash(f)
+    entry = BaselineEntry(
+        rule_id=f.rule_id,
+        path=f.path,
+        finding_hash=h,
+        accepted_at=_TODAY,
+    )
+    bl = _make_baseline_file([entry])
+    partition = partition_findings([f], bl)
+    assert f in partition.accepted
+    assert f not in partition.new
+
+
+def test_partition_marks_unmatched_baseline_entry_as_fixed() -> None:
+    entry = BaselineEntry(
+        rule_id="old.rule",
+        path=None,
+        finding_hash="abcd1234",
+        accepted_at=_TODAY,
+    )
+    bl = _make_baseline_file([entry])
+    partition = partition_findings([], bl)
+    assert entry in partition.fixed
+    assert partition.new == []
+    assert partition.accepted == []
+
+
+def test_partition_only_evaluates_fail_and_warn() -> None:
+    f_pass = _make_finding(status=RuleStatus.PASS)
+    f_na = _make_finding(rule_id="na.rule", status=RuleStatus.NOT_APPLICABLE)
+    bl = _make_baseline_file()
+    partition = partition_findings([f_pass, f_na], bl)
+    # Neither PASS nor NOT_APPLICABLE should appear in any bucket
+    assert f_pass not in partition.new
+    assert f_pass not in partition.accepted
+    assert f_na not in partition.new
+    assert f_na not in partition.accepted
+    assert partition.fixed == []
+
+
+def test_partition_message_rewording_treated_as_new() -> None:
+    f_orig = _make_finding(message="original message")
+    h = compute_finding_hash(f_orig)
+    entry = BaselineEntry(
+        rule_id=f_orig.rule_id,
+        path=f_orig.path,
+        finding_hash=h,
+        accepted_at=_TODAY,
+    )
+    bl = _make_baseline_file([entry])
+    f_reworded = _make_finding(message="different message entirely")
+    partition = partition_findings([f_reworded], bl)
+    assert f_reworded in partition.new
+    assert entry in partition.fixed
+
+
+def test_partition_path_difference_treated_as_new() -> None:
+    f_a = _make_finding(path="a.py")
+    h = compute_finding_hash(f_a)
+    entry = BaselineEntry(
+        rule_id=f_a.rule_id,
+        path="a.py",
+        finding_hash=h,
+        accepted_at=_TODAY,
+    )
+    bl = _make_baseline_file([entry])
+    f_b = _make_finding(path="b.py")
+    partition = partition_findings([f_b], bl)
+    assert f_b in partition.new
+    assert entry in partition.fixed
+
+
+def test_partition_empty_baseline_all_findings_new() -> None:
+    findings = [_make_finding(rule_id="r.1"), _make_finding(rule_id="r.2")]
+    bl = _make_baseline_file()
+    partition = partition_findings(findings, bl)
+    assert len(partition.new) == 2
+    assert all(f in partition.new for f in findings)
+    assert partition.accepted == []
+    assert partition.fixed == []
+
+
+def test_partition_empty_findings_all_baseline_fixed() -> None:
+    entries = [
+        BaselineEntry(rule_id="r.1", finding_hash="aaaabbbb", accepted_at=_TODAY),
+        BaselineEntry(rule_id="r.2", finding_hash="ccccdddd", accepted_at=_TODAY),
+    ]
+    bl = _make_baseline_file(entries)
+    partition = partition_findings([], bl)
+    assert len(partition.fixed) == 2
+    fixed_rule_ids = {e.rule_id for e in partition.fixed}
+    assert fixed_rule_ids == {"r.1", "r.2"}
+    assert partition.new == []
+    assert partition.accepted == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 3: YAML I/O
+# ---------------------------------------------------------------------------
+
+
+def test_load_baseline_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(BaselineError, match="not found"):
+        load_baseline(tmp_path / "nonexistent.yaml")
+
+
+def test_load_baseline_invalid_yaml_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "baseline.yaml"
+    bad.write_text("{key: [invalid: yaml: :\n", encoding="utf-8")
+    with pytest.raises(BaselineError, match="YAML"):
+        load_baseline(bad)
+
+
+def test_load_baseline_non_mapping_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "baseline.yaml"
+    bad.write_text("- item1\n- item2\n", encoding="utf-8")
+    with pytest.raises(BaselineError, match="mapping"):
+        load_baseline(bad)
+
+
+def test_load_baseline_extra_fields_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "baseline.yaml"
+    bad.write_text(
+        "generated_at: '2026-05-01T00:00:00'\n"
+        "hasscheck_version: '0.14.0'\n"
+        "ruleset: 'test'\n"
+        "accepted_findings: []\n"
+        "unexpected_key: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(BaselineError):
+        load_baseline(bad)
+
+
+def test_write_baseline_creates_parent_dir(tmp_path: Path) -> None:
+    target = tmp_path / "subdir" / "nested" / "baseline.yaml"
+    bl = _make_baseline_file()
+    write_baseline(bl, target)
+    assert target.exists()
+
+
+def test_write_baseline_round_trip_preserves_entries(tmp_path: Path) -> None:
+    entry = BaselineEntry(
+        rule_id="m.d.e",
+        path="manifest.json",
+        finding_hash="abcd1234",
+        accepted_at=date(2026, 5, 1),
+        reason="known issue",
+    )
+    bl = _make_baseline_file([entry])
+    target = tmp_path / "baseline.yaml"
+    write_baseline(bl, target)
+    loaded = load_baseline(target)
+    assert len(loaded.accepted_findings) == 1
+    assert loaded.accepted_findings[0].rule_id == "m.d.e"
+    assert loaded.accepted_findings[0].reason == "known issue"
+    assert loaded.accepted_findings[0].finding_hash == "abcd1234"
+
+
+def test_write_baseline_sorts_entries_deterministically(tmp_path: Path) -> None:
+    entries = [
+        BaselineEntry(
+            rule_id="z.rule", path=None, finding_hash="zzzz9999", accepted_at=_TODAY
+        ),
+        BaselineEntry(
+            rule_id="a.rule", path=None, finding_hash="aaaa1111", accepted_at=_TODAY
+        ),
+        BaselineEntry(
+            rule_id="m.rule", path=None, finding_hash="mmmm5555", accepted_at=_TODAY
+        ),
+    ]
+    bl = _make_baseline_file(entries)
+    target = tmp_path / "baseline.yaml"
+    write_baseline(bl, target)
+    loaded = load_baseline(target)
+    rule_ids = [e.rule_id for e in loaded.accepted_findings]
+    assert rule_ids == sorted(rule_ids)
+
+
+# ---------------------------------------------------------------------------
+# Slice 4: Builder helpers
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_from_findings_filters_to_fail_and_warn() -> None:
+    findings = [
+        _make_finding(rule_id="f.rule", status=RuleStatus.FAIL),
+        _make_finding(rule_id="w.rule", status=RuleStatus.WARN),
+        _make_finding(rule_id="p.rule", status=RuleStatus.PASS),
+        _make_finding(rule_id="na.rule", status=RuleStatus.NOT_APPLICABLE),
+    ]
+    bl = baseline_from_findings(
+        findings,
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    rule_ids = {e.rule_id for e in bl.accepted_findings}
+    assert "f.rule" in rule_ids
+    assert "w.rule" in rule_ids
+    assert "p.rule" not in rule_ids
+    assert "na.rule" not in rule_ids
+
+
+def test_baseline_from_findings_sets_today_and_empty_reason() -> None:
+    findings = [_make_finding(rule_id="x.y", status=RuleStatus.FAIL)]
+    bl = baseline_from_findings(
+        findings,
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    assert len(bl.accepted_findings) == 1
+    entry = bl.accepted_findings[0]
+    assert entry.accepted_at == _TODAY
+    assert entry.reason == ""
+
+
+def test_merge_baseline_preserves_reason_for_matched_hash() -> None:
+    f = _make_finding(rule_id="x.y", status=RuleStatus.FAIL)
+    h = compute_finding_hash(f)
+    old_entry = BaselineEntry(
+        rule_id=f.rule_id,
+        path=f.path,
+        finding_hash=h,
+        accepted_at=date(2026, 1, 1),
+        reason="known debt",
+    )
+    existing = _make_baseline_file([old_entry])
+    merged = merge_baseline(
+        existing,
+        [f],
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    assert len(merged.accepted_findings) == 1
+    assert merged.accepted_findings[0].reason == "known debt"
+
+
+def test_merge_baseline_preserves_accepted_at_for_matched_hash() -> None:
+    f = _make_finding(rule_id="x.y", status=RuleStatus.FAIL)
+    h = compute_finding_hash(f)
+    original_date = date(2026, 1, 1)
+    old_entry = BaselineEntry(
+        rule_id=f.rule_id,
+        path=f.path,
+        finding_hash=h,
+        accepted_at=original_date,
+        reason="",
+    )
+    existing = _make_baseline_file([old_entry])
+    merged = merge_baseline(
+        existing,
+        [f],
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    assert merged.accepted_findings[0].accepted_at == original_date
+
+
+def test_merge_baseline_drops_stale_entries() -> None:
+    stale_entry = BaselineEntry(
+        rule_id="stale.rule",
+        path=None,
+        finding_hash="stale123",
+        accepted_at=_TODAY,
+        reason="was valid",
+    )
+    existing = _make_baseline_file([stale_entry])
+    # Pass empty findings — everything is stale
+    merged = merge_baseline(
+        existing,
+        [],
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    assert merged.accepted_findings == []
+
+
+def test_merge_baseline_adds_new_findings_with_empty_reason() -> None:
+    existing = _make_baseline_file()
+    f = _make_finding(rule_id="new.rule", status=RuleStatus.WARN)
+    merged = merge_baseline(
+        existing,
+        [f],
+        hasscheck_version="0.14.0",
+        ruleset="test-ruleset",
+        now=_NOW,
+        today=_TODAY,
+    )
+    assert len(merged.accepted_findings) == 1
+    assert merged.accepted_findings[0].reason == ""
+    assert merged.accepted_findings[0].accepted_at == _TODAY
+
+
+def test_drop_from_baseline_removes_all_for_rule_id() -> None:
+    entries = [
+        BaselineEntry(
+            rule_id="W001", path="a.py", finding_hash="aaaa1111", accepted_at=_TODAY
+        ),
+        BaselineEntry(
+            rule_id="W001", path="b.py", finding_hash="bbbb2222", accepted_at=_TODAY
+        ),
+        BaselineEntry(
+            rule_id="W002", path=None, finding_hash="cccc3333", accepted_at=_TODAY
+        ),
+    ]
+    existing = _make_baseline_file(entries)
+    new_bl, removed = drop_from_baseline(existing, rule_id="W001", path=None, now=_NOW)
+    assert removed == 2
+    assert all(e.rule_id != "W001" for e in new_bl.accepted_findings)
+    assert len(new_bl.accepted_findings) == 1
+
+
+def test_drop_from_baseline_path_narrows_to_single_entry() -> None:
+    entries = [
+        BaselineEntry(
+            rule_id="W001", path="a.py", finding_hash="aaaa1111", accepted_at=_TODAY
+        ),
+        BaselineEntry(
+            rule_id="W001", path="b.py", finding_hash="bbbb2222", accepted_at=_TODAY
+        ),
+    ]
+    existing = _make_baseline_file(entries)
+    new_bl, removed = drop_from_baseline(
+        existing, rule_id="W001", path="a.py", now=_NOW
+    )
+    assert removed == 1
+    remaining_paths = [e.path for e in new_bl.accepted_findings]
+    assert "a.py" not in remaining_paths
+    assert "b.py" in remaining_paths
+
+
+def test_drop_from_baseline_no_match_raises() -> None:
+    entries = [
+        BaselineEntry(
+            rule_id="W001", path=None, finding_hash="aaaa1111", accepted_at=_TODAY
+        ),
+    ]
+    existing = _make_baseline_file(entries)
+    with pytest.raises(BaselineError, match="no baseline entries matched"):
+        drop_from_baseline(existing, rule_id="W999", path=None, now=_NOW)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1348,3 +1348,28 @@ def test_check_no_baseline_flag_unchanged(tmp_path: Path) -> None:
     # Must still have FAIL findings and exit 1 (no PASS for empty integration)
     assert any(f["status"] == "fail" for f in result_json["findings"])
     assert result_new.exit_code == 1
+
+
+def test_check_advisory_gate_with_baseline_always_exits_zero(tmp_path: Path) -> None:
+    """advisory gate mode + --baseline → always exit 0 even if new findings exist."""
+    write_minimal_integration(tmp_path)
+    # Create baseline with zero entries (so all findings are "new")
+    baseline_path = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(app, ["baseline", "create", "--path", str(tmp_path)])
+    # Clear the baseline so all findings are treated as new
+    baseline_path.write_text(
+        "generated_at: '2026-01-01T00:00:00'\n"
+        "hasscheck_version: '0.0.0'\n"
+        "ruleset: 'test'\n"
+        "accepted_findings: []\n",
+        encoding="utf-8",
+    )
+    # Write a hasscheck.yaml with advisory gate
+    (tmp_path / "hasscheck.yaml").write_text(
+        "schema_version: '0.7.0'\ngate:\n  mode: advisory\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        app, ["check", "--path", str(tmp_path), "--baseline", str(baseline_path)]
+    )
+    assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -856,3 +856,495 @@ def test_check_unknown_profile_exits_nonzero_with_error_message(tmp_path: Path) 
     assert result.exit_code == 1
     combined_output = (result.output or "") + (result.stderr or "")
     assert "Unknown profile" in combined_output or "unknown" in combined_output.lower()
+
+
+# ---------- Phase 6: baseline subapp (#149) ----------
+
+
+def test_baseline_subcommand_is_registered() -> None:
+    """hasscheck baseline --help exits 0 and mentions the subcommands."""
+    result = runner.invoke(app, ["baseline", "--help"])
+    assert result.exit_code == 0
+    assert "baseline" in result.output.lower()
+
+
+def test_baseline_create_writes_valid_file(tmp_path: Path) -> None:
+    """baseline create writes hasscheck-baseline.yaml that passes load_baseline."""
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    result = runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out_file.exists()
+    loaded = load_baseline(out_file)
+    assert loaded.hasscheck_version is not None
+
+
+def test_baseline_create_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    """baseline create exits 1 when file exists and --force is not passed (D5)."""
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Create the file first
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    assert out_file.exists()
+    # Try again without --force
+    result = runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "update" in combined.lower() or "force" in combined.lower()
+
+
+def test_baseline_create_force_overwrites(tmp_path: Path) -> None:
+    """baseline create --force overwrites an existing file."""
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "create",
+            "--path",
+            str(tmp_path),
+            "--out",
+            str(out_file),
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    loaded = load_baseline(out_file)
+    assert loaded.accepted_findings is not None
+
+
+def test_baseline_create_only_includes_fail_and_warn(tmp_path: Path) -> None:
+    """baseline create produces entries only for FAIL and WARN findings (D6)."""
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    loaded = load_baseline(out_file)
+    # Run a live check and verify only FAIL/WARN entries in baseline
+    from hasscheck.checker import run_check
+    from hasscheck.models import RuleStatus
+
+    report = run_check(tmp_path)
+    baseline_ids = {e.rule_id for e in loaded.accepted_findings}
+    # All baseline entries must correspond to eligible findings
+    assert baseline_ids.issubset({f.rule_id for f in report.findings}), (
+        "Baseline entries should only come from actual findings"
+    )
+    # PASS findings must not be in baseline entries
+    pass_ids = {f.rule_id for f in report.findings if f.status == RuleStatus.PASS}
+    assert not baseline_ids.intersection(pass_ids), (
+        "PASS findings should not appear in baseline"
+    )
+
+
+def test_baseline_update_preserves_reason(tmp_path: Path) -> None:
+    """baseline update keeps the reason for hash-matched entries (D1)."""
+    import yaml
+
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Create initial baseline
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    # Manually inject a reason into the first entry
+    loaded = load_baseline(out_file)
+    if not loaded.accepted_findings:
+        pytest.skip("no findings to baseline in this integration fixture")
+    raw = yaml.safe_load(out_file.read_text())
+    raw["accepted_findings"][0]["reason"] = "preserved reason"
+    out_file.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    # Run update
+    result = runner.invoke(
+        app,
+        ["baseline", "update", "--path", str(tmp_path), "--file", str(out_file)],
+    )
+    assert result.exit_code == 0, result.output
+    updated = load_baseline(out_file)
+    reasons = [e.reason for e in updated.accepted_findings]
+    assert "preserved reason" in reasons
+
+
+def test_baseline_update_drops_stale_entries(tmp_path: Path) -> None:
+    """baseline update removes entries that don't match any live finding."""
+    import yaml
+
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Create initial baseline
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    # Inject a stale entry with a hash that no live finding can match
+    raw = yaml.safe_load(out_file.read_text())
+    raw["accepted_findings"].append(
+        {
+            "rule_id": "nonexistent.rule",
+            "path": None,
+            "finding_hash": "dead1234",
+            "accepted_at": "2026-01-01",
+            "reason": "stale",
+        }
+    )
+    out_file.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["baseline", "update", "--path", str(tmp_path), "--file", str(out_file)],
+    )
+    assert result.exit_code == 0, result.output
+    updated = load_baseline(out_file)
+    assert all(e.rule_id != "nonexistent.rule" for e in updated.accepted_findings)
+
+
+def test_baseline_update_missing_file_errors(tmp_path: Path) -> None:
+    """baseline update exits 1 when baseline file does not exist."""
+    write_minimal_integration(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "update",
+            "--path",
+            str(tmp_path),
+            "--file",
+            str(tmp_path / "missing.yaml"),
+        ],
+    )
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "error" in combined.lower()
+
+
+def test_baseline_drop_rule_removes_all(tmp_path: Path) -> None:
+    """baseline drop --rule removes all entries for that rule (D2)."""
+    from hasscheck.baseline import load_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    loaded = load_baseline(out_file)
+    if not loaded.accepted_findings:
+        pytest.skip("no findings to drop in this integration fixture")
+    target_rule = loaded.accepted_findings[0].rule_id
+    result = runner.invoke(
+        app,
+        ["baseline", "drop", "--rule", target_rule, "--file", str(out_file)],
+    )
+    assert result.exit_code == 0, result.output
+    updated = load_baseline(out_file)
+    assert all(e.rule_id != target_rule for e in updated.accepted_findings)
+
+
+def test_baseline_drop_rule_path_narrows(tmp_path: Path) -> None:
+    """baseline drop --rule --path removes only that exact (rule, path) entry (D2)."""
+    from datetime import UTC, date, datetime
+
+    from hasscheck.baseline import (
+        BaselineEntry,
+        BaselineFile,
+        load_baseline,
+        write_baseline,
+    )
+
+    out_file = tmp_path / "baseline.yaml"
+    entries = [
+        BaselineEntry(
+            rule_id="demo.rule",
+            path="file_a.py",
+            finding_hash="aaaa1111",
+            accepted_at=date(2026, 5, 1),
+        ),
+        BaselineEntry(
+            rule_id="demo.rule",
+            path="file_b.py",
+            finding_hash="bbbb2222",
+            accepted_at=date(2026, 5, 1),
+        ),
+    ]
+    bl = BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="test",
+        accepted_findings=entries,
+    )
+    write_baseline(bl, out_file)
+    result = runner.invoke(
+        app,
+        [
+            "baseline",
+            "drop",
+            "--rule",
+            "demo.rule",
+            "--path",
+            "file_a.py",
+            "--file",
+            str(out_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    updated = load_baseline(out_file)
+    paths = [e.path for e in updated.accepted_findings]
+    assert "file_a.py" not in paths
+    assert "file_b.py" in paths
+
+
+def test_baseline_drop_unknown_rule_errors(tmp_path: Path) -> None:
+    """baseline drop exits 1 when no entries match the rule (D2 guard)."""
+    from datetime import UTC, date, datetime
+
+    from hasscheck.baseline import BaselineEntry, BaselineFile, write_baseline
+
+    out_file = tmp_path / "baseline.yaml"
+    entries = [
+        BaselineEntry(
+            rule_id="real.rule",
+            path=None,
+            finding_hash="aaaa1111",
+            accepted_at=date(2026, 5, 1),
+        )
+    ]
+    bl = BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="test",
+        accepted_findings=entries,
+    )
+    write_baseline(bl, out_file)
+    result = runner.invoke(
+        app,
+        ["baseline", "drop", "--rule", "nonexistent.rule", "--file", str(out_file)],
+    )
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "error" in combined.lower()
+
+
+# ---------- Phase 7: check --baseline integration (#149) ----------
+
+
+def test_check_with_baseline_round_trip_exits_zero(tmp_path: Path) -> None:
+    """After `baseline create`, `check --baseline` exits 0 (all findings accepted)."""
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    create_result = runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    assert create_result.exit_code == 0, create_result.output
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(out_file),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_check_with_baseline_new_finding_exits_nonzero(tmp_path: Path) -> None:
+    """A new FAIL/WARN finding not in baseline causes exit 1."""
+    from datetime import UTC, datetime
+
+    from hasscheck.baseline import BaselineFile, write_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Write an EMPTY baseline (no accepted findings) — all findings will be new
+    bl = BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="hasscheck-ha-2026.5",
+        accepted_findings=[],
+    )
+    write_baseline(bl, out_file)
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--baseline", str(out_file)],
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_check_with_baseline_corrupt_yaml_errors(tmp_path: Path) -> None:
+    """check --baseline with corrupt YAML exits 1 and shows error."""
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "baseline.yaml"
+    out_file.write_text("{bad: yaml: :\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--baseline", str(out_file)],
+    )
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "error" in combined.lower()
+
+
+def test_check_with_baseline_missing_file_errors(tmp_path: Path) -> None:
+    """check --baseline with non-existent file exits 1 and shows error."""
+    write_minimal_integration(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(tmp_path / "missing.yaml"),
+        ],
+    )
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "error" in combined.lower()
+
+
+def test_check_with_baseline_accepted_label_in_terminal(tmp_path: Path) -> None:
+    """Terminal output shows [accepted] for findings in the baseline."""
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--baseline", str(out_file)],
+    )
+    # At least some findings should be accepted if create worked
+    assert "[accepted]" in result.output, (
+        f"Expected [accepted] label in output but got:\n{result.output}"
+    )
+
+
+def test_check_with_baseline_new_label_in_terminal(tmp_path: Path) -> None:
+    """Terminal output shows [new] for FAIL/WARN findings not in baseline."""
+    from datetime import UTC, datetime
+
+    from hasscheck.baseline import BaselineFile, write_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Empty baseline → all findings are [new]
+    bl = BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="hasscheck-ha-2026.5",
+        accepted_findings=[],
+    )
+    write_baseline(bl, out_file)
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--baseline", str(out_file)],
+    )
+    assert "[new]" in result.output, (
+        f"Expected [new] label in output but got:\n{result.output}"
+    )
+
+
+def test_check_with_baseline_fixed_summary_in_terminal(tmp_path: Path) -> None:
+    """Terminal output shows 'fixed since baseline' summary for stale entries."""
+    from datetime import UTC, date, datetime
+
+    from hasscheck.baseline import BaselineEntry, BaselineFile, write_baseline
+
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    # Add a stale entry that won't match any live finding
+    bl = BaselineFile(
+        generated_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        hasscheck_version="0.14.0",
+        ruleset="hasscheck-ha-2026.5",
+        accepted_findings=[
+            BaselineEntry(
+                rule_id="stale.rule",
+                path=None,
+                finding_hash="stale000",
+                accepted_at=date(2026, 5, 1),
+                reason="",
+            )
+        ],
+    )
+    write_baseline(bl, out_file)
+    result = runner.invoke(
+        app,
+        ["check", "--path", str(tmp_path), "--baseline", str(out_file)],
+    )
+    assert "fixed since baseline" in result.output.lower(), (
+        f"Expected 'fixed since baseline' in output but got:\n{result.output}"
+    )
+
+
+def test_check_with_baseline_does_not_change_json_output(tmp_path: Path) -> None:
+    """JSON output is identical whether or not --baseline is passed (D3)."""
+    write_minimal_integration(tmp_path)
+    out_file = tmp_path / "hasscheck-baseline.yaml"
+    runner.invoke(
+        app,
+        ["baseline", "create", "--path", str(tmp_path), "--out", str(out_file)],
+    )
+    # JSON without baseline
+    without = runner.invoke(app, ["check", "--path", str(tmp_path), "--format", "json"])
+    # JSON with baseline
+    with_bl = runner.invoke(
+        app,
+        [
+            "check",
+            "--path",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--baseline",
+            str(out_file),
+        ],
+    )
+    payload_without = json.loads(without.stdout)
+    payload_with = json.loads(with_bl.stdout)
+    # The JSON structure must be identical (no extra baseline keys)
+    assert payload_without["findings"] == payload_with["findings"]
+    assert payload_without["summary"] == payload_with["summary"]
+
+
+def test_check_no_baseline_flag_unchanged(tmp_path: Path) -> None:
+    """Without --baseline, check behavior is identical to pre-baseline behavior."""
+    write_minimal_integration(tmp_path)
+    result_new = runner.invoke(
+        app, ["check", "--path", str(tmp_path), "--format", "json"]
+    )
+    result_json = json.loads(result_new.stdout)
+    # Must still have FAIL findings and exit 1 (no PASS for empty integration)
+    assert any(f["status"] == "fail" for f in result_json["findings"])
+    assert result_new.exit_code == 1


### PR DESCRIPTION
Closes #149

## PR Type
- [x] New feature

## Summary
- Introduces `hasscheck baseline create|update|drop` subcommands for managing `hasscheck-baseline.yaml`
- Adds `--baseline` flag to `check` command; findings partitioned into `new`, `accepted`, `fixed` buckets
- Terminal output labels accepted findings `[accepted]` and new findings `[new]`; shows fixed count in footer
- Gate mode operates on `new` findings only — brownfield integrations can adopt CI without breaking immediately

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/baseline/__init__.py` | New package; re-exports public API |
| `src/hasscheck/baseline/core.py` | `BaselineEntry`, `BaselineFile`, `FindingPartition`, `compute_finding_hash`, `partition_findings`, `load_baseline`, `write_baseline`, `baseline_from_findings`, `merge_baseline`, `drop_from_baseline` |
| `src/hasscheck/baseline/cli.py` | `baseline_app` Typer subapp with `create`, `update`, `drop` subcommands |
| `src/hasscheck/cli.py` | Wire `baseline_app`; add `--baseline` to `check`; partition + label findings |
| `src/hasscheck/output.py` | `print_terminal_report` gains `partition=None`; `[accepted]`/`[new]` labels; fixed-count footer |
| `docs/decisions/0016-baseline-mode.md` | ADR 0016 |
| `tests/test_baseline.py` | 37 unit tests |
| `tests/test_cli.py` | 20+ integration tests |

## Test Plan
- [x] 1099 tests passing (up from 1041, +58)
- [x] Strict TDD — RED → GREEN → REFACTOR per task group
- [x] All pre-commit hooks pass (ruff, ruff-format, YAML, TOML)
- [x] SDD verify-report: PASS