### PR TITLE
chore(release): bump version to 0.15.2 (#149)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.15.1"
+version = "0.15.2"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `src/hasscheck/__init__.py` to `0.15.2`
- Updates `uv.lock`

## Bundled in this release
- #149 — Baseline mode (`hasscheck baseline create|update|drop`, `check --baseline`)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | 0.15.1 → 0.15.2 |
| `src/hasscheck/__init__.py` | 0.15.1 → 0.15.2 |
| `uv.lock` | updated |

## Test Plan
- [x] Version consistency pre-commit hook passes
- [x] CI will run on this PR