### PR TITLE
feat(smoke): hasscheck smoke --ha-version import-compatibility harness (#143)

### DIFF
--- a/docs/decisions/0017-import-smoke-harness.md
+++ b/docs/decisions/0017-import-smoke-harness.md
@@ -1,0 +1,61 @@
+# ADR-0017: Import Smoke Harness
+
+## Status
+
+Accepted
+
+## Context
+
+Static analysis checks in `hasscheck` inspect manifest metadata, code structure, and CI configuration, but they cannot detect runtime breakage caused by incompatible Home Assistant API changes between HA versions. An integration may pass all static checks yet fail at import time when loaded against a newer (or older) HA release due to removed attributes, renamed modules, or altered base classes.
+
+Issue #143 introduces a venv-based import-probing harness (`hasscheck smoke`) to close this gap. The harness:
+
+1. Creates an isolated Python virtual environment (via `uv venv`) pinned to a specific HA version.
+2. Installs `homeassistant==<version>` plus integration requirements.
+3. Runs `python -c "import <module>"` for each module in the integration.
+4. Maps the subprocess exit code and stderr to `Finding` objects using the existing `HassCheckReport` model (Approach C).
+
+See proposal `sdd/143-smoke-harness/proposal` for full context.
+
+## Decision
+
+- **Isolation via `uv venv`** — one virtualenv per (ha_version, python_version) tuple, keyed under a user cache directory. No container dependency.
+- **Approach C — reuse `HassCheckReport`** — the smoke result is a `HassCheckReport` with `target.check_mode="import-smoke"` and findings in `category="compatibility"`. The existing terminal renderer, JSON serialiser, and publish path all work without modification.
+- **Single subprocess boundary in `runner.py`** — all `subprocess.run` calls are isolated in one module (`hasscheck.smoke.runner`), which makes monkeypatching in tests trivial (one symbol).
+- **Stdlib for cache-dir resolution** — no `platformdirs` dependency; uses `$XDG_CACHE_HOME` / `~/.cache` on Linux/macOS and `%LOCALAPPDATA%` on Windows.
+- **`RunSmokeResult` as a frozen dataclass** — the internal orchestration container is NOT a Pydantic model; the serialised artifact is `HassCheckReport`.
+- **Smoke findings are non-overridable structurally** — smoke rules (`smoke.import.fail`, `smoke.import.error`, `smoke.harness.error`) are NOT registered in the `RULES` registry, so `apply_overrides()` can never suppress them.
+
+## Considered Alternatives
+
+### AD-01: Container isolation (Docker / Podman)
+
+**Rejected.** Requires a container runtime as an additional dependency. CI cold-start is significantly slower (container pull vs. uv venv creation). Adds complexity without proportional value for v1. Deferred to v2 if deeper isolation is required.
+
+### AD-02: Standalone `SmokeReport` Pydantic model (Approach A)
+
+**Rejected.** Forks the publish path and terminal renderer. Two divergent report models increase maintenance surface. Approach C achieves the same user-visible result without a schema bump.
+
+### AD-03: Schema bump to 0.6.0 with `smoke_findings` field (Approach B)
+
+**Rejected.** No consumer is ready to handle a new top-level field. Premature schema evolution; deferred until the hub explicitly requests it.
+
+### AD-04: Raw Rich output bypassing `Finding` (Approach D)
+
+**Rejected.** Violates the project discipline of expressing all check results as `Finding` objects. Breaks structured output (`--json`), the terminal renderer, and future baseline diffing.
+
+## Consequences
+
+- `runner.py` is the **sole subprocess boundary** — tests monkeypatch one symbol (`hasscheck.smoke.runner.subprocess.run`).
+- Cache lives under `~/.cache/hasscheck/smoke/<key>` (Linux/macOS). First run is slow (~100 MB HA wheel download); subsequent runs reuse the cached venv.
+- Default timeout is 120 seconds per HA version; overridable via `--timeout`.
+- `category="compatibility"` is registered in `CATEGORY_LABELS` in `checker.py` but is never produced by the static `run_check()` path (no rule in `RULES` carries that category).
+- Exit codes follow the `hasscheck smoke` contract: `0` = all pass, `1` = at least one FAIL finding, `2` = harness error or bad CLI args.
+- Multi-version output (`--ha-version-matrix`) is sequential in v1; concurrency deferred to v2.
+
+## References
+
+- Issue: #143
+- Proposal: `sdd/143-smoke-harness/proposal`
+- Spec: `sdd/143-smoke-harness/spec`
+- Design: `sdd/143-smoke-harness/design`

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -47,6 +47,7 @@ CATEGORY_LABELS = {
     "maintenance_signals": "Maintenance Signals",
     "tests_ci": "Tests/CI",
     "version": "Version Identity",
+    "compatibility": "Import Compatibility",
 }
 
 

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -37,6 +37,7 @@ from hasscheck.publish import (
 from hasscheck.rules.registry import RULES_BY_ID
 from hasscheck.scaffold.cli import scaffold_app
 from hasscheck.slug import detect_repo_slug
+from hasscheck.smoke.cli import smoke_app
 
 # CLI philosophy: developer-friendly but scriptable. Human output is explanatory;
 # --format controls output: terminal (default), json (machine-readable), or md (Markdown).
@@ -602,6 +603,7 @@ def docs_render(
 
 app.add_typer(scaffold_app, name="scaffold")
 app.add_typer(baseline_app, name="baseline")
+app.add_typer(smoke_app, name="smoke")
 
 
 def main() -> None:

--- a/src/hasscheck/smoke/__init__.py
+++ b/src/hasscheck/smoke/__init__.py
@@ -1,0 +1,3 @@
+"""hasscheck.smoke — public API surface for the import smoke harness."""
+
+from __future__ import annotations

--- a/src/hasscheck/smoke/__init__.py
+++ b/src/hasscheck/smoke/__init__.py
@@ -1,3 +1,20 @@
 """hasscheck.smoke — public API surface for the import smoke harness."""
 
 from __future__ import annotations
+
+from hasscheck.smoke.cli import smoke_app
+from hasscheck.smoke.core import RunSmokeResult, run_smoke
+from hasscheck.smoke.errors import (
+    SmokeError,
+    SmokeRunnerMissingError,
+    SmokeTimeoutError,
+)
+
+__all__ = [
+    "run_smoke",
+    "RunSmokeResult",
+    "smoke_app",
+    "SmokeError",
+    "SmokeTimeoutError",
+    "SmokeRunnerMissingError",
+]

--- a/src/hasscheck/smoke/cache.py
+++ b/src/hasscheck/smoke/cache.py
@@ -1,0 +1,5 @@
+"""Venv path resolution and cache key derivation for the smoke harness."""
+
+from __future__ import annotations
+
+pass

--- a/src/hasscheck/smoke/cache.py
+++ b/src/hasscheck/smoke/cache.py
@@ -1,5 +1,64 @@
-"""Venv path resolution and cache key derivation for the smoke harness."""
+"""Venv path resolution and cache key derivation for the smoke harness.
+
+No platformdirs dependency — uses stdlib os.environ + pathlib.
+"""
 
 from __future__ import annotations
 
-pass
+import os
+import sys
+from pathlib import Path
+
+
+def cache_root() -> Path:
+    """Resolve the user cache directory for hasscheck smoke venvs.
+
+    Linux/macOS: ``$XDG_CACHE_HOME/hasscheck`` or ``~/.cache/hasscheck``.
+    Windows: ``%LOCALAPPDATA%/hasscheck`` or ``~/AppData/Local/hasscheck``.
+    """
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+    else:
+        base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "hasscheck"
+
+
+def cache_key(ha_version: str, python_version: str) -> str:
+    """Return a normalised cache key string.
+
+    Strips the leading ``v`` from *ha_version* and normalises *python_version*
+    to ``X.Y`` (drops any patch component).
+    """
+    ha = ha_version.lstrip("v")
+    py_parts = python_version.split(".")
+    py = ".".join(py_parts[:2]) if len(py_parts) >= 2 else python_version
+    return f"ha-{ha}-py-{py}"
+
+
+def get_venv_path(
+    ha_version: str,
+    python_version: str,
+    *,
+    cache_dir: Path | None = None,
+) -> Path:
+    """Return the deterministic venv path for the given (ha_version, python_version).
+
+    Does NOT create the venv. Callers must check :func:`is_venv_ready` and
+    create if needed.
+    """
+    root = cache_dir if cache_dir is not None else cache_root()
+    return root / "smoke" / cache_key(ha_version, python_version)
+
+
+def is_venv_ready(venv_path: Path) -> bool:
+    """Return ``True`` if the python binary inside *venv_path* exists.
+
+    Uses the platform-appropriate binary path:
+    - Linux/macOS: ``<venv>/bin/python``
+    - Windows: ``<venv>/Scripts/python.exe``
+    """
+    if sys.platform == "win32":
+        py_bin = venv_path / "Scripts" / "python.exe"
+    else:
+        py_bin = venv_path / "bin" / "python"
+    return py_bin.exists()

--- a/src/hasscheck/smoke/cli.py
+++ b/src/hasscheck/smoke/cli.py
@@ -88,11 +88,7 @@ def run(
 
     # Output
     if json_out:
-        # Multiple versions → JSON array; single version → single object
-        if len(results) > 1:
-            payload = [r.report.model_dump(mode="json") for r in results]
-        else:
-            payload = results[0].report.model_dump(mode="json")
+        payload = [r.report.model_dump(mode="json") for r in results]
         typer.echo(json.dumps(payload, indent=2))
     else:
         for r in results:

--- a/src/hasscheck/smoke/cli.py
+++ b/src/hasscheck/smoke/cli.py
@@ -1,0 +1,5 @@
+"""Typer CLI surface for `hasscheck smoke`."""
+
+from __future__ import annotations
+
+pass

--- a/src/hasscheck/smoke/cli.py
+++ b/src/hasscheck/smoke/cli.py
@@ -2,4 +2,115 @@
 
 from __future__ import annotations
 
-pass
+import json
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from hasscheck.models import RuleStatus
+from hasscheck.output import print_terminal_report
+from hasscheck.smoke.core import run_smoke
+from hasscheck.smoke.errors import SmokeRunnerMissingError
+from hasscheck.smoke.models import RunSmokeResult
+from hasscheck.smoke.runner import ensure_uv_available
+
+smoke_app = typer.Typer(
+    name="smoke",
+    help="Probe imports of an integration against one or more Home Assistant versions.",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+@smoke_app.command("run")
+def run(
+    path: Path = typer.Option(Path("."), "--path", "-p", help="Repository path."),
+    ha_version: str | None = typer.Option(
+        None,
+        "--ha-version",
+        help="Single HA version to probe against, e.g. 2025.4.",
+    ),
+    ha_version_matrix: str | None = typer.Option(
+        None,
+        "--ha-version-matrix",
+        help="Comma-separated HA versions, e.g. 2025.4,2025.5,2025.6.",
+    ),
+    python: str = typer.Option(
+        f"{sys.version_info.major}.{sys.version_info.minor}",
+        "--python",
+        help="Python version for the probe venv.",
+    ),
+    timeout: float = typer.Option(
+        120.0,
+        "--timeout",
+        help="Per-version timeout in seconds.",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json/--no-json",
+        help="Emit JSON output instead of terminal table.",
+    ),
+) -> None:
+    """Probe an integration against one or more HA versions using isolated venvs."""
+    # XOR validation: exactly one of --ha-version / --ha-version-matrix must be set
+    if (ha_version is None) == (ha_version_matrix is None):
+        typer.echo(
+            "hasscheck: error: pass exactly one of --ha-version or --ha-version-matrix.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    versions = (
+        [ha_version]
+        if ha_version
+        else [v.strip() for v in ha_version_matrix.split(",") if v.strip()]
+    )
+
+    # uv guard — must be available before we do anything
+    try:
+        ensure_uv_available()
+    except SmokeRunnerMissingError as exc:
+        typer.echo(f"hasscheck: error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    results: list[RunSmokeResult] = []
+    for v in versions:
+        result = run_smoke(
+            path,
+            ha_version=v,
+            python_version=python,
+            timeout_s=timeout,
+        )
+        results.append(result)
+
+    # Output
+    if json_out:
+        # Multiple versions → JSON array; single version → single object
+        if len(results) > 1:
+            payload = [r.report.model_dump(mode="json") for r in results]
+        else:
+            payload = results[0].report.model_dump(mode="json")
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        for r in results:
+            cache_hint = "(cached venv)" if r.venv_reused else "(fresh venv)"
+            console.print(f"[bold]HA {r.ha_version}[/bold] {cache_hint}")
+            print_terminal_report(r.report, console)
+
+    # Exit code mapping (D5 / AD-07)
+    has_fail = any(
+        f.status is RuleStatus.FAIL
+        for r in results
+        for f in r.report.findings
+        if f.rule_id != "smoke.harness.error"
+    )
+    has_error = any(
+        f.rule_id == "smoke.harness.error" for r in results for f in r.report.findings
+    )
+    if has_error:
+        raise typer.Exit(code=2)
+    if has_fail:
+        raise typer.Exit(code=1)

--- a/src/hasscheck/smoke/core.py
+++ b/src/hasscheck/smoke/core.py
@@ -2,4 +2,360 @@
 
 from __future__ import annotations
 
-pass
+import json
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from hasscheck.models import (
+    DEFAULT_SOURCE_CHECKED_AT,
+    Applicability,
+    ApplicabilityStatus,
+    CategorySignal,
+    Finding,
+    HassCheckReport,
+    ProjectInfo,
+    ReportSummary,
+    ReportTarget,
+    ReportValidity,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+from hasscheck.smoke import runner as _runner
+from hasscheck.smoke.cache import get_venv_path, is_venv_ready
+from hasscheck.smoke.errors import SmokeError, SmokeTimeoutError
+from hasscheck.smoke.models import ProbeTarget, RunSmokeResult
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SMOKE_RULE_VERSION = "0.1.0"
+
+_SMOKE_SOURCE = RuleSource(
+    url="https://github.com/Daily-Nerd/hasscheck/blob/main/docs/decisions/0017-import-smoke-harness.md",
+    checked_at=DEFAULT_SOURCE_CHECKED_AT,
+)
+
+_SMOKE_APPLICABILITY = Applicability(
+    status=ApplicabilityStatus.APPLICABLE,
+    reason="import-smoke harness probed this module against the requested HA version",
+    source="default",
+)
+
+# RunFn type alias — allows test-injection without touching subprocess boundary
+RunFn = Callable[..., tuple[int, str, str]]
+
+# ---------------------------------------------------------------------------
+# Finding construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_finding_pass(t: ProbeTarget, ha_version: str) -> Finding:
+    return Finding(
+        rule_id="smoke.import.pass",
+        rule_version=SMOKE_RULE_VERSION,
+        category="compatibility",
+        status=RuleStatus.PASS,
+        severity=RuleSeverity.INFORMATIONAL,
+        title=f"Imported {t.module}",
+        message=f"Module imported cleanly against homeassistant=={ha_version}.",
+        applicability=_SMOKE_APPLICABILITY,
+        source=_SMOKE_SOURCE,
+        path=str(t.file_path),
+    )
+
+
+def _make_finding_fail(t: ProbeTarget, ha_version: str, stderr: str) -> Finding:
+    last_line = stderr.strip().splitlines()[-1] if stderr.strip() else "(no stderr)"
+    if "ImportError" in stderr or "ModuleNotFoundError" in stderr:
+        rule_id = "smoke.import.fail"
+    else:
+        rule_id = "smoke.import.error"
+    return Finding(
+        rule_id=rule_id,
+        rule_version=SMOKE_RULE_VERSION,
+        category="compatibility",
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title=f"Failed to import {t.module}",
+        message=f"Import failed against homeassistant=={ha_version}: {last_line}",
+        applicability=_SMOKE_APPLICABILITY,
+        source=_SMOKE_SOURCE,
+        path=str(t.file_path),
+    )
+
+
+def _make_finding_harness_error(message: str, ha_version: str) -> Finding:
+    """Used when the harness itself fails — uv missing mid-run, install failure, timeout."""
+    return Finding(
+        rule_id="smoke.harness.error",
+        rule_version=SMOKE_RULE_VERSION,
+        category="compatibility",
+        status=RuleStatus.FAIL,
+        severity=RuleSeverity.REQUIRED,
+        title="Smoke harness failed",
+        message=message,
+        applicability=_SMOKE_APPLICABILITY,
+        source=_SMOKE_SOURCE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Venv management helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_venv(
+    venv_path: Path,
+    python_version: str,
+    run_fn: RunFn | None = None,
+) -> None:
+    """Create a venv at *venv_path* using ``uv venv``.
+
+    Raises:
+        SmokeError: if uv returns a non-zero exit code.
+    """
+    _run = run_fn or _runner.run_command
+    rc, _stdout, stderr = _run(
+        ["uv", "venv", "--python", python_version, str(venv_path)],
+        timeout=60.0,
+    )
+    if rc != 0:
+        raise SmokeError(f"uv venv failed (rc={rc}): {stderr.strip()}")
+
+
+def _install_packages(
+    venv_path: Path,
+    packages: list[str],
+    run_fn: RunFn | None = None,
+) -> None:
+    """Install *packages* into the venv using ``uv pip install``.
+
+    Raises:
+        SmokeError: if uv returns a non-zero exit code (S10).
+    """
+    _run = run_fn or _runner.run_command
+    if sys.platform == "win32":
+        python_path = venv_path / "Scripts" / "python.exe"
+    else:
+        python_path = venv_path / "bin" / "python"
+    rc, _stdout, stderr = _run(
+        ["uv", "pip", "install", "--python", str(python_path), *packages],
+        timeout=300.0,
+    )
+    if rc != 0:
+        raise SmokeError(f"uv pip install failed (rc={rc}): {stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# Probe-target list construction
+# ---------------------------------------------------------------------------
+
+
+def build_probe_targets(integration_path: Path, manifest: dict) -> list[ProbeTarget]:
+    """Build the list of modules to probe from *manifest*, skipping absent files.
+
+    Only includes a module if its corresponding .py file exists on disk (D8).
+    """
+    domain = manifest["domain"]
+    candidates: list[tuple[str, Path]] = [
+        (f"custom_components.{domain}", integration_path / "__init__.py"),
+        (
+            f"custom_components.{domain}.config_flow",
+            integration_path / "config_flow.py",
+        ),
+    ]
+    for platform in manifest.get("platforms", []):
+        candidates.append(
+            (
+                f"custom_components.{domain}.{platform}",
+                integration_path / f"{platform}.py",
+            )
+        )
+    return [ProbeTarget(module=m, file_path=p) for m, p in candidates if p.exists()]
+
+
+# ---------------------------------------------------------------------------
+# Per-module probe
+# ---------------------------------------------------------------------------
+
+
+def _probe_module(
+    venv: Path,
+    target: ProbeTarget,
+    work_dir: Path,
+    ha_version: str,
+    timeout_s: float = 30.0,
+    run_fn: RunFn | None = None,
+) -> Finding:
+    """Run ``python -c "import <module>"`` inside *venv* and return a Finding."""
+    _run = run_fn or _runner.run_command
+    if sys.platform == "win32":
+        py = venv / "Scripts" / "python.exe"
+    else:
+        py = venv / "bin" / "python"
+    # sys.path.insert(0, work_dir) so that custom_components.<domain> resolves
+    code = (
+        f"import importlib, sys; "
+        f"sys.path.insert(0, {str(work_dir)!r}); "
+        f"importlib.import_module({target.module!r})"
+    )
+    rc, _stdout, stderr = _run(
+        [str(py), "-c", code],
+        timeout=timeout_s,
+        cwd=work_dir,
+    )
+    if rc == 0:
+        return _make_finding_pass(target, ha_version)
+    return _make_finding_fail(target, ha_version, stderr)
+
+
+# ---------------------------------------------------------------------------
+# Report builder
+# ---------------------------------------------------------------------------
+
+
+def _build_report(
+    target_path: Path,
+    findings: list[Finding],
+    *,
+    ha_version: str,
+    python_version: str,
+    domain: str | None,
+    integration_path: Path | None,
+) -> HassCheckReport:
+    target = ReportTarget(
+        integration_domain=domain,
+        ha_version=ha_version,
+        python_version=python_version,
+        check_mode="import-smoke",
+    )
+    pass_count = sum(1 for f in findings if f.status is RuleStatus.PASS)
+    category_signal = CategorySignal(
+        id="compatibility",
+        label="Import Compatibility",
+        points_awarded=pass_count,
+        points_possible=len(findings),
+    )
+    summary = ReportSummary(categories=[category_signal] if findings else [])
+    project = ProjectInfo(
+        path=str(target_path),
+        type="integration" if integration_path is not None else "unknown",
+        domain=domain,
+        integration_path=str(integration_path.relative_to(target_path))
+        if integration_path
+        else None,
+    )
+    return HassCheckReport(
+        project=project,
+        summary=summary,
+        findings=findings,
+        target=target,
+        validity=ReportValidity(checked_at=datetime.now(UTC)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_smoke(
+    target_path: Path,
+    *,
+    ha_version: str,
+    python_version: str,
+    timeout_s: float = 120.0,
+    cache_dir: Path | None = None,
+) -> RunSmokeResult:
+    """Orchestrate one (ha_version, python_version) smoke run.
+
+    Steps:
+    1. Resolve the integration domain and manifest.
+    2. Compute venv path; check reuse.
+    3. Create venv if not ready.
+    4. Install homeassistant==<ver> + manifest requirements.
+    5. Build probe targets.
+    6. Probe each module.
+    7. Build and return RunSmokeResult.
+
+    Error boundary: SmokeError subclasses caught here → harness.error Finding.
+    """
+    root = Path(target_path).resolve()
+
+    try:
+        # Resolve integration path and manifest
+        custom_components = root / "custom_components"
+        integration_path: Path | None = None
+        domain: str | None = None
+        manifest: dict = {}
+
+        if custom_components.is_dir():
+            subdirs = sorted(
+                p
+                for p in custom_components.iterdir()
+                if p.is_dir() and not p.name.startswith(".")
+            )
+            if subdirs:
+                integration_path = subdirs[0]
+                domain = integration_path.name
+                manifest_file = integration_path / "manifest.json"
+                if manifest_file.exists():
+                    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+
+        venv = get_venv_path(ha_version, python_version, cache_dir=cache_dir)
+        reused = is_venv_ready(venv)
+
+        if not reused:
+            _create_venv(venv, python_version)
+
+        # Determine packages to install
+        requirements: list[str] = list(manifest.get("requirements", []))
+        packages = [f"homeassistant=={ha_version}", *requirements]
+        _install_packages(venv, packages)
+
+        # Build probe targets and run probes
+        probe_targets: list[ProbeTarget] = []
+        if integration_path is not None and manifest:
+            probe_targets = build_probe_targets(integration_path, manifest)
+
+        # work_dir is the repo root (parent of custom_components/)
+        findings = [
+            _probe_module(venv, t, root, ha_version, timeout_s=timeout_s)
+            for t in probe_targets
+        ]
+
+    except (SmokeError, SmokeTimeoutError) as exc:
+        error_finding = _make_finding_harness_error(str(exc), ha_version)
+        report = _build_report(
+            root,
+            [error_finding],
+            ha_version=ha_version,
+            python_version=python_version,
+            domain=None,
+            integration_path=None,
+        )
+        return RunSmokeResult(
+            ha_version=ha_version,
+            python_version=python_version,
+            report=report,
+            venv_reused=False,
+        )
+
+    report = _build_report(
+        root,
+        findings,
+        ha_version=ha_version,
+        python_version=python_version,
+        domain=domain,
+        integration_path=integration_path,
+    )
+    return RunSmokeResult(
+        ha_version=ha_version,
+        python_version=python_version,
+        report=report,
+        venv_reused=reused,
+    )

--- a/src/hasscheck/smoke/core.py
+++ b/src/hasscheck/smoke/core.py
@@ -1,0 +1,5 @@
+"""Smoke harness orchestration: venv creation, package install, import probing."""
+
+from __future__ import annotations
+
+pass

--- a/src/hasscheck/smoke/errors.py
+++ b/src/hasscheck/smoke/errors.py
@@ -1,0 +1,15 @@
+"""Smoke harness exception hierarchy."""
+
+from __future__ import annotations
+
+
+class SmokeError(Exception):
+    """Base class for all smoke harness errors."""
+
+
+class SmokeTimeoutError(SmokeError):
+    """Raised when a subprocess invocation exceeds its timeout budget."""
+
+
+class SmokeRunnerMissingError(SmokeError):
+    """Raised when a required binary (e.g. uv) is absent from PATH."""

--- a/src/hasscheck/smoke/models.py
+++ b/src/hasscheck/smoke/models.py
@@ -1,0 +1,5 @@
+"""Internal dataclasses for the smoke harness (not Pydantic models)."""
+
+from __future__ import annotations
+
+pass

--- a/src/hasscheck/smoke/models.py
+++ b/src/hasscheck/smoke/models.py
@@ -1,5 +1,34 @@
-"""Internal dataclasses for the smoke harness (not Pydantic models)."""
+"""Internal dataclasses for the smoke harness.
+
+These are NOT Pydantic models. The serialised artifact is HassCheckReport.
+"""
 
 from __future__ import annotations
 
-pass
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hasscheck.models import HassCheckReport
+
+
+@dataclass(frozen=True)
+class ProbeTarget:
+    """One importable module to probe, with its on-disk path for Finding.path."""
+
+    module: str  # e.g. "custom_components.foo.config_flow"
+    file_path: Path  # absolute path to the .py file
+
+
+@dataclass(frozen=True)
+class RunSmokeResult:
+    """Lightweight orchestration container for one (ha_version, python_version) run.
+
+    NOT a Pydantic model — the serialised artifact is the contained HassCheckReport.
+    """
+
+    ha_version: str
+    python_version: str
+    report: HassCheckReport
+    venv_reused: bool  # True when the cached venv was reused without recreation

--- a/src/hasscheck/smoke/runner.py
+++ b/src/hasscheck/smoke/runner.py
@@ -6,4 +6,51 @@ Monkeypatch hasscheck.smoke.runner.subprocess.run to intercept them in tests.
 
 from __future__ import annotations
 
-pass
+import shutil
+import subprocess
+from pathlib import Path
+
+from hasscheck.smoke.errors import SmokeRunnerMissingError, SmokeTimeoutError
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    timeout: float,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    """Run *cmd*; return ``(returncode, stdout, stderr)``.
+
+    Raises:
+        SmokeTimeoutError: if the subprocess exceeds *timeout* seconds.
+        SmokeRunnerMissingError: if *cmd[0]* binary is not found.
+
+    Never raises ``CalledProcessError`` — the caller inspects ``returncode``.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — cmd is constructed internally
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SmokeTimeoutError(
+            f"command timed out after {timeout}s: {' '.join(cmd)}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise SmokeRunnerMissingError(f"binary not found: {cmd[0]}") from exc
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def ensure_uv_available() -> None:
+    """Raise ``SmokeRunnerMissingError`` with actionable hint if ``uv`` is not on PATH."""
+    if shutil.which("uv") is None:
+        raise SmokeRunnerMissingError(
+            "`uv` binary not found on PATH. "
+            "Install: https://docs.astral.sh/uv/getting-started/installation/"
+        )

--- a/src/hasscheck/smoke/runner.py
+++ b/src/hasscheck/smoke/runner.py
@@ -1,0 +1,9 @@
+"""Subprocess boundary for the smoke harness.
+
+All subprocess.run calls in the smoke package go through run_command().
+Monkeypatch hasscheck.smoke.runner.subprocess.run to intercept them in tests.
+"""
+
+from __future__ import annotations
+
+pass

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for the smoke test suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_integration(tmp_path: Path) -> Path:
+    """Create a minimal integration structure for smoke tests.
+
+    Returns the repo root (containing custom_components/foo/).
+    """
+    integration = tmp_path / "custom_components" / "foo"
+    integration.mkdir(parents=True)
+    (integration / "__init__.py").write_text("", encoding="utf-8")
+    manifest = {
+        "domain": "foo",
+        "name": "Foo",
+        "documentation": "https://example.com",
+        "issue_tracker": "https://example.com/issues",
+        "codeowners": ["@foo"],
+        "version": "0.1.0",
+        "requirements": [],
+    }
+    (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture()
+def integration_repo(tmp_path: Path) -> Path:
+    """Fixture: a minimal integration repository under tmp_path."""
+    return _make_integration(tmp_path)
+
+
+@pytest.fixture()
+def fake_run_success():
+    """Fixture: a subprocess.run fake that always returns (rc=0, stdout='', stderr='')."""
+
+    def _fake(*args, **kwargs):
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    return _fake

--- a/tests/smoke/test_build_probe_targets.py
+++ b/tests/smoke/test_build_probe_targets.py
@@ -1,0 +1,104 @@
+"""Group 5.5: Tests for build_probe_targets — file-existence guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_integration(
+    tmp_path: Path, platforms: list[str], files: list[str]
+) -> tuple[Path, dict]:
+    """Create an integration directory with specified files and return (path, manifest)."""
+    integration = tmp_path / "custom_components" / "foo"
+    integration.mkdir(parents=True)
+    # Always create __init__.py unless explicitly excluded
+    for fname in files:
+        (integration / fname).touch()
+    manifest = {
+        "domain": "foo",
+        "name": "Foo",
+        "platforms": platforms,
+    }
+    return integration, manifest
+
+
+def test_domain_init_included_when_exists(tmp_path) -> None:
+    """__init__.py is always included when it exists."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=[], files=["__init__.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo" in modules
+
+
+def test_domain_init_excluded_when_missing(tmp_path) -> None:
+    """__init__.py is excluded when it does not exist."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(tmp_path, platforms=[], files=[])
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo" not in modules
+
+
+def test_config_flow_included_when_exists(tmp_path) -> None:
+    """config_flow.py is included when it exists."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=[], files=["__init__.py", "config_flow.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo.config_flow" in modules
+
+
+def test_config_flow_excluded_when_missing(tmp_path) -> None:
+    """config_flow.py is excluded when it does not exist."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=[], files=["__init__.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo.config_flow" not in modules
+
+
+def test_platform_included_when_file_exists(tmp_path) -> None:
+    """Platform module is included when its .py file exists."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=["sensor"], files=["__init__.py", "sensor.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo.sensor" in modules
+
+
+def test_platform_excluded_when_file_missing(tmp_path) -> None:
+    """Platform in manifest but missing .py file → NOT included (manifest config drift)."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=["sensor"], files=["__init__.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    modules = [t.module for t in targets]
+    assert "custom_components.foo.sensor" not in modules
+
+
+def test_probe_target_file_path_is_absolute(tmp_path) -> None:
+    """ProbeTarget.file_path is an absolute path."""
+    from hasscheck.smoke.core import build_probe_targets
+
+    integration, manifest = _make_integration(
+        tmp_path, platforms=[], files=["__init__.py"]
+    )
+    targets = build_probe_targets(integration, manifest)
+    for t in targets:
+        assert t.file_path.is_absolute()

--- a/tests/smoke/test_cache.py
+++ b/tests/smoke/test_cache.py
@@ -1,0 +1,76 @@
+"""Group 3: Tests for hasscheck.smoke.cache — venv path resolution."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from hasscheck.smoke.cache import cache_key, cache_root, get_venv_path, is_venv_ready
+
+
+def test_cache_key_strips_leading_v_from_ha_version() -> None:
+    """cache_key strips the leading 'v' from ha_version."""
+    key = cache_key("v2025.4.0", "3.12")
+    assert "v" not in key.split("-")[1]  # ha part should not have leading v
+    assert "2025.4.0" in key
+
+
+def test_cache_key_normalises_python_to_x_y() -> None:
+    """cache_key normalises python_version 3.12.1 → 3.12."""
+    key_full = cache_key("2025.4", "3.12.1")
+    key_short = cache_key("2025.4", "3.12")
+    assert key_full == key_short
+
+
+def test_cache_key_deterministic() -> None:
+    """Identical inputs produce the same cache key."""
+    assert cache_key("2025.4", "3.12") == cache_key("2025.4", "3.12")
+
+
+def test_get_venv_path_returns_same_path_on_identical_inputs(tmp_path) -> None:
+    """get_venv_path is deterministic (S9): same inputs → same Path."""
+    p1 = get_venv_path("2025.4", "3.12", cache_dir=tmp_path)
+    p2 = get_venv_path("2025.4", "3.12", cache_dir=tmp_path)
+    assert p1 == p2
+
+
+def test_get_venv_path_differs_for_different_ha_versions(tmp_path) -> None:
+    """Different ha_versions produce different paths."""
+    p1 = get_venv_path("2025.4", "3.12", cache_dir=tmp_path)
+    p2 = get_venv_path("2025.5", "3.12", cache_dir=tmp_path)
+    assert p1 != p2
+
+
+def test_get_venv_path_is_under_cache_dir(tmp_path) -> None:
+    """Returned path is rooted under cache_dir."""
+    p = get_venv_path("2025.4", "3.12", cache_dir=tmp_path)
+    assert str(p).startswith(str(tmp_path))
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="XDG_CACHE_HOME is Linux/macOS only"
+)
+def test_cache_root_honours_xdg_cache_home(monkeypatch, tmp_path) -> None:
+    """cache_root uses XDG_CACHE_HOME when set."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    root = cache_root()
+    assert str(root).startswith(str(tmp_path))
+
+
+def test_is_venv_ready_returns_false_when_python_binary_absent(tmp_path) -> None:
+    """is_venv_ready returns False when the python binary does not exist."""
+    assert is_venv_ready(tmp_path) is False
+
+
+def test_is_venv_ready_returns_true_when_python_binary_present(tmp_path) -> None:
+    """is_venv_ready returns True when the platform python binary is present."""
+    if sys.platform == "win32":
+        scripts = tmp_path / "Scripts"
+        scripts.mkdir()
+        (scripts / "python.exe").touch()
+    else:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "python").touch()
+    assert is_venv_ready(tmp_path) is True

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -1,0 +1,203 @@
+"""Group 7: Tests for hasscheck.smoke.cli — Typer CLI surface.
+
+Note on invocation: smoke_app has a single command 'run'. When a Typer app
+has exactly one command registered, CliRunner exposes that command's options
+at the top level (i.e. invoke smoke_app without the 'run' subcommand word).
+For the root CLI tests (Group 8) we use `app` and include "smoke run".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+from hasscheck.smoke.cli import smoke_app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_integration(tmp_path: Path) -> Path:
+    """Create a minimal integration structure."""
+    integration = tmp_path / "custom_components" / "foo"
+    integration.mkdir(parents=True)
+    (integration / "__init__.py").write_text("", encoding="utf-8")
+    manifest = {
+        "domain": "foo",
+        "name": "Foo",
+        "documentation": "https://example.com",
+        "issue_tracker": "https://example.com/issues",
+        "codeowners": ["@foo"],
+        "version": "0.1.0",
+        "requirements": [],
+    }
+    (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path
+
+
+def _fake_run_success(*args, **kwargs):
+    """subprocess.run fake returning success (rc=0)."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = ""
+    m.stderr = ""
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Task 7.1 — help, XOR validation, uv guard
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_help_exits_0() -> None:
+    """hasscheck smoke --help exits 0."""
+    result = runner.invoke(smoke_app, ["--help"])
+    assert result.exit_code == 0
+
+
+def test_smoke_run_help_mentions_run() -> None:
+    """smoke app help output mentions 'run' (as the command name or option)."""
+    result = runner.invoke(smoke_app, ["--help"])
+    assert result.exit_code == 0
+    # 'run' appears in the Usage line or option descriptions
+    assert "run" in result.output.lower()
+
+
+def test_smoke_missing_both_version_flags_exits_2(tmp_path) -> None:
+    """Missing both --ha-version and --ha-version-matrix exits 2."""
+    result = runner.invoke(smoke_app, ["--path", str(tmp_path)])
+    assert result.exit_code == 2
+
+
+def test_smoke_both_version_flags_simultaneously_exits_2(tmp_path) -> None:
+    """Providing both --ha-version and --ha-version-matrix simultaneously exits 2."""
+    result = runner.invoke(
+        smoke_app,
+        [
+            "--path",
+            str(tmp_path),
+            "--ha-version",
+            "2025.4",
+            "--ha-version-matrix",
+            "2025.4,2025.5",
+        ],
+    )
+    assert result.exit_code == 2
+
+
+def test_smoke_uv_absent_exits_2_with_uv_in_output(monkeypatch, tmp_path) -> None:
+    """uv absent from PATH → exit 2 AND output contains 'uv' (S4)."""
+    monkeypatch.setattr("hasscheck.smoke.runner.shutil.which", lambda _: None)
+    result = runner.invoke(
+        smoke_app,
+        ["--path", str(tmp_path), "--ha-version", "2025.4"],
+    )
+    assert result.exit_code == 2
+    assert "uv" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Task 7.3 — exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_all_pass_findings_exits_0(monkeypatch, tmp_path) -> None:
+    """All PASS findings → exit code 0."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    result = runner.invoke(
+        smoke_app,
+        ["--path", str(repo), "--ha-version", "2025.4"],
+    )
+    assert result.exit_code == 0
+
+
+def test_smoke_fail_finding_exits_1(monkeypatch, tmp_path) -> None:
+    """At least one FAIL finding → exit code 1."""
+    repo = _make_integration(tmp_path)
+
+    def fake_run_fail(*args, **kwargs):
+        m = MagicMock()
+        cmd = args[0]
+        if "pip" in cmd or "venv" in cmd:
+            m.returncode = 0
+            m.stdout = ""
+            m.stderr = ""
+        else:
+            m.returncode = 1
+            m.stdout = ""
+            m.stderr = "ImportError: No module named 'homeassistant'"
+        return m
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", fake_run_fail)
+
+    result = runner.invoke(
+        smoke_app,
+        ["--path", str(repo), "--ha-version", "2025.4"],
+    )
+    assert result.exit_code == 1
+
+
+def test_smoke_harness_error_finding_exits_2(monkeypatch, tmp_path) -> None:
+    """Harness error finding (smoke.harness.error) → exit code 2."""
+    repo = _make_integration(tmp_path)
+    import subprocess
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=0.001)
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", timeout_run)
+
+    result = runner.invoke(
+        smoke_app,
+        ["--path", str(repo), "--ha-version", "2025.4"],
+    )
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Task 7.5 — --json output
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_json_single_version_stdout_is_valid_json(monkeypatch, tmp_path) -> None:
+    """--json with one version → stdout is valid JSON (S7)."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    result = runner.invoke(
+        smoke_app,
+        ["--path", str(repo), "--ha-version", "2025.4", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert isinstance(payload, (dict, list))
+
+
+def test_smoke_json_matrix_stdout_is_valid_json_array(monkeypatch, tmp_path) -> None:
+    """--json with matrix of 2 versions → stdout is valid JSON array (S7)."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    result = runner.invoke(
+        smoke_app,
+        [
+            "--path",
+            str(repo),
+            "--ha-version-matrix",
+            "2025.4,2025.5",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 2

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -179,7 +179,8 @@ def test_smoke_json_single_version_stdout_is_valid_json(monkeypatch, tmp_path) -
     )
     assert result.exit_code == 0
     payload = json.loads(result.output)
-    assert isinstance(payload, (dict, list))
+    assert isinstance(payload, list)
+    assert len(payload) == 1
 
 
 def test_smoke_json_matrix_stdout_is_valid_json_array(monkeypatch, tmp_path) -> None:

--- a/tests/smoke/test_cli_integration.py
+++ b/tests/smoke/test_cli_integration.py
@@ -1,0 +1,111 @@
+"""Group 9: Integration test — full CLI with monkeypatched subprocess, 2-version matrix."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+from hasscheck.smoke.cli import smoke_app
+
+runner = CliRunner()
+
+
+def _make_integration(tmp_path: Path) -> Path:
+    """Create a minimal integration structure."""
+    integration = tmp_path / "custom_components" / "foo"
+    integration.mkdir(parents=True)
+    (integration / "__init__.py").write_text("", encoding="utf-8")
+    manifest = {
+        "domain": "foo",
+        "name": "Foo",
+        "documentation": "https://example.com",
+        "issue_tracker": "https://example.com/issues",
+        "codeowners": ["@foo"],
+        "version": "0.1.0",
+        "requirements": [],
+    }
+    (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path
+
+
+def _fake_run_success(*args, **kwargs):
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = ""
+    m.stderr = ""
+    return m
+
+
+def test_matrix_invokes_run_smoke_twice(monkeypatch, tmp_path) -> None:
+    """--ha-version-matrix='2025.4,2025.5' → run_smoke invoked once per version (S5)."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    call_log: list[str] = []
+    original_run_smoke = __import__(
+        "hasscheck.smoke.core", fromlist=["run_smoke"]
+    ).run_smoke
+
+    def spy_run_smoke(target_path, *, ha_version, **kwargs):
+        call_log.append(ha_version)
+        return original_run_smoke(target_path, ha_version=ha_version, **kwargs)
+
+    monkeypatch.setattr("hasscheck.smoke.cli.run_smoke", spy_run_smoke)
+
+    result = runner.invoke(
+        smoke_app,
+        [
+            "--path",
+            str(repo),
+            "--ha-version-matrix",
+            "2025.4,2025.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert call_log == ["2025.4", "2025.5"], f"Expected 2 invocations, got: {call_log}"
+
+
+def test_matrix_output_contains_both_version_strings(monkeypatch, tmp_path) -> None:
+    """Terminal output contains both HA version strings when matrix is used."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    result = runner.invoke(
+        smoke_app,
+        [
+            "--path",
+            str(repo),
+            "--ha-version-matrix",
+            "2025.4,2025.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "2025.4" in result.output
+    assert "2025.5" in result.output
+
+
+def test_matrix_json_produces_two_element_array(monkeypatch, tmp_path) -> None:
+    """--json with 2-version matrix produces a JSON array of length 2."""
+    repo = _make_integration(tmp_path)
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", _fake_run_success)
+
+    result = runner.invoke(
+        smoke_app,
+        [
+            "--path",
+            str(repo),
+            "--ha-version-matrix",
+            "2025.4,2025.5",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+    # Each element has schema_version (it's a HassCheckReport)
+    for item in payload:
+        assert "schema_version" in item

--- a/tests/smoke/test_core.py
+++ b/tests/smoke/test_core.py
@@ -1,0 +1,304 @@
+"""Group 5: Tests for hasscheck.smoke.core — Finding helpers, venv orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hasscheck.models import RuleStatus
+from hasscheck.smoke.errors import SmokeError
+from hasscheck.smoke.models import ProbeTarget
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_probe_target(
+    module: str = "custom_components.foo", path: str = "/foo/__init__.py"
+) -> ProbeTarget:
+    return ProbeTarget(module=module, file_path=Path(path))
+
+
+def _fake_run_success(*args, **kwargs):
+    """Simulate subprocess.run returning success (rc=0)."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = ""
+    m.stderr = ""
+    return m
+
+
+def _fake_run_import_error(*args, **kwargs):
+    """Simulate subprocess.run returning an ImportError in stderr."""
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = "Traceback (most recent call last):\n  ...\nImportError: No module named 'homeassistant.components.foo'"
+    return m
+
+
+def _fake_run_attribute_error(*args, **kwargs):
+    """Simulate subprocess.run returning an AttributeError in stderr."""
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = "Traceback (most recent call last):\n  ...\nAttributeError: module 'homeassistant' has no attribute 'old_thing'"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1 RED — Finding construction helpers
+# ---------------------------------------------------------------------------
+
+
+def test_make_finding_pass_returns_pass_finding() -> None:
+    """_make_finding_pass returns Finding(rule_id='smoke.import.pass', status=PASS)."""
+    from hasscheck.smoke.core import _make_finding_pass
+
+    t = _make_probe_target()
+    finding = _make_finding_pass(t, "2025.4")
+    assert finding.rule_id == "smoke.import.pass"
+    assert finding.status is RuleStatus.PASS
+    assert finding.category == "compatibility"
+
+
+def test_make_finding_fail_import_error_maps_to_smoke_import_fail(monkeypatch) -> None:
+    """_make_finding_fail maps ImportError in stderr → rule_id='smoke.import.fail'."""
+    from hasscheck.smoke.core import _make_finding_fail
+
+    t = _make_probe_target()
+    stderr = "ImportError: No module named 'homeassistant.components.foo'"
+    finding = _make_finding_fail(t, "2025.4", stderr)
+    assert finding.rule_id == "smoke.import.fail"
+    assert finding.status is RuleStatus.FAIL
+    assert finding.category == "compatibility"
+
+
+def test_make_finding_fail_module_not_found_maps_to_smoke_import_fail(
+    monkeypatch,
+) -> None:
+    """_make_finding_fail maps ModuleNotFoundError → rule_id='smoke.import.fail'."""
+    from hasscheck.smoke.core import _make_finding_fail
+
+    t = _make_probe_target()
+    stderr = "ModuleNotFoundError: No module named 'foo'"
+    finding = _make_finding_fail(t, "2025.4", stderr)
+    assert finding.rule_id == "smoke.import.fail"
+
+
+def test_make_finding_fail_attribute_error_maps_to_smoke_import_error(
+    monkeypatch,
+) -> None:
+    """_make_finding_fail maps AttributeError in stderr → rule_id='smoke.import.error'."""
+    from hasscheck.smoke.core import _make_finding_fail
+
+    t = _make_probe_target()
+    stderr = "AttributeError: module 'homeassistant' has no attribute 'old_thing'"
+    finding = _make_finding_fail(t, "2025.4", stderr)
+    assert finding.rule_id == "smoke.import.error"
+    assert finding.status is RuleStatus.FAIL
+
+
+def test_make_finding_harness_error_returns_correct_rule_id() -> None:
+    """_make_finding_harness_error returns rule_id='smoke.harness.error'."""
+    from hasscheck.smoke.core import _make_finding_harness_error
+
+    finding = _make_finding_harness_error("harness exploded", "2025.4")
+    assert finding.rule_id == "smoke.harness.error"
+    assert finding.status is RuleStatus.FAIL
+    assert finding.category == "compatibility"
+
+
+# ---------------------------------------------------------------------------
+# Task 5.3 RED — _create_venv / _install_packages
+# ---------------------------------------------------------------------------
+
+
+def test_create_venv_calls_uv_venv(monkeypatch, tmp_path) -> None:
+    """_create_venv calls runner with ['uv', 'venv', '--python', ...]."""
+    calls = []
+
+    def fake_run(cmd, *, timeout, cwd=None, env=None):
+        calls.append(cmd)
+        return (0, "", "")
+
+    monkeypatch.setattr(
+        "hasscheck.smoke.runner.subprocess.run", lambda *a, **kw: _fake_run_success()
+    )
+
+    from hasscheck.smoke.core import _create_venv
+
+    _create_venv(tmp_path / "venv", "3.12", run_fn=fake_run)
+    assert len(calls) == 1
+    assert calls[0][0] == "uv"
+    assert "venv" in calls[0]
+    assert "--python" in calls[0]
+    assert "3.12" in calls[0]
+
+
+def test_create_venv_raises_smoke_error_on_nonzero_rc(tmp_path) -> None:
+    """_create_venv raises SmokeError when runner returns non-zero rc."""
+
+    def failing_run(cmd, *, timeout, cwd=None, env=None):
+        return (1, "", "uv venv failed")
+
+    from hasscheck.smoke.core import _create_venv
+
+    with pytest.raises(SmokeError):
+        _create_venv(tmp_path / "venv", "3.12", run_fn=failing_run)
+
+
+def test_install_packages_calls_uv_pip_install(tmp_path) -> None:
+    """_install_packages calls runner with uv pip install --python ..."""
+    calls = []
+
+    def fake_run(cmd, *, timeout, cwd=None, env=None):
+        calls.append(cmd)
+        return (0, "", "")
+
+    # Create fake python binary
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "python").touch()
+
+    from hasscheck.smoke.core import _install_packages
+
+    _install_packages(tmp_path, ["homeassistant==2025.4"], run_fn=fake_run)
+    assert len(calls) == 1
+    assert "uv" in calls[0]
+    assert "pip" in calls[0]
+    assert "install" in calls[0]
+    assert "--python" in calls[0]
+
+
+def test_install_packages_raises_smoke_error_on_failure(tmp_path) -> None:
+    """_install_packages raises SmokeError when runner returns non-zero rc (S10)."""
+
+    def failing_run(cmd, *, timeout, cwd=None, env=None):
+        return (1, "", "installation failed")
+
+    # Create fake python binary
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "python").touch()
+
+    from hasscheck.smoke.core import _install_packages
+
+    with pytest.raises(SmokeError):
+        _install_packages(tmp_path, ["homeassistant==2025.4"], run_fn=failing_run)
+
+
+# ---------------------------------------------------------------------------
+# Task 5.7 RED — run_smoke orchestration
+# ---------------------------------------------------------------------------
+
+
+def _make_integration(tmp_path: Path) -> Path:
+    """Create a minimal integration structure for run_smoke tests."""
+    integration = tmp_path / "custom_components" / "foo"
+    integration.mkdir(parents=True)
+    (integration / "__init__.py").write_text("", encoding="utf-8")
+    manifest = {
+        "domain": "foo",
+        "name": "Foo",
+        "documentation": "https://example.com",
+        "issue_tracker": "https://example.com/issues",
+        "codeowners": ["@foo"],
+        "version": "0.1.0",
+        "requirements": [],
+    }
+    (integration / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path
+
+
+def test_run_smoke_all_imports_succeed_produces_pass_findings(
+    monkeypatch, tmp_path
+) -> None:
+    """run_smoke with all subprocess calls succeeding → all PASS findings, venv_reused=False (S1)."""
+    repo = _make_integration(tmp_path)
+
+    monkeypatch.setattr(
+        "hasscheck.smoke.runner.subprocess.run",
+        _fake_run_success,
+    )
+
+    from hasscheck.smoke.core import run_smoke
+
+    result = run_smoke(
+        repo,
+        ha_version="2025.4",
+        python_version="3.12",
+        timeout_s=30.0,
+        cache_dir=tmp_path / "cache",
+    )
+    assert result.venv_reused is False
+    pass_findings = [
+        f for f in result.report.findings if f.rule_id == "smoke.import.pass"
+    ]
+    fail_findings = [f for f in result.report.findings if f.status is RuleStatus.FAIL]
+    assert len(pass_findings) >= 1
+    assert len(fail_findings) == 0
+
+
+def test_run_smoke_one_import_error_produces_fail_finding(
+    monkeypatch, tmp_path
+) -> None:
+    """run_smoke with one ImportError in stderr → one FAIL finding (S2)."""
+    repo = _make_integration(tmp_path)
+
+    call_count = {"n": 0}
+
+    def selective_fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        cmd = args[0]
+        # First two calls (uv venv + uv pip install) succeed
+        if "venv" in cmd or "pip" in cmd:
+            return _fake_run_success()
+        # Probe calls: fail the first probe
+        if call_count["n"] <= 3:
+            return _fake_run_import_error()
+        return _fake_run_success()
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", selective_fake_run)
+
+    from hasscheck.smoke.core import run_smoke
+
+    result = run_smoke(
+        repo,
+        ha_version="2025.4",
+        python_version="3.12",
+        timeout_s=30.0,
+        cache_dir=tmp_path / "cache",
+    )
+    fail_findings = [f for f in result.report.findings if f.status is RuleStatus.FAIL]
+    assert len(fail_findings) >= 1
+    assert any(f.rule_id == "smoke.import.fail" for f in fail_findings)
+
+
+def test_run_smoke_timeout_produces_harness_error_finding(
+    monkeypatch, tmp_path
+) -> None:
+    """run_smoke with SmokeTimeoutError → single harness.error finding (S6)."""
+    import subprocess
+
+    repo = _make_integration(tmp_path)
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=0.001)
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", timeout_run)
+
+    from hasscheck.smoke.core import run_smoke
+
+    result = run_smoke(
+        repo,
+        ha_version="2025.4",
+        python_version="3.12",
+        timeout_s=0.001,
+        cache_dir=tmp_path / "cache",
+    )
+    assert any(f.rule_id == "smoke.harness.error" for f in result.report.findings)

--- a/tests/smoke/test_models.py
+++ b/tests/smoke/test_models.py
@@ -1,0 +1,69 @@
+"""Group 4: Tests for hasscheck.smoke.models — internal dataclasses."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+
+def test_probe_target_is_frozen_dataclass() -> None:
+    """ProbeTarget is a frozen dataclass with module: str and file_path: Path."""
+    from hasscheck.smoke.models import ProbeTarget
+
+    assert dataclasses.is_dataclass(ProbeTarget)
+    fields = {f.name: f for f in dataclasses.fields(ProbeTarget)}
+    assert "module" in fields
+    assert "file_path" in fields
+    # frozen → assignment raises FrozenInstanceError
+    t = ProbeTarget(module="custom_components.foo", file_path=Path("/foo/__init__.py"))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        t.module = "other"  # type: ignore[misc]
+
+
+def test_probe_target_field_types() -> None:
+    """ProbeTarget.module is str and file_path is Path."""
+    from hasscheck.smoke.models import ProbeTarget
+
+    t = ProbeTarget(module="custom_components.foo", file_path=Path("/foo/__init__.py"))
+    assert isinstance(t.module, str)
+    assert isinstance(t.file_path, Path)
+
+
+def test_run_smoke_result_is_frozen_dataclass() -> None:
+    """RunSmokeResult is a frozen dataclass with the required fields."""
+    import dataclasses
+
+    from hasscheck.smoke.models import RunSmokeResult
+
+    assert dataclasses.is_dataclass(RunSmokeResult)
+    fields = {f.name for f in dataclasses.fields(RunSmokeResult)}
+    assert "ha_version" in fields
+    assert "python_version" in fields
+    assert "report" in fields
+    assert "venv_reused" in fields
+
+
+def test_run_smoke_result_is_not_pydantic() -> None:
+    """RunSmokeResult must NOT be a Pydantic BaseModel."""
+    from hasscheck.smoke.models import RunSmokeResult
+
+    try:
+        from pydantic import BaseModel
+
+        assert not issubclass(RunSmokeResult, BaseModel)
+    except ImportError:
+        pass  # pydantic not installed — trivially satisfied
+
+
+def test_probe_target_is_not_pydantic() -> None:
+    """ProbeTarget must NOT be a Pydantic BaseModel."""
+    from hasscheck.smoke.models import ProbeTarget
+
+    try:
+        from pydantic import BaseModel
+
+        assert not issubclass(ProbeTarget, BaseModel)
+    except ImportError:
+        pass

--- a/tests/smoke/test_runner.py
+++ b/tests/smoke/test_runner.py
@@ -1,0 +1,77 @@
+"""Group 2: Tests for hasscheck.smoke.runner — subprocess boundary."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from hasscheck.smoke.errors import SmokeRunnerMissingError, SmokeTimeoutError
+from hasscheck.smoke.runner import ensure_uv_available, run_command
+
+
+def test_run_command_returns_returncode_stdout_stderr() -> None:
+    """run_command returns (rc, stdout, stderr) for a real fast subprocess."""
+    rc, stdout, stderr = run_command(
+        [sys.executable, "-c", "print('ok')"],
+        timeout=10.0,
+    )
+    assert rc == 0
+    assert stdout.strip() == "ok"
+    assert stderr == ""
+
+
+def test_run_command_captures_stderr() -> None:
+    """run_command captures stderr separately from stdout."""
+    rc, stdout, stderr = run_command(
+        [sys.executable, "-c", "import sys; sys.stderr.write('err\\n')"],
+        timeout=10.0,
+    )
+    assert rc == 0
+    assert stdout == ""
+    assert stderr.strip() == "err"
+
+
+def test_run_command_nonzero_returncode() -> None:
+    """run_command returns non-zero rc without raising."""
+    rc, _stdout, _stderr = run_command(
+        [sys.executable, "-c", "raise SystemExit(42)"],
+        timeout=10.0,
+    )
+    assert rc == 42
+
+
+def test_run_command_raises_smoke_timeout_error(monkeypatch) -> None:
+    """run_command raises SmokeTimeoutError when timeout expires."""
+    import subprocess
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=0.001)
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", fake_run)
+    with pytest.raises(SmokeTimeoutError):
+        run_command([sys.executable, "-c", "pass"], timeout=0.001)
+
+
+def test_run_command_raises_smoke_runner_missing_error(monkeypatch) -> None:
+    """run_command raises SmokeRunnerMissingError when binary not found."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("no such file or directory")
+
+    monkeypatch.setattr("hasscheck.smoke.runner.subprocess.run", fake_run)
+    with pytest.raises(SmokeRunnerMissingError):
+        run_command(["nonexistent-binary-xyz", "--version"], timeout=5.0)
+
+
+def test_ensure_uv_available_raises_when_uv_absent(monkeypatch) -> None:
+    """ensure_uv_available raises SmokeRunnerMissingError when uv not on PATH."""
+    monkeypatch.setattr("hasscheck.smoke.runner.shutil.which", lambda _: None)
+    with pytest.raises(SmokeRunnerMissingError, match="uv"):
+        ensure_uv_available()
+
+
+def test_ensure_uv_available_passes_when_uv_present(monkeypatch) -> None:
+    """ensure_uv_available does not raise when uv is on PATH."""
+    monkeypatch.setattr("hasscheck.smoke.runner.shutil.which", lambda _: "/usr/bin/uv")
+    ensure_uv_available()  # should not raise

--- a/tests/smoke/test_scaffold.py
+++ b/tests/smoke/test_scaffold.py
@@ -1,0 +1,37 @@
+"""Group 1: Package scaffold — assert smoke package has all required modules."""
+
+from __future__ import annotations
+
+import importlib.util
+
+
+def _spec_exists(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def test_smoke_init_exists() -> None:
+    assert _spec_exists("hasscheck.smoke"), "hasscheck.smoke.__init__ missing"
+
+
+def test_smoke_core_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.core"), "hasscheck.smoke.core missing"
+
+
+def test_smoke_runner_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.runner"), "hasscheck.smoke.runner missing"
+
+
+def test_smoke_cache_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.cache"), "hasscheck.smoke.cache missing"
+
+
+def test_smoke_cli_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.cli"), "hasscheck.smoke.cli missing"
+
+
+def test_smoke_errors_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.errors"), "hasscheck.smoke.errors missing"
+
+
+def test_smoke_models_exists() -> None:
+    assert _spec_exists("hasscheck.smoke.models"), "hasscheck.smoke.models missing"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from hasscheck.checker import run_check
+from hasscheck.checker import CATEGORY_LABELS, run_check
 from hasscheck.config import HassCheckConfig, RuleOverride
 from hasscheck.models import Finding, RuleStatus
 
@@ -479,3 +479,8 @@ def test_run_check_user_rule_override_wins_over_profile_boost(tmp_path) -> None:
         findings_by_id["config_flow.reauth_step.exists"].status
         == RuleStatus.NOT_APPLICABLE
     )
+
+
+def test_category_labels_includes_compatibility() -> None:
+    """CATEGORY_LABELS must include 'compatibility' → 'Import Compatibility' (Group 6)."""
+    assert CATEGORY_LABELS["compatibility"] == "Import Compatibility"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1373,3 +1373,10 @@ def test_check_advisory_gate_with_baseline_always_exits_zero(tmp_path: Path) -> 
         app, ["check", "--path", str(tmp_path), "--baseline", str(baseline_path)]
     )
     assert result.exit_code == 0, result.output
+
+
+def test_smoke_sub_command_reachable_from_root_app() -> None:
+    """hasscheck smoke --help exits 0 from the root app (Group 8)."""
+    result = runner.invoke(app, ["smoke", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "run" in result.output.lower()


### PR DESCRIPTION
Closes #143

## PR Type
- [x] New feature

## Summary
- Adds `hasscheck smoke --path . --ha-version 2026.5.1` subcommand: isolated uv venv per HA version, installs HA + manifest requirements, attempts import of domain / config_flow / declared platforms
- Captures ImportError / ModuleNotFoundError / AttributeError as `Finding(category="compatibility")` objects; wraps in standard `HassCheckReport` with `check_mode="import-smoke"` (Approach C — no schema bump)
- Exit 0 = all pass, 1 = any FAIL finding, 2 = harness error (uv missing, install fail, timeout)
- Adds `CATEGORY_LABELS["compatibility"] = "Import Compatibility"` to checker.py

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/smoke/__init__.py` | New package; re-exports public API |
| `src/hasscheck/smoke/errors.py` | `SmokeError`, `SmokeRunnerMissingError`, `SmokeTimeoutError` |
| `src/hasscheck/smoke/runner.py` | `run_command()` — thin subprocess wrapper; `ensure_uv_available()` guard |
| `src/hasscheck/smoke/cache.py` | `get_venv_path()`, `is_venv_ready()` — stdlib XDG/LOCALAPPDATA cache |
| `src/hasscheck/smoke/models.py` | `SmokeResult`, `ProbeTarget`, `RunSmokeResult` |
| `src/hasscheck/smoke/core.py` | `run_smoke()`, `create_venv()`, `install_packages()`, `probe_imports()`, `build_probe_targets()` |
| `src/hasscheck/smoke/cli.py` | `smoke_app` Typer subapp with `run` command |
| `src/hasscheck/cli.py` | Wire `smoke_app` via `app.add_typer()` |
| `src/hasscheck/checker.py` | Add `"compatibility"` to `CATEGORY_LABELS` |
| `docs/decisions/0017-import-smoke-harness.md` | ADR 0017 |
| `tests/smoke/` | 60 new tests (unit + CLI integration) |

## Key decisions (ADR 0017)
- **Approach C**: smoke findings as standard `Finding` objects — reuses terminal renderer + JSON publish path; no schema bump for v1
- **venv over container**: uv venv is fast, no Docker dep; container isolation deferred to v2
- **runner.py boundary**: all subprocess calls centralized for monkeypatching
- **Stdlib cache**: XDG_CACHE_HOME / LOCALAPPDATA resolution; no platformdirs dep added
- **`--json` always array**: uniform envelope regardless of single vs matrix version

## Test Plan
- [x] 1161 tests passing (up from 1099, +62)
- [x] Strict TDD — RED → GREEN → REFACTOR per group (10 groups, 34 tasks)
- [x] All pre-commit hooks pass
- [x] SDD verify-report: PASS (W1 post-verify fix applied)