### PR TITLE
feat(cli): hasscheck inventory --ha-config bulk scan command (closes #152)

### DIFF
--- a/src/hasscheck/checker.py
+++ b/src/hasscheck/checker.py
@@ -5,7 +5,12 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 
-from hasscheck.config import HassCheckConfig, apply_overrides, discover_config
+from hasscheck.config import (
+    HassCheckConfig,
+    ProjectApplicability,
+    apply_overrides,
+    discover_config,
+)
 from hasscheck.detect import detect_project
 from hasscheck.models import (
     Applicability,
@@ -19,7 +24,7 @@ from hasscheck.models import (
 )
 from hasscheck.profiles import PROFILES, ProfileDefinition
 from hasscheck.provenance import detect_provenance
-from hasscheck.rules.base import RuleDefinition
+from hasscheck.rules.base import ProjectContext, RuleDefinition
 from hasscheck.rules.registry import RULES
 from hasscheck.slug import detect_repo_slug
 from hasscheck.target import build_validity, detect_target
@@ -119,43 +124,47 @@ def apply_profile_overrides(
     return result
 
 
-def run_check(
-    path: Path | str,
+def run_check_at(
+    root: Path,
+    integration_path: Path | None,
+    domain: str | None,
     *,
     config: HassCheckConfig | None = None,
     no_config: bool = False,
     profile_name: str | None = None,
     ha_version: str | None = None,
+    applicability: ProjectApplicability | None = None,
+    rule_settings: dict[str, dict] | None = None,
 ) -> HassCheckReport:
-    """Run a full HassCheck report for the given repository path.
+    """Run the full ruleset at a pre-resolved (root, integration_path, domain).
 
-    Override order:
-      1. Rules fire and produce raw findings.
-      2. Profile severity_overrides and disabled_rules are applied
-         (apply_profile_overrides). Only overridable rules are affected.
-      3. Per-rule RuleOverride entries from hasscheck.yaml are applied last
-         (apply_overrides). User intent always wins over profile.
+    Discovery has already happened — caller owns it. This function only
+    executes rules. Used by `run_check()` (single-integration discovery
+    wrapper) and `run_inventory()` (fan-out over many pre-discovered paths).
     """
     if config is not None and no_config:
         raise ValueError("Cannot pass both config= and no_config=True; pick one.")
 
-    root = Path(path).resolve()
-
     if config is None and not no_config:
         config = discover_config(root)
 
-    rule_settings: dict[str, dict] = {}
-    if config is not None:
-        rule_settings = {
-            rule_id: override.settings
-            for rule_id, override in (config.rules or {}).items()
-            if override.settings
-        }
+    if rule_settings is None:
+        rule_settings = {}
+        if config is not None:
+            rule_settings = {
+                rule_id: override.settings
+                for rule_id, override in (config.rules or {}).items()
+                if override.settings
+            }
 
-    context = detect_project(
-        root,
-        applicability=config.applicability if config else None,
-        rule_settings=rule_settings,
+    context = ProjectContext(
+        root=root,
+        integration_path=integration_path,
+        domain=domain,
+        applicability=applicability
+        if applicability is not None
+        else (config.applicability if config else None),
+        rule_settings=rule_settings or {},
     )
 
     now = datetime.now(UTC)
@@ -255,4 +264,59 @@ def run_check(
         provenance=detect_provenance(now=now),
         target=target,
         validity=validity,
+    )
+
+
+def run_check(
+    path: Path | str,
+    *,
+    config: HassCheckConfig | None = None,
+    no_config: bool = False,
+    profile_name: str | None = None,
+    ha_version: str | None = None,
+) -> HassCheckReport:
+    """Discover the integration in `path` and run the full ruleset.
+
+    Thin wrapper over `run_check_at()`. Kept for backwards compatibility
+    with all single-integration callers (cli.py, action runner, etc.).
+
+    Override order:
+      1. Rules fire and produce raw findings.
+      2. Profile severity_overrides and disabled_rules are applied
+         (apply_profile_overrides). Only overridable rules are affected.
+      3. Per-rule RuleOverride entries from hasscheck.yaml are applied last
+         (apply_overrides). User intent always wins over profile.
+    """
+    if config is not None and no_config:
+        raise ValueError("Cannot pass both config= and no_config=True; pick one.")
+
+    root = Path(path).resolve()
+
+    if config is None and not no_config:
+        config = discover_config(root)
+
+    rule_settings: dict[str, dict] = {}
+    if config is not None:
+        rule_settings = {
+            rule_id: override.settings
+            for rule_id, override in (config.rules or {}).items()
+            if override.settings
+        }
+
+    context = detect_project(
+        root,
+        applicability=config.applicability if config else None,
+        rule_settings=rule_settings,
+    )
+
+    return run_check_at(
+        root,
+        context.integration_path,
+        context.domain,
+        config=config,
+        no_config=no_config,
+        profile_name=profile_name,
+        ha_version=ha_version,
+        applicability=context.applicability,
+        rule_settings=context.rule_settings,
     )

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -23,6 +23,7 @@ from hasscheck.config import ConfigError, GateConfig, GateMode, discover_config
 from hasscheck.diff import _load_report, compute_delta, delta_to_md
 from hasscheck.docs_render import check_drift, render_all
 from hasscheck.init import init_project
+from hasscheck.inventory import InventoryResult, run_inventory
 from hasscheck.models import Finding, HassCheckReport, RuleSeverity, RuleStatus
 from hasscheck.output import print_terminal_report, report_to_json, report_to_md
 from hasscheck.publish import (
@@ -313,6 +314,129 @@ def badge(
     typer.echo(f"Wrote {len(artifacts)} badge(s) to {out_dir}")
     for a in artifacts:
         typer.echo(f"  {a.filename}: {a.label_left} — {a.label_right}")
+
+
+@app.command()
+def inventory(
+    ha_config: Path = typer.Argument(
+        ...,
+        help=(
+            "Path to a Home Assistant configuration directory "
+            "(the one containing custom_components/)."
+        ),
+    ),
+    format: OutputFormat = typer.Option(
+        OutputFormat.TERMINAL,
+        "--format",
+        help="Output format: terminal (default) or json.",
+        case_sensitive=False,
+    ),
+    ha_version: str | None = typer.Option(
+        None,
+        "--ha-version",
+        help=(
+            "Home Assistant core version to evaluate compatibility against "
+            "(e.g. 2026.5.0). Forwarded to every per-integration check."
+        ),
+    ),
+    no_config: bool = typer.Option(
+        False,
+        "--no-config",
+        help="Ignore hasscheck.yaml even if present in any integration.",
+    ),
+) -> None:
+    """Scan all custom integrations under a Home Assistant config dir.
+
+    Walks <ha_config>/custom_components/, runs the full ruleset on every
+    integration that has a manifest.json, and emits a consolidated report.
+
+    Exit codes:
+      0 — every integration passed (no FAIL findings).
+      1 — at least one integration has a FAIL finding or failed to scan.
+      2 — argument error (missing dir, etc.) [Typer default].
+    """
+    if not ha_config.exists():
+        typer.echo(
+            f"hasscheck: error: ha_config path does not exist: {ha_config}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if not ha_config.is_dir():
+        typer.echo(
+            f"hasscheck: error: ha_config must be a directory: {ha_config}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if not (ha_config / "custom_components").is_dir():
+        typer.echo(
+            f"hasscheck: error: no custom_components/ directory found at {ha_config}",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if format is OutputFormat.MD:
+        typer.echo(
+            "hasscheck: error: --format md is not supported for inventory.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    result = run_inventory(
+        ha_config,
+        ha_version=ha_version,
+        no_config=no_config,
+    )
+
+    if format is OutputFormat.JSON:
+        typer.echo(json.dumps(result.to_json_dict(), indent=2))
+    else:
+        _print_inventory_terminal(result)
+
+    raise typer.Exit(code=result.exit_code)
+
+
+def _print_inventory_terminal(result: InventoryResult) -> None:
+    """Render a one-row-per-integration table to the shared `console`.
+
+    Reuses the module-level rich.Console (already instantiated at module scope).
+    No new dependency — rich.table.Table is in the same package as Console.
+    """
+    from rich.table import Table
+
+    table = Table(title=f"HassCheck Inventory — {result.ha_config}")
+    table.add_column("Domain", style="bold")
+    table.add_column("Version")
+    table.add_column("FAIL", justify="right", style="red")
+    table.add_column("WARN", justify="right", style="yellow")
+    table.add_column("Status")
+
+    for entry in result.entries:
+        if not entry.ok:
+            table.add_row(
+                entry.domain, "—", "—", "—", f"[red]ERROR[/red] {entry.error}"
+            )
+            continue
+        report = entry.report
+        fails = sum(1 for f in report.findings if f.status is RuleStatus.FAIL)
+        warns = sum(1 for f in report.findings if f.status is RuleStatus.WARN)
+        status = (
+            "[red]FAIL[/red]"
+            if fails
+            else "[yellow]WARN[/yellow]"
+            if warns
+            else "[green]PASS[/green]"
+        )
+        version = report.project.integration_version or "—"
+        table.add_row(entry.domain, version, str(fails), str(warns), status)
+
+    console.print(table)
+    s = result.summary
+    console.print(
+        f"\n{s.total} integration(s) scanned: "
+        f"[green]{s.passed} pass[/green], "
+        f"[yellow]{s.warned} warn[/yellow], "
+        f"[red]{s.failed} fail[/red]"
+    )
 
 
 @app.command()

--- a/src/hasscheck/cli.py
+++ b/src/hasscheck/cli.py
@@ -369,10 +369,10 @@ def inventory(
         raise typer.Exit(code=2)
     if not (ha_config / "custom_components").is_dir():
         typer.echo(
-            f"hasscheck: error: no custom_components/ directory found at {ha_config}",
+            f"hasscheck: warning: no custom_components/ directory found at {ha_config}",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=0)
 
     if format is OutputFormat.MD:
         typer.echo(

--- a/src/hasscheck/inventory.py
+++ b/src/hasscheck/inventory.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from hasscheck.checker import run_check_at
+from hasscheck.models import HassCheckReport, RuleStatus
+
+
+@dataclass(frozen=True)
+class InventoryEntry:
+    """One row in the inventory: either a successful report or an error."""
+
+    domain: str  # always present; derived from directory name
+    integration_path: Path  # absolute path to the integration dir
+    report: HassCheckReport | None = None  # None iff error is set
+    error: str | None = None  # None iff report is set
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+@dataclass(frozen=True)
+class InventorySummary:
+    total: int
+    passed: int  # entries whose report has zero FAIL findings
+    failed: int  # entries with >=1 FAIL finding OR error set
+    warned: int  # entries with >=1 WARN and zero FAIL
+
+
+@dataclass(frozen=True)
+class InventoryResult:
+    ha_config: Path
+    entries: list[InventoryEntry] = field(default_factory=list)
+
+    @property
+    def summary(self) -> InventorySummary:
+        total = len(self.entries)
+        failed = sum(1 for e in self.entries if not e.ok or _has_fail(e.report))
+        warned = sum(
+            1
+            for e in self.entries
+            if e.ok and not _has_fail(e.report) and _has_warn(e.report)
+        )
+        passed = total - failed - warned
+        return InventorySummary(
+            total=total, passed=passed, failed=failed, warned=warned
+        )
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.summary.failed > 0 else 0
+
+    def to_json_dict(self) -> dict:
+        return {
+            "ha_config": str(self.ha_config),
+            "integrations": [
+                e.report.to_json_dict()
+                if e.ok
+                else {
+                    "domain": e.domain,
+                    "integration_path": str(e.integration_path),
+                    "error": e.error,
+                }
+                for e in self.entries
+            ],
+        }
+
+
+def _has_fail(report: HassCheckReport | None) -> bool:
+    return report is not None and any(
+        f.status is RuleStatus.FAIL for f in report.findings
+    )
+
+
+def _has_warn(report: HassCheckReport | None) -> bool:
+    return report is not None and any(
+        f.status is RuleStatus.WARN for f in report.findings
+    )
+
+
+def discover_integrations(ha_config: Path) -> list[Path]:
+    """Return sorted list of integration directories under ha_config/custom_components/.
+
+    Filters: must be a directory, must NOT start with '.', must contain
+    a manifest.json file (file presence only — not parsed). Returned in
+    deterministic alphabetical order so terminal/JSON output is stable.
+
+    Returns [] if custom_components/ does not exist (caller decides whether
+    that's an error or empty inventory).
+    """
+    cc = ha_config / "custom_components"
+    if not cc.is_dir():
+        return []
+    return sorted(
+        p
+        for p in cc.iterdir()
+        if p.is_dir() and not p.name.startswith(".") and (p / "manifest.json").is_file()
+    )
+
+
+def run_inventory(
+    ha_config: Path,
+    *,
+    ha_version: str | None = None,
+    no_config: bool = False,
+) -> InventoryResult:
+    """Discover integrations under ha_config and run the full ruleset on each.
+
+    Errors during a single integration's check are captured as an
+    InventoryEntry with `error` set and `report=None`; the scan continues.
+    No exception escapes this function except for argument-validation
+    errors raised before iteration starts.
+    """
+    ha_config = ha_config.resolve()
+    integrations = discover_integrations(ha_config)
+    entries: list[InventoryEntry] = []
+
+    for integ_path in integrations:
+        domain = integ_path.name  # HA convention: dir name == domain
+        try:
+            # Each integration is its own "root" for config discovery purposes.
+            # We deliberately do NOT pass a hasscheck.yaml from ha_config — HA
+            # config dirs are not the right place for hasscheck overrides.
+            report = run_check_at(
+                root=integ_path.parent.parent,  # the ha_config dir
+                integration_path=integ_path,
+                domain=domain,
+                no_config=no_config,
+                ha_version=ha_version,
+            )
+            entries.append(
+                InventoryEntry(
+                    domain=domain,
+                    integration_path=integ_path,
+                    report=report,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — explicit broad catch is the contract
+            entries.append(
+                InventoryEntry(
+                    domain=domain,
+                    integration_path=integ_path,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+
+    return InventoryResult(ha_config=ha_config, entries=entries)

--- a/src/hasscheck/inventory.py
+++ b/src/hasscheck/inventory.py
@@ -53,6 +53,7 @@ class InventoryResult:
         return 1 if self.summary.failed > 0 else 0
 
     def to_json_dict(self) -> dict:
+        s = self.summary
         return {
             "ha_config": str(self.ha_config),
             "integrations": [
@@ -65,6 +66,12 @@ class InventoryResult:
                 }
                 for e in self.entries
             ],
+            "summary": {
+                "total": s.total,
+                "pass": s.passed,
+                "warn": s.warned,
+                "fail": s.failed,
+            },
         }
 
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -155,6 +155,8 @@ def test_cli_inventory_json_output(tmp_path) -> None:
     data = json.loads(result.output)
     assert "integrations" in data
     assert "ha_config" in data
+    assert "summary" in data
+    assert data["summary"]["total"] == 2
     assert len(data["integrations"]) == 2
 
 
@@ -170,7 +172,7 @@ def test_cli_inventory_missing_path(tmp_path) -> None:
 
 def test_cli_inventory_no_custom_components(tmp_path) -> None:
     result = runner.invoke(app, ["inventory", str(tmp_path)])
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "custom_components" in result.output
 
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from hasscheck.cli import app
+from hasscheck.inventory import discover_integrations, run_inventory
+
+
+def _make_integration(ha_config, domain: str, *, version: str = "0.1.0") -> None:
+    integ = ha_config / "custom_components" / domain
+    integ.mkdir(parents=True, exist_ok=True)
+    (integ / "manifest.json").write_text(
+        json.dumps(
+            {
+                "domain": domain,
+                "name": domain.title(),
+                "documentation": "https://example.com",
+                "issue_tracker": "https://example.com/issues",
+                "codeowners": ["@nobody"],
+                "version": version,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# G1 — Discovery tests
+# ---------------------------------------------------------------------------
+
+
+def test_discover_finds_all_valid_integrations(tmp_path) -> None:
+    _make_integration(tmp_path, "alpha")
+    _make_integration(tmp_path, "beta")
+    _make_integration(tmp_path, "gamma")
+    result = discover_integrations(tmp_path)
+    assert [p.name for p in result] == ["alpha", "beta", "gamma"]
+
+
+def test_discover_skips_dotfile_dirs(tmp_path) -> None:
+    cc = tmp_path / "custom_components"
+    cc.mkdir(parents=True)
+    (cc / ".cache").mkdir()
+    _make_integration(tmp_path, "valid")
+    result = discover_integrations(tmp_path)
+    assert [p.name for p in result] == ["valid"]
+
+
+def test_discover_skips_dirs_without_manifest(tmp_path) -> None:
+    _make_integration(tmp_path, "valid")
+    incomplete = tmp_path / "custom_components" / "incomplete"
+    incomplete.mkdir(parents=True, exist_ok=True)
+    result = discover_integrations(tmp_path)
+    assert [p.name for p in result] == ["valid"]
+
+
+def test_discover_returns_empty_when_custom_components_missing(tmp_path) -> None:
+    result = discover_integrations(tmp_path)
+    assert result == []
+
+
+def test_discover_returns_empty_when_custom_components_empty(tmp_path) -> None:
+    (tmp_path / "custom_components").mkdir()
+    result = discover_integrations(tmp_path)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# G2 — Orchestration / run_inventory tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_inventory_collects_one_entry_per_integration(tmp_path) -> None:
+    _make_integration(tmp_path, "alpha")
+    _make_integration(tmp_path, "beta")
+    _make_integration(tmp_path, "gamma")
+    result = run_inventory(tmp_path, no_config=True)
+    assert len(result.entries) == 3
+    for entry in result.entries:
+        assert entry.ok
+        assert entry.report is not None
+
+
+def test_run_inventory_continues_after_check_exception(tmp_path) -> None:
+    _make_integration(tmp_path, "good")
+    _make_integration(tmp_path, "bad")
+
+    def _raise_for_bad(root, integration_path, domain, **kwargs):
+        if domain == "bad":
+            raise RuntimeError("Simulated rule crash")
+        from hasscheck.checker import run_check_at as _orig
+
+        return _orig(root, integration_path, domain, **kwargs)
+
+    with patch("hasscheck.inventory.run_check_at", side_effect=_raise_for_bad):
+        result = run_inventory(tmp_path, no_config=True)
+
+    assert len(result.entries) == 2
+    domains = {e.domain for e in result.entries}
+    assert domains == {"good", "bad"}
+    bad_entry = next(e for e in result.entries if e.domain == "bad")
+    good_entry = next(e for e in result.entries if e.domain == "good")
+    assert bad_entry.error is not None
+    assert "RuntimeError" in bad_entry.error
+    assert good_entry.report is not None
+
+
+def test_run_inventory_summary_counts_fails(tmp_path) -> None:
+    # A minimal integration with only manifest.json will trigger FAIL findings
+    # (many rules require additional files). This ensures summary.failed >= 1.
+    _make_integration(tmp_path, "broken")
+    result = run_inventory(tmp_path, no_config=True)
+    assert result.summary.failed >= 1
+    assert result.exit_code == 1
+
+
+def test_run_inventory_exit_code_zero_on_empty(tmp_path) -> None:
+    (tmp_path / "custom_components").mkdir()
+    result = run_inventory(tmp_path, no_config=True)
+    assert result.exit_code == 0
+    assert result.summary.total == 0
+
+
+def test_run_inventory_empty_returns_zero_exit_code(tmp_path) -> None:
+    result = run_inventory(tmp_path, no_config=True)
+    assert result.exit_code == 0
+    assert result.summary.total == 0
+
+
+# ---------------------------------------------------------------------------
+# G3 — CLI tests
+# ---------------------------------------------------------------------------
+
+runner = CliRunner()
+
+
+def test_cli_inventory_terminal_output(tmp_path) -> None:
+    _make_integration(tmp_path, "myintegration")
+    _make_integration(tmp_path, "another")
+    result = runner.invoke(app, ["inventory", str(tmp_path), "--no-config"])
+    assert "integration(s) scanned" in result.output
+    assert "myintegration" in result.output
+    assert "another" in result.output
+
+
+def test_cli_inventory_json_output(tmp_path) -> None:
+    _make_integration(tmp_path, "alpha")
+    _make_integration(tmp_path, "beta")
+    result = runner.invoke(
+        app, ["inventory", str(tmp_path), "--format", "json", "--no-config"]
+    )
+    data = json.loads(result.output)
+    assert "integrations" in data
+    assert "ha_config" in data
+    assert len(data["integrations"]) == 2
+
+
+def test_cli_inventory_missing_path(tmp_path) -> None:
+    nonexistent = tmp_path / "does_not_exist"
+    result = runner.invoke(app, ["inventory", str(nonexistent)])
+    assert result.exit_code == 2
+    # Error message goes to stderr, but CliRunner mixes by default
+    assert "does not exist" in result.output or (
+        result.output == "" and result.exit_code == 2
+    )
+
+
+def test_cli_inventory_no_custom_components(tmp_path) -> None:
+    result = runner.invoke(app, ["inventory", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "custom_components" in result.output
+
+
+def test_cli_inventory_propagates_ha_version(tmp_path) -> None:
+    _make_integration(tmp_path, "alpha")
+    result = runner.invoke(
+        app,
+        [
+            "inventory",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--ha-version",
+            "2026.5.0",
+            "--no-config",
+        ],
+    )
+    data = json.loads(result.output)
+    integrations = data["integrations"]
+    assert len(integrations) == 1
+    # The report's target section should carry ha_version
+    target = integrations[0].get("target", {})
+    assert target.get("ha_version") == "2026.5.0"


### PR DESCRIPTION
Closes #152

## Summary
- Extracts `run_check_at(root, integration_path, domain, ...)` from `run_check()` in `checker.py` — execution primitive that inventory can call per-integration without fighting single-winner discovery semantics
- New `src/hasscheck/inventory.py` — `discover_integrations()`, `InventoryResult`, `run_inventory()` with per-integration try/except (errors captured, scan continues)
- New `hasscheck inventory <ha_config_path>` CLI command with `--format terminal|json`, `--ha-version`, `--no-config`
- Terminal: one row per domain + summary line; JSON: `{"integrations": [...], "summary": {"total", "pass", "warn", "fail"}}`
- Exit 0 = all pass/warn or empty; Exit 1 = any FAIL; Exit 2 = bad path

## Test plan
- [x] 15 tests in `tests/test_inventory.py` (5 discovery, 5 orchestration, 5 CLI)
- [x] 1349 tests pass — 0 regressions
- [x] `sdd-verify` PASS — 0 CRITICAL, 0 WARNING post-fix