### PR TITLE
chore(release): bump version to 0.15.4 (#144)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasscheck"
-version = "0.15.3"
+version = "0.15.4"
 description = "Unofficial sourced checks for Home Assistant custom integration repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hasscheck/__init__.py
+++ b/src/hasscheck/__init__.py
@@ -1,3 +1,3 @@
 """HassCheck package."""
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "hasscheck"
-version = "0.15.3"
+version = "0.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bumps to 0.15.4

## Bundled
- #144 — advisory model + 10 HA deprecation rules (55 → 65 rules total)

| File | Change |
|------|--------|
| `pyproject.toml` | 0.15.3 → 0.15.4 |
| `src/hasscheck/__init__.py` | 0.15.3 → 0.15.4 |
| `uv.lock` | updated |