### PR TITLE
feat(action,cli): add optional ha-version input (closes #181)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Publish endpoint URL when emit-publish is true. Defaults to https://hasscheck.io.'
     required: false
     default: 'https://hasscheck.io'
+  ha-version:
+    description: 'Home Assistant core version this report was tested against (e.g. 2026.5.0). When set, propagated to the published report; omit to leave unset.'
+    required: false
+    default: ''
   token:
     description: 'GitHub token for diff-mode PR comment posting. Alias for github-token; used by the diff-mode steps.'
     required: false
@@ -170,6 +174,9 @@ runs:
         ARGS=""
         if [ "${{ inputs.no-config }}" = "true" ]; then
           ARGS="--no-config"
+        fi
+        if [ -n "${{ inputs.ha-version }}" ]; then
+          ARGS="$ARGS --ha-version ${{ inputs.ha-version }}"
         fi
         hasscheck publish \
           --path "${{ inputs.path }}" \

--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -125,6 +125,7 @@ def run_check(
     config: HassCheckConfig | None = None,
     no_config: bool = False,
     profile_name: str | None = None,
+    ha_version: str | None = None,
 ) -> HassCheckReport:
     """Run a full HassCheck report for the given repository path.
 
@@ -158,7 +159,9 @@ def run_check(
     )
 
     now = datetime.now(UTC)
-    target = detect_target(root, context.integration_path, context.domain)
+    target = detect_target(
+        root, context.integration_path, context.domain, ha_version=ha_version
+    )
     validity = build_validity(checked_at=now)
 
     # Pipe version identity from detect_target into the rule context (ADR-0002)

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -369,6 +369,14 @@ def publish(
         "--dry-run",
         help="Validate and preview without making any network request.",
     ),
+    ha_version: str | None = typer.Option(
+        None,
+        "--ha-version",
+        help=(
+            "Home Assistant core version this report was tested against "
+            "(e.g. 2026.5.0). No format validation. Propagated to the published report."
+        ),
+    ),
 ) -> None:
     """Opt-in upload of a HassCheck report to a hosted service.
 
@@ -504,6 +512,7 @@ def publish(
             endpoint=endpoint,
             oidc_token=token,
             no_config=no_config,
+            ha_version=ha_version,
         )
     except ConfigError as exc:
         typer.echo(f"hasscheck: error: {exc}", err=True)

--- a/src/hasscheck/publish.py
+++ b/src/hasscheck/publish.py
@@ -148,9 +148,10 @@ def publish_report(
     config: HassCheckConfig | None = None,
     no_config: bool = False,
     client: httpx.Client | None = None,
+    ha_version: str | None = None,
 ) -> PublishResult:
     """Run a check and POST the resulting JSON report to the hosted service."""
-    report = run_check(path, config=config, no_config=no_config)
+    report = run_check(path, config=config, no_config=no_config, ha_version=ha_version)
     body = report.to_json_dict()
 
     owns_client = client is None

--- a/src/hasscheck/target.py
+++ b/src/hasscheck/target.py
@@ -24,6 +24,7 @@ def detect_target(
     root: Path,
     integration_path: Path | None,
     domain: str | None,
+    ha_version: str | None = None,
 ) -> ReportTarget | None:
     """Detect exact-build identity for the integration under check.
 
@@ -41,7 +42,7 @@ def detect_target(
     Other fields populate independently:
         - commit_sha     ← os.environ["GITHUB_SHA"] (None outside CI)
         - python_version ← sys.version_info major.minor.patch (D11)
-        - ha_version     ← None this PR (D12)
+        - ha_version     ← ha_version parameter (caller-supplied; default None)
         - check_mode     ← "static"
         - integration_domain ← domain parameter
     """
@@ -90,7 +91,7 @@ def detect_target(
             integration_version_source=integration_version_source,  # type: ignore[arg-type]
             integration_release_tag=integration_release_tag,
             commit_sha=commit_sha,
-            ha_version=None,  # D12: always None in this PR
+            ha_version=ha_version,
             python_version=python_version,
             check_mode="static",
             manifest_hash=manifest_hash,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1514,3 +1514,88 @@ def test_diff_malformed_json_exit_2(tmp_path: Path) -> None:
 
     result = runner.invoke(app, ["diff", str(base), str(head)])
     assert result.exit_code == 2, result.output
+
+
+# ---------------------------------------------------------------------------
+# Issue #181 — --ha-version CLI option on publish command (S2)
+
+
+def _make_fake_publish_result():
+    from hasscheck.publish import PublishResult
+
+    return PublishResult(
+        report_id="rep_test",
+        report_url="https://hasscheck.io/owner/repo/reports/rep_test",
+        badge_url_template="https://hasscheck.io/api/badge/{category}.json",
+        schema_version="0.5.0",
+    )
+
+
+def test_publish_cli_forwards_ha_version(tmp_path, monkeypatch) -> None:
+    """publish --ha-version 2026.5.0 must forward ha_version='2026.5.0' to publish_report."""
+    monkeypatch.setenv("HASSCHECK_OIDC_TOKEN", "tok-test")
+    write_minimal_integration(tmp_path)
+
+    spy_kwargs = {}
+
+    def fake_publish_report(
+        path,
+        *,
+        endpoint,
+        oidc_token,
+        no_config=False,
+        config=None,
+        ha_version=None,
+        **kw,
+    ):
+        spy_kwargs["ha_version"] = ha_version
+        return _make_fake_publish_result()
+
+    monkeypatch.setattr("hasscheck.cli.publish_report", fake_publish_report)
+
+    result = runner.invoke(
+        app,
+        [
+            "publish",
+            "--path",
+            str(tmp_path),
+            "--ha-version",
+            "2026.5.0",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert spy_kwargs.get("ha_version") == "2026.5.0"
+
+
+def test_publish_cli_omits_ha_version_defaults_none(tmp_path, monkeypatch) -> None:
+    """publish without --ha-version must call publish_report with ha_version=None."""
+    monkeypatch.setenv("HASSCHECK_OIDC_TOKEN", "tok-test")
+    write_minimal_integration(tmp_path)
+
+    spy_kwargs = {}
+
+    def fake_publish_report(
+        path,
+        *,
+        endpoint,
+        oidc_token,
+        no_config=False,
+        config=None,
+        ha_version=None,
+        **kw,
+    ):
+        spy_kwargs["ha_version"] = ha_version
+        return _make_fake_publish_result()
+
+    monkeypatch.setattr("hasscheck.cli.publish_report", fake_publish_report)
+
+    result = runner.invoke(
+        app,
+        [
+            "publish",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert spy_kwargs.get("ha_version") is None

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -396,3 +396,70 @@ def test_detect_oidc_token_does_not_raise_when_missing(monkeypatch):
     monkeypatch.delenv(OIDC_TOKEN_ENV_VAR, raising=False)
     # Must not raise MissingTokenError
     detect_oidc_token(None)
+
+
+# ---------------------------------------------------------------------------
+# Issue #181 — ha_version threading through publish_report (S3, S5)
+
+
+def test_publish_report_threads_ha_version():
+    """publish_report(ha_version=...) must put that value in the POST body target."""
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "report_id": "rep_abc",
+                "report_url": "https://hasscheck.io/owner/repo/reports/rep_abc",
+                "badge_url_template": "https://hasscheck.io/api/badge/{category}.json",
+                "schema_version": "0.5.0",
+            },
+        )
+
+    with _make_client(handler) as client:
+        publish_report(
+            fixture,
+            endpoint="https://hasscheck.io",
+            oidc_token="tok-abc",
+            no_config=True,
+            client=client,
+            ha_version="2026.5.0",
+        )
+
+    assert captured["body"]["target"]["ha_version"] == "2026.5.0"
+
+
+def test_publish_report_omits_ha_version_null():
+    """publish_report() without ha_version must leave target.ha_version as None."""
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    fixture = os.path.join(repo_root, "examples", "good_integration")
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "report_id": "rep_xyz",
+                "report_url": "https://hasscheck.io/owner/repo/reports/rep_xyz",
+                "badge_url_template": "https://hasscheck.io/api/badge/{category}.json",
+                "schema_version": "0.5.0",
+            },
+        )
+
+    with _make_client(handler) as client:
+        publish_report(
+            fixture,
+            endpoint="https://hasscheck.io",
+            oidc_token="tok-abc",
+            no_config=True,
+            client=client,
+        )
+
+    assert captured["body"]["target"]["ha_version"] is None

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -456,3 +456,36 @@ def test_requirements_hash_handles_mixed_valid_and_invalid() -> None:
     assert result is not None
     assert isinstance(result, str)
     assert len(result) == 64
+
+
+# ---------------------------------------------------------------------------
+# Issue #181 — ha_version threading through detect_target
+# ---------------------------------------------------------------------------
+
+
+def test_detect_target_passes_ha_version(tmp_path: Path) -> None:
+    """detect_target passes ha_version=... to ReportTarget.ha_version (S4)."""
+    import json as json_mod
+
+    from hasscheck.target import detect_target
+
+    (tmp_path / "manifest.json").write_text(
+        json_mod.dumps({"domain": "test", "version": "1.0.0", "name": "Test"})
+    )
+    result = detect_target(tmp_path, tmp_path, "test", ha_version="2026.5.0")
+    assert result is not None
+    assert result.ha_version == "2026.5.0"
+
+
+def test_detect_target_omitted_ha_version_is_none(tmp_path: Path) -> None:
+    """Omitting ha_version leaves ReportTarget.ha_version as None (backward compat)."""
+    import json as json_mod
+
+    from hasscheck.target import detect_target
+
+    (tmp_path / "manifest.json").write_text(
+        json_mod.dumps({"domain": "test", "version": "1.0.0", "name": "Test"})
+    )
+    result = detect_target(tmp_path, tmp_path, "test")
+    assert result is not None
+    assert result.ha_version is None


### PR DESCRIPTION
Closes #181

## Summary
- Adds `ha-version` optional input to `action.yml` — propagated to `hasscheck publish` via bash guard (`[ -n ... ]`) preventing empty-string injection into Typer
- Threads `ha_version: str | None = None` through `detect_target()` → `run_check()` → `publish_report()` → CLI `publish --ha-version`
- Replaces the D12 `ha_version=None` placeholder in `target.py:93`
- No schema bump needed — `ha_version` already nullable in `ReportTarget` (schema 0.5.0)

## Test plan
- [x] 6 new tests: `test_target.py` (2), `test_publish.py` (2), `test_cli.py` (2)
- [x] 1334 tests pass — 0 regressions
- [x] `sdd-verify` PASS — 0 CRITICAL, 0 WARNING