### PR TITLE
feat(action): diff-aware PR comments + regression detection (#150)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ inputs:
     description: 'Publish endpoint URL when emit-publish is true. Defaults to https://hasscheck.io.'
     required: false
     default: 'https://hasscheck.io'
+  token:
+    description: 'GitHub token for diff-mode PR comment posting. Alias for github-token; used by the diff-mode steps.'
+    required: false
+    default: ''
+  diff-mode:
+    description: 'Run diff-aware PR comment showing only new/fixed findings between base and HEAD (requires fetch-depth: 0 in parent workflow).'
+    required: false
+    default: 'false'
 
 outputs:
   exit-code:
@@ -83,6 +91,38 @@ runs:
           --edit-last 2>/dev/null || \
         gh pr comment "${{ github.event.pull_request.number }}" \
           --body-file hasscheck-report.md
+
+    - name: Checkout base branch for diff
+      if: inputs.diff-mode == 'true' && github.event_name == 'pull_request'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        fetch-depth: 0
+
+    - name: Run hasscheck on base branch
+      if: inputs.diff-mode == 'true' && github.event_name == 'pull_request'
+      shell: bash
+      run: hasscheck check --path "${{ inputs.path }}" --format json > /tmp/hasscheck-base.json || true
+
+    - name: Checkout PR HEAD for diff
+      if: inputs.diff-mode == 'true' && github.event_name == 'pull_request'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Post diff PR comment
+      if: inputs.diff-mode == 'true' && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        hasscheck check --path "${{ inputs.path }}" --format json > /tmp/hasscheck-head.json || true
+        hasscheck diff /tmp/hasscheck-base.json /tmp/hasscheck-head.json --format md > /tmp/hasscheck-delta.md || true
+        gh pr comment ${{ github.event.pull_request.number }} \
+          --edit-last --body-file /tmp/hasscheck-delta.md 2>/dev/null || \
+        gh pr comment ${{ github.event.pull_request.number }} \
+          --body-file /tmp/hasscheck-delta.md
 
     - name: Generate badges
       if: inputs.emit-badges == 'true'

--- a/docs/decisions/0019-diff-pr-comments.md
+++ b/docs/decisions/0019-diff-pr-comments.md
@@ -1,0 +1,158 @@
+# ADR 0019 — Diff-aware PR comments
+
+**Status**: Accepted
+**Issue**: #150
+**Date**: 2026-05-02
+
+## Context
+
+hasscheck currently posts a full-state PR comment via `comment-pr: 'true'`.
+As rulesets grow, that comment becomes noisy for reviewers who only care about
+regressions. A diff-aware mode should show only new / fixed findings between
+the base branch and the PR HEAD.
+
+---
+
+## Decisions
+
+### D1 — `ReportDelta` as a frozen dataclass with tuple fields
+
+**Decision**: `@dataclass(frozen=True)` in `diff.py`, fields are `tuple[Finding, ...]`.
+
+**Rationale**: It is a computation result, not a versioned schema. No
+serialization/validation needed at the type. Tuples make the dataclass hashable
+and immutable, matching baseline conventions (`BaselineEntry` is Pydantic because
+it persists; `FindingPartition` in `baseline/core.py` is a frozen dataclass
+because it doesn't).
+
+**Rejected alternatives**: Pydantic `BaseModel` — over-engineered for a transient
+struct; plain `NamedTuple` — less explicit, can't add validators later.
+
+**Reversal cost**: Low.
+
+---
+
+### D2 — Reuse `compute_finding_hash` from `hasscheck.baseline` (no extraction)
+
+**Decision**: `from hasscheck.baseline import compute_finding_hash`. No move to
+`hasscheck.hashing`.
+
+**Rationale**: ADR 0016 owns hash-policy semantics (`rule_id | path |
+normalized_message`). Forking or moving the function risks divergence.
+
+**Rejected alternatives**: Extract to `hasscheck.hashing` (medium-effort refactor
+for zero functional gain; breaks ADR 0016 ownership); duplicate the function
+(ADR 0016 violation, drift risk).
+
+**Reversal cost**: Low.
+
+---
+
+### D3 — Markdown comment carries sticky marker `<!-- hasscheck-pr-comment -->`
+
+**Decision**: Marker comment as the first line of `delta_to_md` output.
+
+**Rationale**: Current action uses `gh pr comment --edit-last`, which is positional.
+A marker gives forward-compat for explicit content-based detection without forcing
+a refactor today.
+
+**Rejected alternatives**: No marker (lock-in to `--edit-last`; no upgrade path);
+separate state file (more moving parts).
+
+**Reversal cost**: Low (cosmetic).
+
+---
+
+### D4 — `diff` is a root Typer command (not a sub-app)
+
+**Decision**: `@app.command("diff")` directly on `app` in `cli.py`.
+
+**Rationale**: `diff` has a single verb taking two file arguments — sub-app would
+add ceremony with no commands to host.
+
+**Rejected alternatives**: `hasscheck diff <subcmd>` sub-app (no second verb in
+scope); standalone script (loses Typer help, version flag, error handling).
+
+**Reversal cost**: Low.
+
+---
+
+### D5 — `diff-mode` is a new orthogonal action input (not a behavior change to `comment-pr`)
+
+**Decision**: New `diff-mode: 'false'` input. Existing `comment-pr` semantics
+unchanged.
+
+**Rationale**: Backward compatibility — existing users who set `comment-pr: 'true'`
+continue to see the full-state report. Opt-in keeps the dual-checkout cost opt-in.
+
+**Rejected alternatives**: Repurpose `comment-pr` to always diff (breaking change);
+make `diff-mode` imply `comment-pr` (couples two decisions).
+
+**Reversal cost**: Medium (would need a deprecation cycle if reversed).
+
+---
+
+### D6 — Module location: flat `src/hasscheck/diff.py`
+
+**Decision**: Single file `diff.py`, not a `diff/` package.
+
+**Rationale**: ~3 public symbols, ~120 LOC expected. Diff is small enough to stay
+flat; can be promoted later if needed.
+
+**Rejected alternatives**: `src/hasscheck/diff/{core.py,cli.py}` package
+(premature); add to `output.py` (semantic mismatch).
+
+**Reversal cost**: Low (pure refactor).
+
+---
+
+### D7 — Exit codes: `0`/`1`/`2` semantic split
+
+**Decision**: `0` = no new findings, `1` = new findings exist, `2` = I/O or parse
+error.
+
+**Rationale**: Mirrors POSIX convention where `1` is "found something" and `2` is
+"tool failure". Lets CI gate on "PR introduced new findings" without conflating with
+parse errors.
+
+**Rejected alternatives**: Always `0` (loses CI gate signal); `0` vs. `1` only
+(parse errors masquerade as findings); use `--strict` flag (extra surface).
+
+**Reversal cost**: Medium (callers may script on exit codes).
+
+---
+
+### D8 — `ReportDelta` is NOT re-exported from `hasscheck/__init__.py`
+
+**Decision**: No change to `hasscheck/__init__.py`. `diff` module accessed only via
+`from hasscheck.diff import ...`.
+
+**Rationale**: Internal computation surface, not a public Python API. Re-exporting
+commits to backward compat we don't owe yet.
+
+**Rejected alternatives**: Re-export at root (premature commitment); export under
+`hasscheck.api` (no such namespace exists yet).
+
+**Reversal cost**: Low (additive change later).
+
+---
+
+## v1 Limitations
+
+- Status changes (FAIL → WARN on same rule_id/path/message) are NOT regressions —
+  hash does not include status field (intentional per ADR 0016 policy).
+- No `allow_regression` gate config.
+- No per-line PR annotations.
+- No caching of base-branch JSON across runs.
+
+## Parent-workflow contract
+
+When `diff-mode: 'true'`, the parent workflow MUST configure:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```
+
+Without `fetch-depth: 0`, shallow clones will fail to find the base SHA.

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -20,6 +20,7 @@ from hasscheck.baseline import (
 from hasscheck.baseline.cli import baseline_app
 from hasscheck.checker import run_check
 from hasscheck.config import ConfigError, GateConfig, GateMode, discover_config
+from hasscheck.diff import _load_report, compute_delta, delta_to_md
 from hasscheck.docs_render import check_drift, render_all
 from hasscheck.init import init_project
 from hasscheck.models import Finding, HassCheckReport, RuleSeverity, RuleStatus
@@ -571,6 +572,67 @@ def init(
         return
     for artifact in artifacts:
         console.print(f"[green]Created:[/] {artifact.target}")
+
+
+@app.command("diff")
+def diff_cmd(
+    base_json: Path = typer.Argument(..., help="Base branch report JSON"),
+    head_json: Path = typer.Argument(..., help="PR HEAD report JSON"),
+    format: str = typer.Option(
+        "md", "--format", "-f", help="Output format: md or json"
+    ),
+    output: Path | None = typer.Option(
+        None, "--output", "-o", help="Write to file instead of stdout"
+    ),
+) -> None:
+    """Compare two HassCheck JSON reports and show new / fixed findings.
+
+    BASE_JSON is the report from the base branch; HEAD_JSON is the report from
+    the PR HEAD. Exits 0 when no new findings are introduced, 1 when new
+    findings exist, and 2 on read/parse error.
+
+    Examples:
+      hasscheck diff base.json head.json
+      hasscheck diff base.json head.json --format json
+      hasscheck diff base.json head.json --output delta.md
+    """
+    try:
+        base_report = _load_report(base_json)
+    except FileNotFoundError as exc:
+        typer.echo(f"hasscheck diff: file not found: {base_json}", err=True)
+        raise typer.Exit(code=2) from exc
+    except ValueError as exc:
+        typer.echo(f"hasscheck diff: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    try:
+        head_report = _load_report(head_json)
+    except FileNotFoundError as exc:
+        typer.echo(f"hasscheck diff: file not found: {head_json}", err=True)
+        raise typer.Exit(code=2) from exc
+    except ValueError as exc:
+        typer.echo(f"hasscheck diff: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    delta = compute_delta(base_report, head_report)
+
+    if format == "json":
+        payload = {
+            "new": [f.model_dump(mode="json") for f in delta.new],
+            "fixed": [f.model_dump(mode="json") for f in delta.fixed],
+            "unchanged": [f.model_dump(mode="json") for f in delta.unchanged],
+        }
+        rendered = json.dumps(payload, indent=2)
+    else:
+        rendered = delta_to_md(delta)
+
+    if output is not None:
+        output.write_text(rendered, encoding="utf-8")
+    else:
+        typer.echo(rendered, nl=False)
+
+    if delta.new:
+        raise typer.Exit(code=1)
 
 
 @app.command("docs-render")

--- a/src/hasscheck/diff.py
+++ b/src/hasscheck/diff.py
@@ -1,0 +1,174 @@
+"""Diff layer for hasscheck reports.
+
+Pure module — no Typer, no Rich, no I/O.
+Provides: ReportDelta (ADR-D1), compute_delta (ADR-D2), delta_to_md (ADR-D3),
+and the private _load_report helper (used by cli.py for the `diff` command).
+
+Design decisions documented in docs/decisions/0019-diff-pr-comments.md.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from hasscheck.baseline import compute_finding_hash  # ADR-D2: no extraction
+from hasscheck.models import Finding, HassCheckReport
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReportDelta:
+    """Immutable result of diffing two HassCheckReports.
+
+    Identity is computed via ``compute_finding_hash`` (ADR 0016 / ADR-D2).
+    Status-only changes (FAIL → WARN, same rule_id/path/message) appear in
+    ``unchanged`` because the hash policy intentionally excludes the status
+    field — see spec v1 limitation note.
+    """
+
+    new: tuple[Finding, ...]
+    fixed: tuple[Finding, ...]
+    unchanged: tuple[Finding, ...]
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def _findings_by_hash(report: HassCheckReport) -> dict[str, Finding]:
+    """Build a hash → Finding mapping for all findings in *report*.
+
+    When two findings share the same hash (duplicate entries in a report),
+    the last one wins — acceptable for v1 where duplicates are unexpected.
+    """
+    return {compute_finding_hash(f): f for f in report.findings}
+
+
+def compute_delta(base: HassCheckReport, head: HassCheckReport) -> ReportDelta:
+    """Compute the diff between *base* and *head* reports.
+
+    - ``new``:       findings whose hash is in head but NOT in base (regressions)
+    - ``fixed``:     findings whose hash is in base but NOT in head (resolved)
+    - ``unchanged``: findings whose hash appears in BOTH (same identity)
+
+    The result contains ``Finding`` objects, not raw hashes.
+    """
+    base_hashes = _findings_by_hash(base)
+    head_hashes = _findings_by_hash(head)
+
+    new = tuple(f for h, f in head_hashes.items() if h not in base_hashes)
+    fixed = tuple(f for h, f in base_hashes.items() if h not in head_hashes)
+    unchanged = tuple(f for h, f in head_hashes.items() if h in base_hashes)
+
+    return ReportDelta(new=new, fixed=fixed, unchanged=unchanged)
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+_EMOJI = {
+    "fail": "❌",
+    "warn": "⚠️",
+    "pass": "✅",
+}
+_MARKER = "<!-- hasscheck-pr-comment -->"
+
+
+def _finding_line(f: Finding) -> str:
+    """Render a single Finding as a Markdown list item.
+
+    Format: ``- {emoji} `{rule_id}` — `{path or "(repo)"}` ``
+    """
+    emoji = _EMOJI.get(str(f.status).lower(), "🔍")
+    location = f"`{f.path}`" if f.path else "`(repo)`"
+    return f"- {emoji} `{f.rule_id}` — {location}"
+
+
+def delta_to_md(delta: ReportDelta) -> str:
+    """Render *delta* as a Markdown PR comment body.
+
+    Always starts with the sticky marker ``<!-- hasscheck-pr-comment -->``
+    so that the action can detect and update it in future iterations (ADR-D3).
+
+    When all three tuples are empty, outputs a brief "No changes detected"
+    message instead of empty section headers.
+    """
+    lines: list[str] = [_MARKER, "", "## HassCheck — PR delta", ""]
+
+    if not delta.new and not delta.fixed and not delta.unchanged:
+        lines.append("No changes detected.")
+        lines.append("")
+        lines.append("---")
+        lines.append("_Run `hasscheck check` locally for the full report._")
+        return "\n".join(lines)
+
+    n_new = len(delta.new)
+    n_fixed = len(delta.fixed)
+    n_unchanged = len(delta.unchanged)
+
+    lines.append(
+        f"**Summary**: {n_new} new · {n_fixed} fixed · {n_unchanged} unchanged"
+    )
+    lines.append("")
+
+    if delta.new:
+        lines.append(f"### New findings ({n_new})")
+        lines.append("")
+        for f in delta.new:
+            lines.append(_finding_line(f))
+        lines.append("")
+
+    if delta.fixed:
+        lines.append(f"### Fixed findings ({n_fixed})")
+        lines.append("")
+        for f in delta.fixed:
+            lines.append(_finding_line(f))
+        lines.append("")
+
+    if delta.unchanged:
+        lines.append("<details>")
+        lines.append(f"<summary>Unchanged: {n_unchanged} findings</summary>")
+        lines.append("")
+        for f in delta.unchanged:
+            lines.append(_finding_line(f))
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("_Run `hasscheck check` locally for the full report._")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O helper (used only by cli.py — not exported from hasscheck/__init__.py)
+# ---------------------------------------------------------------------------
+
+
+def _load_report(path: Path) -> HassCheckReport:
+    """Load and validate a HassCheckReport from *path*.
+
+    Raises ``FileNotFoundError`` when the file does not exist.
+    Raises ``ValueError`` (wrapping ``json.JSONDecodeError`` or
+    ``pydantic.ValidationError``) on parse or schema errors.
+    Callers in cli.py catch these and map them to exit code 2.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON parse error in {path.name}: {exc}") from exc
+
+    try:
+        return HassCheckReport.model_validate(raw)
+    except Exception as exc:  # pydantic.ValidationError
+        raise ValueError(f"invalid report in {path.name}: {exc}") from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1380,3 +1380,137 @@ def test_smoke_sub_command_reachable_from_root_app() -> None:
     result = runner.invoke(app, ["smoke", "--help"])
     assert result.exit_code == 0, result.output
     assert "run" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Group 4 — hasscheck diff command
+# ---------------------------------------------------------------------------
+
+
+def _minimal_report_json(findings: list[dict] | None = None) -> str:
+    """Return a minimal valid HassCheckReport JSON string."""
+    return json.dumps(
+        {
+            "schema_version": "0.5.0",
+            "project": {"path": "/repo"},
+            "summary": {
+                "overall": "informational_only",
+                "security_review": "not_performed",
+                "official_ha_tier": "not_assigned",
+                "hacs_acceptance": "not_guaranteed",
+            },
+            "findings": findings or [],
+        }
+    )
+
+
+def _finding_dict(
+    rule_id: str = "x.y",
+    message: str = "msg",
+    path: str | None = None,
+    status: str = "fail",
+) -> dict:
+    return {
+        "rule_id": rule_id,
+        "rule_version": "1.0",
+        "category": "test",
+        "status": status,
+        "severity": "required",
+        "title": "Test",
+        "message": message,
+        "applicability": {"status": "applicable", "reason": "ok", "source": "default"},
+        "source": {"url": "https://example.com"},
+        "path": path,
+    }
+
+
+def test_s5_identical_files_exit_0(tmp_path: Path) -> None:
+    """S5 — identical base and head → exit 0 (no new findings)."""
+    report = _minimal_report_json([_finding_dict("a.b")])
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text(report, encoding="utf-8")
+    head.write_text(report, encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head)])
+    assert result.exit_code == 0, result.output
+
+
+def test_s6_new_findings_exit_1(tmp_path: Path) -> None:
+    """S6 — head introduces a new finding → exit 1."""
+    base_report = _minimal_report_json([_finding_dict("a.b")])
+    head_report = _minimal_report_json([_finding_dict("a.b"), _finding_dict("c.d")])
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text(base_report, encoding="utf-8")
+    head.write_text(head_report, encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head)])
+    assert result.exit_code == 1, result.output
+
+
+def test_s7_missing_file_exit_2(tmp_path: Path) -> None:
+    """S7 — nonexistent base file → exit 2 with stderr message."""
+    nonexistent = tmp_path / "nonexistent.json"
+    head = tmp_path / "head.json"
+    head.write_text(_minimal_report_json(), encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(nonexistent), str(head)])
+    assert result.exit_code == 2, result.output
+
+
+def test_s8_format_json_output(tmp_path: Path) -> None:
+    """S8 — --format json emits valid JSON with new/fixed/unchanged keys."""
+    base_report = _minimal_report_json([_finding_dict("a.b")])
+    head_report = _minimal_report_json([_finding_dict("a.b"), _finding_dict("c.d")])
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text(base_report, encoding="utf-8")
+    head.write_text(head_report, encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head), "--format", "json"])
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert set(payload.keys()) == {"new", "fixed", "unchanged"}
+    assert len(payload["new"]) == 1
+    assert payload["new"][0]["rule_id"] == "c.d"
+
+
+def test_diff_md_output_contains_marker(tmp_path: Path) -> None:
+    """Default --format md output contains the sticky PR comment marker."""
+    base_report = _minimal_report_json([_finding_dict("a.b")])
+    head_report = _minimal_report_json([_finding_dict("a.b"), _finding_dict("c.d")])
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text(base_report, encoding="utf-8")
+    head.write_text(head_report, encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head)])
+    assert "<!-- hasscheck-pr-comment -->" in result.stdout
+
+
+def test_diff_output_file_written(tmp_path: Path) -> None:
+    """--output PATH writes the result to a file instead of stdout."""
+    base_report = _minimal_report_json()
+    head_report = _minimal_report_json()
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    out = tmp_path / "delta.md"
+    base.write_text(base_report, encoding="utf-8")
+    head.write_text(head_report, encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head), "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert "hasscheck" in out.read_text(encoding="utf-8").lower()
+
+
+def test_diff_malformed_json_exit_2(tmp_path: Path) -> None:
+    """Malformed JSON in base file → exit 2."""
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text("not valid json {{{", encoding="utf-8")
+    head.write_text(_minimal_report_json(), encoding="utf-8")
+
+    result = runner.invoke(app, ["diff", str(base), str(head)])
+    assert result.exit_code == 2, result.output

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,329 @@
+"""Tests for hasscheck.diff — strict TDD, Groups 1–3."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from hasscheck.models import (
+    Applicability,
+    ApplicabilityStatus,
+    Finding,
+    HassCheckReport,
+    RuleSeverity,
+    RuleSource,
+    RuleStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_finding(
+    rule_id: str = "x.y",
+    message: str = "msg",
+    path: str | None = None,
+    status: RuleStatus = RuleStatus.FAIL,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        rule_version="1.0",
+        category="test",
+        status=status,
+        severity=RuleSeverity.REQUIRED,
+        title="Test Finding",
+        message=message,
+        applicability=Applicability(
+            status=ApplicabilityStatus.APPLICABLE,
+            reason="applicable",
+            source="default",
+        ),
+        source=RuleSource(url="https://example.com"),
+        path=path,
+    )
+
+
+def _make_report(findings: list[Finding]) -> HassCheckReport:
+    return HassCheckReport.model_validate(
+        {
+            "schema_version": "0.5.0",
+            "project": {"path": "/repo"},
+            "summary": {
+                "overall": "informational_only",
+                "security_review": "not_performed",
+                "official_ha_tier": "not_assigned",
+                "hacs_acceptance": "not_guaranteed",
+            },
+            "findings": [f.model_dump(mode="json") for f in findings],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group 1 — ReportDelta dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_report_delta_is_importable() -> None:
+    from hasscheck.diff import ReportDelta  # noqa: F401 (import check)
+
+
+def test_report_delta_is_frozen_dataclass() -> None:
+    from hasscheck.diff import ReportDelta
+
+    assert dataclasses.is_dataclass(ReportDelta)
+    assert ReportDelta.__dataclass_params__.frozen  # type: ignore[attr-defined]
+
+
+def test_report_delta_has_correct_fields() -> None:
+    from hasscheck.diff import ReportDelta
+
+    fields = {f.name: f for f in dataclasses.fields(ReportDelta)}
+    assert set(fields) == {"new", "fixed", "unchanged"}
+    for field_name in ("new", "fixed", "unchanged"):
+        assert fields[field_name].type == "tuple[Finding, ...]"
+
+
+def test_report_delta_instantiates() -> None:
+    from hasscheck.diff import ReportDelta
+
+    f = _make_finding()
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    assert delta.new == (f,)
+    assert delta.fixed == ()
+    assert delta.unchanged == ()
+
+
+def test_report_delta_is_immutable() -> None:
+    from hasscheck.diff import ReportDelta
+
+    delta = ReportDelta(new=(), fixed=(), unchanged=())
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        delta.new = ()  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Group 2 — compute_delta
+# ---------------------------------------------------------------------------
+
+
+def test_compute_delta_importable() -> None:
+    from hasscheck.diff import compute_delta  # noqa: F401
+
+
+def test_s1_identical_reports_all_unchanged() -> None:
+    """S1 — identical reports produce empty new/fixed, all in unchanged."""
+    from hasscheck.diff import compute_delta
+
+    f1 = _make_finding(rule_id="a.b", message="msg1", path="p.py")
+    f2 = _make_finding(rule_id="c.d", message="msg2", path=None)
+    report = _make_report([f1, f2])
+    delta = compute_delta(report, report)
+
+    assert delta.new == ()
+    assert delta.fixed == ()
+    assert len(delta.unchanged) == 2
+
+
+def test_s2_new_finding_in_head() -> None:
+    """S2 — head has one additional finding; it appears in new."""
+    from hasscheck.diff import compute_delta
+
+    existing = _make_finding(rule_id="a.b", message="msg")
+    added = _make_finding(rule_id="c.d", message="added")
+    base = _make_report([existing])
+    head = _make_report([existing, added])
+    delta = compute_delta(base, head)
+
+    assert len(delta.new) == 1
+    assert delta.new[0].rule_id == "c.d"
+    assert delta.fixed == ()
+    assert len(delta.unchanged) == 1
+
+
+def test_s3_finding_removed_in_head() -> None:
+    """S3 — base has a finding not present in head; it appears in fixed."""
+    from hasscheck.diff import compute_delta
+
+    existing = _make_finding(rule_id="a.b", message="msg")
+    removed = _make_finding(rule_id="c.d", message="removed")
+    base = _make_report([existing, removed])
+    head = _make_report([existing])
+    delta = compute_delta(base, head)
+
+    assert delta.new == ()
+    assert len(delta.fixed) == 1
+    assert delta.fixed[0].rule_id == "c.d"
+    assert len(delta.unchanged) == 1
+
+
+def test_s4_status_only_change_is_unchanged() -> None:
+    """S4 — same rule_id/path/message but status FAIL→WARN counts as unchanged."""
+    from hasscheck.diff import compute_delta
+
+    base_f = _make_finding(
+        rule_id="a.b", message="msg", path="p.py", status=RuleStatus.FAIL
+    )
+    head_f = _make_finding(
+        rule_id="a.b", message="msg", path="p.py", status=RuleStatus.WARN
+    )
+    base = _make_report([base_f])
+    head = _make_report([head_f])
+    delta = compute_delta(base, head)
+
+    assert delta.new == ()
+    assert delta.fixed == ()
+    assert len(delta.unchanged) == 1
+
+
+def test_compute_delta_mixed_scenario() -> None:
+    """Mixed: one new, one fixed, one unchanged."""
+    from hasscheck.diff import compute_delta
+
+    common = _make_finding(rule_id="common", message="shared")
+    old_only = _make_finding(rule_id="old", message="was there")
+    new_only = _make_finding(rule_id="new", message="appeared")
+    base = _make_report([common, old_only])
+    head = _make_report([common, new_only])
+    delta = compute_delta(base, head)
+
+    assert len(delta.new) == 1
+    assert delta.new[0].rule_id == "new"
+    assert len(delta.fixed) == 1
+    assert delta.fixed[0].rule_id == "old"
+    assert len(delta.unchanged) == 1
+    assert delta.unchanged[0].rule_id == "common"
+
+
+def test_compute_delta_empty_reports() -> None:
+    """Both reports empty → all tuples empty."""
+    from hasscheck.diff import compute_delta
+
+    base = _make_report([])
+    head = _make_report([])
+    delta = compute_delta(base, head)
+
+    assert delta.new == ()
+    assert delta.fixed == ()
+    assert delta.unchanged == ()
+
+
+# ---------------------------------------------------------------------------
+# Group 3 — delta_to_md
+# ---------------------------------------------------------------------------
+
+
+def test_delta_to_md_importable() -> None:
+    from hasscheck.diff import delta_to_md  # noqa: F401
+
+
+def test_s9_empty_delta_contains_no_changes() -> None:
+    """S9 — all-empty delta → contains 'No changes detected'."""
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    delta = ReportDelta(new=(), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "No changes detected" in md
+
+
+def test_s10_nonempty_delta_starts_with_marker() -> None:
+    """S10 — non-empty delta starts with the sticky marker."""
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert md.startswith("<!-- hasscheck-pr-comment -->")
+
+
+def test_delta_to_md_new_section_present_when_nonempty() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "### New findings (1)" in md
+
+
+def test_delta_to_md_new_section_absent_when_empty() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    delta = ReportDelta(new=(), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "### New findings" not in md
+
+
+def test_delta_to_md_fixed_section_present_when_nonempty() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(), fixed=(f,), unchanged=())
+    md = delta_to_md(delta)
+    assert "### Fixed findings (1)" in md
+
+
+def test_delta_to_md_fixed_section_absent_when_empty() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "### Fixed findings" not in md
+
+
+def test_delta_to_md_unchanged_details_block_present() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(), fixed=(), unchanged=(f,))
+    md = delta_to_md(delta)
+    assert "<details>" in md
+    assert "Unchanged" in md
+    assert "1" in md
+
+
+def test_delta_to_md_unchanged_absent_when_empty() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "<details>" not in md
+
+
+def test_delta_to_md_heading_present() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "## HassCheck" in md
+
+
+def test_delta_to_md_finding_line_contains_rule_id() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="manifest.exists", path="custom_components/demo")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "manifest.exists" in md
+
+
+def test_delta_to_md_finding_line_contains_path() -> None:
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    f = _make_finding(rule_id="a.b", path="some/path.py")
+    delta = ReportDelta(new=(f,), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert "some/path.py" in md
+
+
+def test_delta_to_md_empty_delta_starts_with_marker() -> None:
+    """Even the empty-delta case should carry the marker for sticky detection."""
+    from hasscheck.diff import ReportDelta, delta_to_md
+
+    delta = ReportDelta(new=(), fixed=(), unchanged=())
+    md = delta_to_md(delta)
+    assert md.startswith("<!-- hasscheck-pr-comment -->")


### PR DESCRIPTION
Closes #150

## PR Type
- [x] New feature

## Summary
- New `src/hasscheck/diff.py`: `ReportDelta` frozen dataclass, `compute_delta()` (reuses `compute_finding_hash` from baseline), `delta_to_md()` with sticky `<!-- hasscheck-pr-comment -->` marker
- New `hasscheck diff <base.json> <head.json>` CLI command: exit 0=no new findings, 1=new findings, 2=error
- `action.yml` new `diff-mode` input (default `'false'`) — backward compatible; when `'true'` runs dual checkout + check + posts delta comment

## Changes

| File | Change |
|------|--------|
| `src/hasscheck/diff.py` | New: `ReportDelta`, `compute_delta`, `delta_to_md`, `_load_report` |
| `src/hasscheck/cli.py` | Add `@app.command("diff")` |
| `action.yml` | `diff-mode` input + 4 conditional steps |
| `docs/decisions/0019-diff-pr-comments.md` | ADR 0019 |
| `tests/test_diff.py` | 25 unit tests |
| `tests/test_cli.py` | 7 integration tests |

## Key decisions (ADR 0019)
- Reuse `compute_finding_hash` from `hasscheck.baseline` — shared identity contract, no duplication
- Status-only changes are NOT new findings in v1 (hash excludes status) — explicit v1 limitation
- `diff-mode` opt-in input preserves all existing action behavior unchanged
- `<details>` collapsed block for unchanged findings — keeps comment readable

## Test Plan
- [x] 1277 tests passing (up from 1245, +32)
- [x] Strict TDD — RED → GREEN → REFACTOR per group
- [x] All pre-commit hooks pass
- [x] `docs-render` clean (0 changed pages)
- [x] SDD verify-report: PASS (0 CRITICALs)